### PR TITLE
Expose last warnings from eventlog for Pod+PVC+SVC

### DIFF
--- a/kubernetes/event_helpers.go
+++ b/kubernetes/event_helpers.go
@@ -1,0 +1,67 @@
+package kubernetes
+
+import (
+	"fmt"
+	"log"
+	"sort"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	api "k8s.io/kubernetes/pkg/api/v1"
+	kubernetes "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+)
+
+func getLastWarningsForObject(conn *kubernetes.Clientset, metadata meta_v1.ObjectMeta, kind string, limit int) ([]api.Event, error) {
+	fs := fields.Set(map[string]string{
+		"involvedObject.name":      metadata.Name,
+		"involvedObject.namespace": metadata.Namespace,
+		"involvedObject.kind":      kind,
+	}).String()
+	log.Printf("[DEBUG] Looking up events via this selector: %q", fs)
+	out, err := conn.CoreV1().Events(metadata.Namespace).List(meta_v1.ListOptions{
+		FieldSelector: fs,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// It would be better to sort & filter on the server-side
+	// but API doesn't seem to support it
+	var warnings []api.Event
+
+	// Bring latest events to the top, for easy access
+	sort.Slice(out.Items, func(i, j int) bool {
+		return out.Items[i].LastTimestamp.After(out.Items[j].LastTimestamp.Time)
+	})
+
+	log.Printf("[DEBUG] Received %d events for %s/%s (%s)",
+		len(out.Items), metadata.Namespace, metadata.Name, kind)
+
+	warnCount := 0
+	uniqueWarnings := make(map[string]api.Event, 0)
+	for _, e := range out.Items {
+		if warnCount >= limit {
+			break
+		}
+
+		if e.Type == api.EventTypeWarning {
+			_, found := uniqueWarnings[e.Message]
+			if found {
+				continue
+			}
+			warnings = append(warnings, e)
+			uniqueWarnings[e.Message] = e
+			warnCount++
+		}
+	}
+
+	return warnings, nil
+}
+
+func stringifyEvents(events []api.Event) string {
+	var output string
+	for _, e := range events {
+		output += fmt.Sprintf("\n   * %s: %s", e.Reason, e.Message)
+	}
+	return output
+}

--- a/kubernetes/resource_kubernetes_persistent_volume_claim.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	pkgApi "k8s.io/apimachinery/pkg/types"
 	api "k8s.io/kubernetes/pkg/api/v1"
 	kubernetes "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
@@ -166,7 +165,6 @@ func resourceKubernetesPersistentVolumeClaimCreate(d *schema.ResourceData, meta 
 	name := out.ObjectMeta.Name
 
 	if d.Get("wait_until_bound").(bool) {
-		var lastEvent api.Event
 		stateConf := &resource.StateChangeConf{
 			Target:  []string{"Bound"},
 			Pending: []string{"Pending"},
@@ -178,20 +176,6 @@ func resourceKubernetesPersistentVolumeClaimCreate(d *schema.ResourceData, meta 
 					return out, "", err
 				}
 
-				events, err := conn.CoreV1().Events(metadata.Namespace).List(meta_v1.ListOptions{
-					FieldSelector: fields.Set(map[string]string{
-						"involvedObject.name":      metadata.Name,
-						"involvedObject.namespace": metadata.Namespace,
-						"involvedObject.kind":      "PersistentVolumeClaim",
-					}).String(),
-				})
-				if err != nil {
-					return out, "", err
-				}
-				if len(events.Items) > 0 {
-					lastEvent = events.Items[0]
-				}
-
 				statusPhase := fmt.Sprintf("%v", out.Status.Phase)
 				log.Printf("[DEBUG] Persistent volume claim %s status received: %#v", out.Name, statusPhase)
 				return out, statusPhase, nil
@@ -199,11 +183,11 @@ func resourceKubernetesPersistentVolumeClaimCreate(d *schema.ResourceData, meta 
 		}
 		_, err = stateConf.WaitForState()
 		if err != nil {
-			reason := ""
-			if lastEvent.Reason != "" {
-				reason = fmt.Sprintf(". Reason: %s: %s", lastEvent.Reason, lastEvent.Message)
+			lastWarnings, wErr := getLastWarningsForObject(conn, out.ObjectMeta, "PersistentVolumeClaim", 3)
+			if wErr != nil {
+				return wErr
 			}
-			return fmt.Errorf("%s%s", err, reason)
+			return fmt.Errorf("%s%s", err, stringifyEvents(lastWarnings))
 		}
 	}
 	log.Printf("[INFO] Persistent volume claim %s created", out.Name)

--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -82,7 +82,11 @@ func resourceKubernetesPodCreate(d *schema.ResourceData, meta interface{}) error
 	}
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return err
+		lastWarnings, wErr := getLastWarningsForObject(conn, out.ObjectMeta, "Pod", 3)
+		if wErr != nil {
+			return wErr
+		}
+		return fmt.Errorf("%s%s", err, stringifyEvents(lastWarnings))
 	}
 	log.Printf("[INFO] Pod %s created", out.Name)
 

--- a/kubernetes/resource_kubernetes_service.go
+++ b/kubernetes/resource_kubernetes_service.go
@@ -176,10 +176,14 @@ func resourceKubernetesServiceCreate(d *schema.ResourceData, meta interface{}) e
 			}
 
 			return resource.RetryableError(fmt.Errorf(
-				"Waiting for load balancer %q to assign IP/hostname", d.Id()))
+				"Waiting for service %q to assign IP/hostname for a load balancer", d.Id()))
 		})
 		if err != nil {
-			return err
+			lastWarnings, wErr := getLastWarningsForObject(conn, out.ObjectMeta, "Service", 3)
+			if wErr != nil {
+				return wErr
+			}
+			return fmt.Errorf("%s%s", err, stringifyEvents(lastWarnings))
 		}
 	}
 


### PR DESCRIPTION
### Examples

#### Service
```
* kubernetes_service.test: Waiting for service "default/radek-blablah" to assign IP/hostname for a load balancer
   * CreatingLoadBalancerFailed: Error creating load balancer (will retry): Failed to create load balancer for service default/radek-blablah: requested ip 10.0.0.1 is neither static nor assigned to LB a049988bc615511e781c642010a8a005(default/radek-blablah): <nil>
```

#### PVC
```
* kubernetes_persistent_volume_claim.example: timeout while waiting for state to become 'Bound' (last state: 'Pending', timeout: 5m0s)
   * ProvisioningFailed: Failed to provision volume with StorageClass "standard": claim.Spec.Selector is not supported for dynamic provisioning on GCE
```

#### Pod
```
* kubernetes_pod.test: timeout while waiting for state to become 'Running' (last state: 'Pending', timeout: 5m0s)
   * FailedSync: Error syncing pod, skipping: failed to "StartContainer" for "example" with ImagePullBackOff: "Back-off pulling image \"nginx:notexists\""

   * Failed: Failed to pull image "nginx:notexists": rpc error: code = 2 desc = Tag notexists not found in repository docker.io/library/nginx
   * FailedSync: Error syncing pod, skipping: failed to "StartContainer" for "example" with ErrImagePull: "rpc error: code = 2 desc = Tag notexists not found in repository docker.io/library/nginx"
```