### PR TITLE
r/pod: Fix a crash caused by wrong field name (config map volume source)

### DIFF
--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -188,9 +188,10 @@ func volumeSchema() *schema.Resource {
 					},
 				},
 				"default_mode": {
-					Type:        schema.TypeInt,
-					Description: "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
-					Optional:    true,
+					Type:         schema.TypeInt,
+					Description:  "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+					Optional:     true,
+					ValidateFunc: validateModeBits,
 				},
 				"name": {
 					Type:        schema.TypeString,

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -473,7 +473,7 @@ func expandConfigMapVolumeSource(l []interface{}) *v1.ConfigMapVolumeSource {
 	}
 	in := l[0].(map[string]interface{})
 	obj := &v1.ConfigMapVolumeSource{
-		DefaultMode: ptrToInt32(int32(in["default_mode "].(int))),
+		DefaultMode: ptrToInt32(int32(in["default_mode"].(int))),
 	}
 
 	if v, ok := in["name"].(string); ok {
@@ -493,7 +493,7 @@ func expandDownwardAPIVolumeSource(l []interface{}) (*v1.DownwardAPIVolumeSource
 	}
 	in := l[0].(map[string]interface{})
 	obj := &v1.DownwardAPIVolumeSource{
-		DefaultMode: ptrToInt32(int32(in["default_mode "].(int))),
+		DefaultMode: ptrToInt32(int32(in["default_mode"].(int))),
 	}
 	if v, ok := in["items"].([]interface{}); ok && len(v) > 0 {
 		var err error

--- a/kubernetes/validators.go
+++ b/kubernetes/validators.go
@@ -165,6 +165,14 @@ func validateTerminationGracePeriodSeconds(value interface{}, key string) (ws []
 	return
 }
 
+func validateModeBits(value interface{}, key string) (ws []string, es []error) {
+	v := value.(int)
+	if v < 0 || v > 0777 {
+		es = append(es, fmt.Errorf("%s (%#o) expects octal notation (a value between 0 and 0777)", key, v))
+	}
+	return
+}
+
 func validateAttributeValueDoesNotContain(searchString string) schema.SchemaValidateFunc {
 	return func(v interface{}, k string) (ws []string, errors []error) {
 		input := v.(string)

--- a/kubernetes/validators_test.go
+++ b/kubernetes/validators_test.go
@@ -1,0 +1,27 @@
+package kubernetes
+
+import (
+	"testing"
+)
+
+func TestValidateModeBits(t *testing.T) {
+	validCases := []int{
+		0, 0001, 0644, 0777,
+	}
+	for _, mode := range validCases {
+		_, es := validateModeBits(mode, "mode")
+		if len(es) > 0 {
+			t.Fatalf("Expected %#o to be valid: %#v", mode, es)
+		}
+	}
+
+	invalidCases := []int{
+		-5, -1, 512, 777,
+	}
+	for _, mode := range invalidCases {
+		_, es := validateModeBits(mode, "mode")
+		if len(es) == 0 {
+			t.Fatalf("Expected %#o to be invalid", mode)
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-kubernetes/issues/18

This affects both `kubernetes_pod` and `kubernetes_replication_controller` as they share part of the schema and related helper functions (which includes the one we're fixing here).

#### Test results

```
$ make testacc TEST=./kubernetes TESTARGS='-run=TestAccKubernetesPod_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./kubernetes -v -run=TestAccKubernetesPod_ -timeout 120m
=== RUN   TestAccKubernetesPod_basic
--- PASS: TestAccKubernetesPod_basic (11.82s)
=== RUN   TestAccKubernetesPod_importBasic
--- PASS: TestAccKubernetesPod_importBasic (5.53s)
=== RUN   TestAccKubernetesPod_with_pod_security_context
--- PASS: TestAccKubernetesPod_with_pod_security_context (4.34s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_exec
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_exec (42.05s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_http_get
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_http_get (6.91s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_tcp
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_tcp (21.81s)
=== RUN   TestAccKubernetesPod_with_container_lifecycle
--- PASS: TestAccKubernetesPod_with_container_lifecycle (7.37s)
=== RUN   TestAccKubernetesPod_with_container_security_context
--- PASS: TestAccKubernetesPod_with_container_security_context (5.84s)
=== RUN   TestAccKubernetesPod_with_volume_mount
--- PASS: TestAccKubernetesPod_with_volume_mount (8.60s)
=== RUN   TestAccKubernetesPod_with_cfg_map_volume_mount
--- PASS: TestAccKubernetesPod_with_cfg_map_volume_mount (15.05s)
=== RUN   TestAccKubernetesPod_with_resource_requirements
--- PASS: TestAccKubernetesPod_with_resource_requirements (6.23s)
=== RUN   TestAccKubernetesPod_with_empty_dir_volume
--- PASS: TestAccKubernetesPod_with_empty_dir_volume (7.47s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	143.142s
```