### PR TITLE
Add support for kubernetes_storage_class

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -104,6 +104,7 @@ func Provider() terraform.ResourceProvider {
 			"kubernetes_secret":                    resourceKubernetesSecret(),
 			"kubernetes_service":                   resourceKubernetesService(),
 			"kubernetes_service_account":           resourceKubernetesServiceAccount(),
+			"kubernetes_storage_class":             resourceKubernetesStorageClass(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/kubernetes/resource_kubernetes_persistent_volume_claim.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim.go
@@ -127,6 +127,13 @@ func resourceKubernetesPersistentVolumeClaim() *schema.Resource {
 							ForceNew:    true,
 							Computed:    true,
 						},
+						"storage_class_name": {
+							Type:        schema.TypeString,
+							Description: "Name of the storage class requested by the claim",
+							Optional:    true,
+							Computed:    true,
+							ForceNew:    true,
+						},
 					},
 				},
 			},

--- a/kubernetes/resource_kubernetes_storage_class.go
+++ b/kubernetes/resource_kubernetes_storage_class.go
@@ -1,0 +1,138 @@
+package kubernetes
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgApi "k8s.io/apimachinery/pkg/types"
+	api "k8s.io/kubernetes/pkg/apis/storage/v1"
+	kubernetes "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+)
+
+func resourceKubernetesStorageClass() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceKubernetesStorageClassCreate,
+		Read:   resourceKubernetesStorageClassRead,
+		Exists: resourceKubernetesStorageClassExists,
+		Update: resourceKubernetesStorageClassUpdate,
+		Delete: resourceKubernetesStorageClassDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"metadata": metadataSchema("storage class", true),
+			"parameters": {
+				Type:        schema.TypeMap,
+				Description: "The parameters for the provisioner that should create volumes of this storage class",
+				Optional:    true,
+				ForceNew:    true,
+			},
+			"storage_provisioner": {
+				Type:        schema.TypeString,
+				Description: "Indicates the type of the provisioner",
+				Required:    true,
+				ForceNew:    true,
+			},
+		},
+	}
+}
+
+func resourceKubernetesStorageClassCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*kubernetes.Clientset)
+
+	metadata := expandMetadata(d.Get("metadata").([]interface{}))
+	storageClass := api.StorageClass{
+		ObjectMeta:  metadata,
+		Provisioner: d.Get("storage_provisioner").(string),
+	}
+
+	if v, ok := d.GetOk("parameters"); ok {
+		storageClass.Parameters = expandStringMap(v.(map[string]interface{}))
+	}
+
+	log.Printf("[INFO] Creating new storage class: %#v", storageClass)
+	out, err := conn.StorageV1().StorageClasses().Create(&storageClass)
+	if err != nil {
+		return err
+	}
+	log.Printf("[INFO] Submitted new storage class: %#v", out)
+	d.SetId(out.Name)
+
+	return resourceKubernetesStorageClassRead(d, meta)
+}
+
+func resourceKubernetesStorageClassRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*kubernetes.Clientset)
+
+	name := d.Id()
+	log.Printf("[INFO] Reading storage class %s", name)
+	storageClass, err := conn.StorageV1().StorageClasses().Get(name, metav1.GetOptions{})
+	if err != nil {
+		log.Printf("[DEBUG] Received error: %#v", err)
+		return err
+	}
+	log.Printf("[INFO] Received storage class: %#v", storageClass)
+	err = d.Set("metadata", flattenMetadata(storageClass.ObjectMeta))
+	if err != nil {
+		return err
+	}
+	d.Set("parameters", storageClass.Parameters)
+	d.Set("storage_provisioner", storageClass.Provisioner)
+
+	return nil
+}
+
+func resourceKubernetesStorageClassUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*kubernetes.Clientset)
+
+	name := d.Id()
+	ops := patchMetadata("metadata.0.", "/metadata/", d)
+	data, err := ops.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("Failed to marshal update operations: %s", err)
+	}
+	log.Printf("[INFO] Updating storage class %q: %v", name, string(data))
+	out, err := conn.StorageV1().StorageClasses().Patch(name, pkgApi.JSONPatchType, data)
+	if err != nil {
+		return fmt.Errorf("Failed to update storage class: %s", err)
+	}
+	log.Printf("[INFO] Submitted updated storage class: %#v", out)
+	d.SetId(buildId(out.ObjectMeta))
+
+	return resourceKubernetesStorageClassRead(d, meta)
+}
+
+func resourceKubernetesStorageClassDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*kubernetes.Clientset)
+
+	name := d.Id()
+	log.Printf("[INFO] Deleting storage class: %#v", name)
+	err := conn.StorageV1().StorageClasses().Delete(name, &metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Config map %s deleted", name)
+
+	d.SetId("")
+	return nil
+}
+
+func resourceKubernetesStorageClassExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	conn := meta.(*kubernetes.Clientset)
+
+	name := d.Id()
+	log.Printf("[INFO] Checking storage class %s", name)
+	_, err := conn.StorageV1().StorageClasses().Get(name, metav1.GetOptions{})
+	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
+			return false, nil
+		}
+		log.Printf("[DEBUG] Received error: %#v", err)
+	}
+	return true, err
+}

