### PR TITLE
docs: Fix outdated links to K8S docs

### DIFF
--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
@@ -27,7 +27,7 @@ func resourceKubernetesHorizontalPodAutoscaler() *schema.Resource {
 			"metadata": namespacedMetadataSchema("horizontal pod autoscaler", true),
 			"spec": {
 				Type:        schema.TypeList,
-				Description: "Behaviour of the autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
+				Description: "Behaviour of the autoscaler. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status",
 				Required:    true,
 				MaxItems:    1,
 				Elem: &schema.Resource{

--- a/kubernetes/resource_kubernetes_limit_range.go
+++ b/kubernetes/resource_kubernetes_limit_range.go
@@ -27,7 +27,7 @@ func resourceKubernetesLimitRange() *schema.Resource {
 			"metadata": namespacedMetadataSchema("limit range", true),
 			"spec": {
 				Type:        schema.TypeList,
-				Description: "Spec defines the limits enforced. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+				Description: "Spec defines the limits enforced. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status",
 				Optional:    true,
 				MaxItems:    1,
 				Elem: &schema.Resource{

--- a/kubernetes/resource_kubernetes_resource_quota.go
+++ b/kubernetes/resource_kubernetes_resource_quota.go
@@ -29,7 +29,7 @@ func resourceKubernetesResourceQuota() *schema.Resource {
 			"metadata": namespacedMetadataSchema("resource quota", true),
 			"spec": {
 				Type:        schema.TypeList,
-				Description: "Spec defines the desired quota. http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+				Description: "Spec defines the desired quota. https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status",
 				Optional:    true,
 				MaxItems:    1,
 				Elem: &schema.Resource{

--- a/kubernetes/resource_kubernetes_service.go
+++ b/kubernetes/resource_kubernetes_service.go
@@ -27,7 +27,7 @@ func resourceKubernetesService() *schema.Resource {
 			"metadata": namespacedMetadataSchema("service", true),
 			"spec": {
 				Type:        schema.TypeList,
-				Description: "Spec defines the behavior of a service. http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+				Description: "Spec defines the behavior of a service. https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status",
 				Required:    true,
 				MaxItems:    1,
 				Elem: &schema.Resource{

--- a/website/docs/r/horizontal_pod_autoscaler.html.markdown
+++ b/website/docs/r/horizontal_pod_autoscaler.html.markdown
@@ -34,7 +34,7 @@ resource "kubernetes_horizontal_pod_autoscaler" "example" {
 The following arguments are supported:
 
 * `metadata` - (Required) Standard horizontal pod autoscaler's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
-* `spec` - (Required) Behaviour of the autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.
+* `spec` - (Required) Behaviour of the autoscaler. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
 
 ## Nested Blocks
 

--- a/website/docs/r/limit_range.html.markdown
+++ b/website/docs/r/limit_range.html.markdown
@@ -50,7 +50,7 @@ resource "kubernetes_limit_range" "example" {
 The following arguments are supported:
 
 * `metadata` - (Required) Standard limit range's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
-* `spec` - (Optional) Spec defines the limits enforced. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status
+* `spec` - (Optional) Spec defines the limits enforced. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
 
 ## Nested Blocks
 

--- a/website/docs/r/resource_quota.html.markdown
+++ b/website/docs/r/resource_quota.html.markdown
@@ -32,7 +32,7 @@ resource "kubernetes_resource_quota" "example" {
 The following arguments are supported:
 
 * `metadata` - (Required) Standard resource quota's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
-* `spec` - (Optional) Spec defines the desired quota. http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status
+* `spec` - (Optional) Spec defines the desired quota. https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
 
 ## Nested Blocks
 

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -38,7 +38,7 @@ resource "kubernetes_service" "example" {
 The following arguments are supported:
 
 * `metadata` - (Required) Standard service's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
-* `spec` - (Required) Spec defines the behavior of a service. http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status
+* `spec` - (Required) Spec defines the behavior of a service. https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
 
 ## Nested Blocks
 


### PR DESCRIPTION
As mentioned in https://github.com/terraform-providers/terraform-provider-kubernetes/pull/9