### PR TITLE
Register GCP auth plugin

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/go-homedir"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"

--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/builtin/providers/google"
+	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -29,6 +30,120 @@ func TestProvider(t *testing.T) {
 
 func TestProvider_impl(t *testing.T) {
 	var _ terraform.ResourceProvider = Provider()
+}
+
+func TestProvider_configure(t *testing.T) {
+	resetEnv := unsetEnv(t)
+	defer resetEnv()
+
+	os.Setenv("KUBECONFIG", "test-fixtures/kube-config.yaml")
+	os.Setenv("KUBE_CTX", "gcp")
+
+	c, err := config.NewRawConfig(map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rc := terraform.NewResourceConfig(c)
+	p := Provider()
+	err = p.Configure(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func unsetEnv(t *testing.T) func() {
+	e := getEnv()
+
+	if err := os.Unsetenv("KUBECONFIG"); err != nil {
+		t.Fatalf("Error unsetting env var KUBECONFIG: %s", err)
+	}
+	if err := os.Unsetenv("KUBE_CONFIG"); err != nil {
+		t.Fatalf("Error unsetting env var KUBE_CONFIG: %s", err)
+	}
+	if err := os.Unsetenv("KUBE_CTX"); err != nil {
+		t.Fatalf("Error unsetting env var KUBE_CTX: %s", err)
+	}
+	if err := os.Unsetenv("KUBE_CTX_AUTH_INFO"); err != nil {
+		t.Fatalf("Error unsetting env var KUBE_CTX_AUTH_INFO: %s", err)
+	}
+	if err := os.Unsetenv("KUBE_CTX_CLUSTER"); err != nil {
+		t.Fatalf("Error unsetting env var KUBE_CTX_CLUSTER: %s", err)
+	}
+	if err := os.Unsetenv("KUBE_HOST"); err != nil {
+		t.Fatalf("Error unsetting env var KUBE_HOST: %s", err)
+	}
+	if err := os.Unsetenv("KUBE_USER"); err != nil {
+		t.Fatalf("Error unsetting env var KUBE_USER: %s", err)
+	}
+	if err := os.Unsetenv("KUBE_PASSWORD"); err != nil {
+		t.Fatalf("Error unsetting env var KUBE_PASSWORD: %s", err)
+	}
+	if err := os.Unsetenv("KUBE_CLIENT_CERT_DATA"); err != nil {
+		t.Fatalf("Error unsetting env var KUBE_CLIENT_CERT_DATA: %s", err)
+	}
+	if err := os.Unsetenv("KUBE_CLIENT_KEY_DATA"); err != nil {
+		t.Fatalf("Error unsetting env var KUBE_CLIENT_KEY_DATA: %s", err)
+	}
+	if err := os.Unsetenv("KUBE_CLUSTER_CA_CERT_DATA"); err != nil {
+		t.Fatalf("Error unsetting env var KUBE_CLUSTER_CA_CERT_DATA: %s", err)
+	}
+
+	return func() {
+		if err := os.Setenv("KUBE_CONFIG", e.Config); err != nil {
+			t.Fatalf("Error resetting env var KUBE_CONFIG: %s", err)
+		}
+		if err := os.Setenv("KUBECONFIG", e.Config); err != nil {
+			t.Fatalf("Error resetting env var KUBECONFIG: %s", err)
+		}
+		if err := os.Setenv("KUBE_CTX", e.Config); err != nil {
+			t.Fatalf("Error resetting env var KUBE_CTX: %s", err)
+		}
+		if err := os.Setenv("KUBE_CTX_AUTH_INFO", e.CtxAuthInfo); err != nil {
+			t.Fatalf("Error resetting env var KUBE_CTX_AUTH_INFO: %s", err)
+		}
+		if err := os.Setenv("KUBE_CTX_CLUSTER", e.CtxCluster); err != nil {
+			t.Fatalf("Error resetting env var KUBE_CTX_CLUSTER: %s", err)
+		}
+		if err := os.Setenv("KUBE_HOST", e.Host); err != nil {
+			t.Fatalf("Error resetting env var KUBE_HOST: %s", err)
+		}
+		if err := os.Setenv("KUBE_USER", e.User); err != nil {
+			t.Fatalf("Error resetting env var KUBE_USER: %s", err)
+		}
+		if err := os.Setenv("KUBE_PASSWORD", e.Password); err != nil {
+			t.Fatalf("Error resetting env var KUBE_PASSWORD: %s", err)
+		}
+		if err := os.Setenv("KUBE_CLIENT_CERT_DATA", e.ClientCertData); err != nil {
+			t.Fatalf("Error resetting env var KUBE_CLIENT_CERT_DATA: %s", err)
+		}
+		if err := os.Setenv("KUBE_CLIENT_KEY_DATA", e.ClientKeyData); err != nil {
+			t.Fatalf("Error resetting env var KUBE_CLIENT_KEY_DATA: %s", err)
+		}
+		if err := os.Setenv("KUBE_CLUSTER_CA_CERT_DATA", e.ClusterCACertData); err != nil {
+			t.Fatalf("Error resetting env var KUBE_CLUSTER_CA_CERT_DATA: %s", err)
+		}
+	}
+}
+
+func getEnv() *currentEnv {
+	e := &currentEnv{
+		Ctx:               os.Getenv("KUBE_CTX_CLUSTER"),
+		CtxAuthInfo:       os.Getenv("KUBE_CTX_AUTH_INFO"),
+		CtxCluster:        os.Getenv("KUBE_CTX_CLUSTER"),
+		Host:              os.Getenv("KUBE_HOST"),
+		User:              os.Getenv("KUBE_USER"),
+		Password:          os.Getenv("KUBE_PASSWORD"),
+		ClientCertData:    os.Getenv("KUBE_CLIENT_CERT_DATA"),
+		ClientKeyData:     os.Getenv("KUBE_CLIENT_KEY_DATA"),
+		ClusterCACertData: os.Getenv("KUBE_CLUSTER_CA_CERT_DATA"),
+	}
+	if cfg := os.Getenv("KUBE_CONFIG"); cfg != "" {
+		e.Config = cfg
+	}
+	if cfg := os.Getenv("KUBECONFIG"); cfg != "" {
+		e.Config = cfg
+	}
+	return e
 }
 
 func testAccPreCheck(t *testing.T) {
@@ -56,4 +171,17 @@ func testAccPreCheck(t *testing.T) {
 	if os.Getenv("GOOGLE_PROJECT") == "" || os.Getenv("GOOGLE_REGION") == "" || os.Getenv("GOOGLE_ZONE") == "" {
 		t.Fatal("GOOGLE_PROJECT, GOOGLE_REGION and GOOGLE_ZONE must be set for acceptance tests")
 	}
+}
+
+type currentEnv struct {
+	Config            string
+	Ctx               string
+	CtxAuthInfo       string
+	CtxCluster        string
+	Host              string
+	User              string
+	Password          string
+	ClientCertData    string
+	ClientKeyData     string
+	ClusterCACertData string
 }

--- a/kubernetes/test-fixtures/kube-config.yaml
+++ b/kubernetes/test-fixtures/kube-config.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: Config
+preferences: {}
+clusters:
+- cluster:
+    certificate-authority-data: ZHVtbXk=
+    server: https://127.0.0.1
+  name: default
+
+contexts:
+- context:
+    cluster: default
+    user: azure
+  name: azure
+- context:
+    cluster: default
+    user: gcp
+  name: gcp
+- context:
+    cluster: default
+    user: oidc
+  name: oidc
+
+users:
+- name: azure
+  user:
+    auth-provider:
+      config:
+        access-token: dummy
+        cmd-args: config config-helper --format=json
+        cmd-path: /usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin/gcloud
+        expiry: 2017-06-19T14:02:42Z
+        expiry-key: '{.credential.token_expiry}'
+        token-key: '{.credential.access_token}'
+      name: azure
+- name: gcp
+  user:
+    auth-provider:
+      config:
+        access-token: dummy
+        cmd-args: config config-helper --format=json
+        cmd-path: /usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin/gcloud
+        expiry: 2017-06-19T14:02:42Z
+        expiry-key: '{.credential.token_expiry}'
+        token-key: '{.credential.access_token}'
+      name: gcp
+- name: oidc
+  user:
+    auth-provider:
+      config:
+        access-token: dummy
+        cmd-args: config config-helper --format=json
+        cmd-path: /usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin/gcloud
+        expiry: 2017-06-19T14:02:42Z
+        expiry-key: '{.credential.token_expiry}'
+        token-key: '{.credential.access_token}'
+      name: oidc


### PR DESCRIPTION
This PR intends to address the bug reported in this issue 
https://github.com/terraform-providers/terraform-provider-kubernetes/issues/5

As described here https://github.com/hashicorp/terraform/issues/15244#issuecomment-307597692
client-go doesn't enable GCP auth plugin by default. We have to do it explicitly.

Fixes #5
Fixes #8