--- a/kubernetes/resource_kubernetes_storage_class_test.go
+++ b/kubernetes/resource_kubernetes_storage_class_test.go
@@ -1,0 +1,284 @@
+package kubernetes
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	api "k8s.io/kubernetes/pkg/apis/storage/v1"
+	kubernetes "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+)
+
+func TestAccKubernetesStorageClass_basic(t *testing.T) {
+	var conf api.StorageClass
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "kubernetes_storage_class.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesStorageClassDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesStorageClassConfig_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesStorageClassExists("kubernetes_storage_class.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.annotations.%", "2"),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.annotations.TestAnnotationOne", "one"),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.annotations.TestAnnotationTwo", "two"),
+					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{"TestAnnotationOne": "one", "TestAnnotationTwo": "two"}),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.labels.%", "3"),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.labels.TestLabelOne", "one"),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.labels.TestLabelTwo", "two"),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.labels.TestLabelThree", "three"),
+					testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{"TestLabelOne": "one", "TestLabelTwo": "two", "TestLabelThree": "three"}),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_storage_class.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_storage_class.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_storage_class.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_storage_class.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "storage_provisioner", "kubernetes.io/gce-pd"),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "parameters.%", "1"),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "parameters.type", "pd-ssd"),
+					testAccCheckStorageClassParameters(&conf, map[string]string{"type": "pd-ssd"}),
+				),
+			},
+			{
+				Config: testAccKubernetesStorageClassConfig_modified(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesStorageClassExists("kubernetes_storage_class.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.annotations.%", "2"),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.annotations.TestAnnotationOne", "one"),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.annotations.Different", "1234"),
+					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{"TestAnnotationOne": "one", "Different": "1234"}),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.labels.%", "2"),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.labels.TestLabelOne", "one"),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.labels.TestLabelThree", "three"),
+					testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{"TestLabelOne": "one", "TestLabelThree": "three"}),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_storage_class.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_storage_class.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_storage_class.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_storage_class.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "storage_provisioner", "kubernetes.io/gce-pd"),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "parameters.%", "2"),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "parameters.type", "pd-standard"),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "parameters.zones", "us-west1-a,us-west1-b"),
+					testAccCheckStorageClassParameters(&conf, map[string]string{"type": "pd-standard", "zones": "us-west1-a,us-west1-b"}),
+				),
+			},
+			{
+				Config: testAccKubernetesStorageClassConfig_noParameters(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesStorageClassExists("kubernetes_storage_class.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.annotations.%", "0"),
+					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{}),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.labels.%", "0"),
+					testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{}),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_storage_class.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_storage_class.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_storage_class.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_storage_class.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "storage_provisioner", "kubernetes.io/gce-pd"),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "parameters.%", "0"),
+					testAccCheckStorageClassParameters(&conf, map[string]string{}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesStorageClass_importBasic(t *testing.T) {
+	resourceName := "kubernetes_storage_class.test"
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesStorageClassDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesStorageClassConfig_basic(name),
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccKubernetesStorageClass_generatedName(t *testing.T) {
+	var conf api.StorageClass
+	prefix := "tf-acc-test-gen-"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "kubernetes_storage_class.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesStorageClassDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesStorageClassConfig_generatedName(prefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesStorageClassExists("kubernetes_storage_class.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.annotations.%", "0"),
+					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{}),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.labels.%", "0"),
+					testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{}),
+					resource.TestCheckResourceAttr("kubernetes_storage_class.test", "metadata.0.generate_name", prefix),
+					resource.TestMatchResourceAttr("kubernetes_storage_class.test", "metadata.0.name", regexp.MustCompile("^"+prefix)),
+					resource.TestCheckResourceAttrSet("kubernetes_storage_class.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_storage_class.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_storage_class.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_storage_class.test", "metadata.0.uid"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesStorageClass_importGeneratedName(t *testing.T) {
+	resourceName := "kubernetes_storage_class.test"
+	prefix := "tf-acc-test-gen-import-"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesStorageClassDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesStorageClassConfig_generatedName(prefix),
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckStorageClassParameters(m *api.StorageClass, expected map[string]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if len(expected) == 0 && len(m.Parameters) == 0 {
+			return nil
+		}
+		if !reflect.DeepEqual(m.Parameters, expected) {
+			return fmt.Errorf("%s parameters don't match.\nExpected: %q\nGiven: %q",
+				m.Name, expected, m.Parameters)
+		}
+		return nil
+	}
+}
+
+func testAccCheckKubernetesStorageClassDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*kubernetes.Clientset)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "kubernetes_storage_class" {
+			continue
+		}
+		name := rs.Primary.ID
+		resp, err := conn.StorageV1().StorageClasses().Get(name, meta_v1.GetOptions{})
+		if err == nil {
+			if resp.Name == rs.Primary.ID {
+				return fmt.Errorf("Storage class still exists: %s", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckKubernetesStorageClassExists(n string, obj *api.StorageClass) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := testAccProvider.Meta().(*kubernetes.Clientset)
+		name := rs.Primary.ID
+		out, err := conn.StorageV1().StorageClasses().Get(name, meta_v1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		*obj = *out
+		return nil
+	}
+}
+
+func testAccKubernetesStorageClassConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_storage_class" "test" {
+	metadata {
+		annotations {
+			TestAnnotationOne = "one"
+			TestAnnotationTwo = "two"
+		}
+		labels {
+			TestLabelOne = "one"
+			TestLabelTwo = "two"
+			TestLabelThree = "three"
+		}
+		name = "%s"
+	}
+	storage_provisioner = "kubernetes.io/gce-pd"
+	parameters {
+		type = "pd-ssd"
+	}
+}`, name)
+}
+
+func testAccKubernetesStorageClassConfig_modified(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_storage_class" "test" {
+	metadata {
+		annotations {
+			TestAnnotationOne = "one"
+			Different = "1234"
+		}
+		labels {
+			TestLabelOne = "one"
+			TestLabelThree = "three"
+		}
+		name = "%s"
+	}
+	storage_provisioner = "kubernetes.io/gce-pd"
+	parameters {
+		type = "pd-standard"
+		zones = "us-west1-a,us-west1-b"
+	}
+}`, name)
+}
+
+func testAccKubernetesStorageClassConfig_noParameters(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_storage_class" "test" {
+	metadata {
+		name = "%s"
+	}
+	storage_provisioner = "kubernetes.io/gce-pd"
+}`, name)
+}
+
+func testAccKubernetesStorageClassConfig_generatedName(prefix string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_storage_class" "test" {
+	metadata {
+		generate_name = "%s"
+	}
+	storage_provisioner = "kubernetes.io/gce-pd"
+}`, prefix)
+}

--- a/kubernetes/structure_persistent_volume_claim.go
+++ b/kubernetes/structure_persistent_volume_claim.go
@@ -41,6 +41,9 @@ func flattenPersistentVolumeClaimSpec(in v1.PersistentVolumeClaimSpec) []interfa
 	if in.VolumeName != "" {
 		att["volume_name"] = in.VolumeName
 	}
+	if in.StorageClassName != nil {
+		att["storage_class_name"] = *in.StorageClassName
+	}
 	return []interface{}{att}
 }
 
@@ -106,6 +109,9 @@ func expandPersistentVolumeClaimSpec(l []interface{}) (v1.PersistentVolumeClaimS
 	}
 	if v, ok := in["volume_name"].(string); ok {
 		obj.VolumeName = v
+	}
+	if v, ok := in["storage_class_name"].(string); ok && v != "" {
+		obj.StorageClassName = ptrToString(v)
 	}
 	return obj, nil
 }

--- a/website/docs/r/persistent_volume_claim.html.markdown
+++ b/website/docs/r/persistent_volume_claim.html.markdown
@@ -81,6 +81,7 @@ The following arguments are supported:
 * `resources` - (Required) A list of the minimum resources the volume should have. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#resources
 * `selector` - (Optional) A label query over volumes to consider for binding.
 * `volume_name` - (Optional) The binding reference to the PersistentVolume backing this claim.
+* `storage_class_name` - (Optional) Name of the storage class requested by the claim
 
 ### `match_expressions`
 

--- a/website/docs/r/storage_class.html.markdown
+++ b/website/docs/r/storage_class.html.markdown
@@ -1,0 +1,63 @@
+---
+layout: "kubernetes"
+page_title: "Kubernetes: kubernetes_storage_class"
+sidebar_current: "docs-kubernetes-resource-storage-class"
+description: |-
+  Storage class is the foundation of dynamic provisioning, allowing cluster administrators to define abstractions for the underlying storage platform.
+---
+
+# kubernetes_storage_class
+
+Storage class is the foundation of dynamic provisioning, allowing cluster administrators to define abstractions for the underlying storage platform.
+
+Read more at http://blog.kubernetes.io/2017/03/dynamic-provisioning-and-storage-classes-kubernetes.html
+
+## Example Usage
+
+```
+resource "kubernetes_storage_class" "example" {
+  metadata {
+    name = "terraform-example"
+  }
+  provisioner = "kubernetes.io/gce-pd"
+  parameters {
+  	type = "pd-standard"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `metadata` - (Required) Standard storage class's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
+* `parameters` - (Optional) The parameters for the provisioner that should create volumes of this storage class.
+	Read more about [available parameters](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#parameters).
+* `storage_provisioner` - (Required) Indicates the type of the provisioner
+
+## Nested Blocks
+
+### `metadata`
+
+#### Arguments
+
+* `annotations` - (Optional) An unstructured key value map stored with the storage class that may be used to store arbitrary metadata. More info: http://kubernetes.io/docs/user-guide/annotations
+* `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#idempotency
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the storage class. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels
+* `name` - (Optional) Name of the storage class, must be unique. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+#### Attributes
+
+
+* `generation` - A sequence number representing a specific generation of the desired state.
+* `resource_version` - An opaque value that represents the internal version of this storage class that can be used by clients to determine when storage class has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+* `self_link` - A URL representing this storage class.
+* `uid` - The unique in time and space value for this storage class. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+
+## Import
+
+kubernetes_storage_class can be imported using its name, e.g.
+
+```
+$ terraform import kubernetes_storage_class.example terraform-example
+```

--- a/website/kubernetes.erb
+++ b/website/kubernetes.erb
@@ -49,6 +49,9 @@
             <li<%= sidebar_current("docs-kubernetes-resource-service-account") %>>
               <a href="/docs/providers/kubernetes/r/service_account.html">kubernetes_service_account</a>
             </li>
+            <li<%= sidebar_current("docs-kubernetes-resource-storage-class") %>>
+              <a href="/docs/providers/kubernetes/r/storage_class.html">kubernetes_storage_class</a>
+            </li>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
Closes https://github.com/terraform-providers/terraform-provider-kubernetes/issues/4

### Test results

```
$ make testacc TEST=./kubernetes TESTARGS='-run="(TestAccKubernetesPersistentVolumeClaim_|TestAccKubernetesStorageClass_)"'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./kubernetes -v -run="(TestAccKubernetesPersistentVolumeClaim_|TestAccKubernetesStorageClass_)" -timeout 120m
=== RUN   TestAccKubernetesPersistentVolumeClaim_basic
--- PASS: TestAccKubernetesPersistentVolumeClaim_basic (4.83s)
=== RUN   TestAccKubernetesPersistentVolumeClaim_importBasic
--- PASS: TestAccKubernetesPersistentVolumeClaim_importBasic (31.03s)
=== RUN   TestAccKubernetesPersistentVolumeClaim_volumeMatch
--- PASS: TestAccKubernetesPersistentVolumeClaim_volumeMatch (56.22s)
=== RUN   TestAccKubernetesPersistentVolumeClaim_volumeUpdate
--- PASS: TestAccKubernetesPersistentVolumeClaim_volumeUpdate (33.79s)
=== RUN   TestAccKubernetesPersistentVolumeClaim_storageClass
--- PASS: TestAccKubernetesPersistentVolumeClaim_storageClass (23.35s)
=== RUN   TestAccKubernetesStorageClass_basic
--- PASS: TestAccKubernetesStorageClass_basic (6.76s)
=== RUN   TestAccKubernetesStorageClass_importBasic
--- PASS: TestAccKubernetesStorageClass_importBasic (2.46s)
=== RUN   TestAccKubernetesStorageClass_generatedName
--- PASS: TestAccKubernetesStorageClass_generatedName (2.16s)
=== RUN   TestAccKubernetesStorageClass_importGeneratedName
--- PASS: TestAccKubernetesStorageClass_importGeneratedName (2.31s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	162.989s
```