### PR TITLE
Add kubernetes_service data source

### DIFF
--- a/kubernetes/data_source_kubernetes_service.go
+++ b/kubernetes/data_source_kubernetes_service.go
@@ -1,0 +1,131 @@
+package kubernetes
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func dataSourceKubernetesService() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceKubernetesServiceRead,
+
+		Schema: map[string]*schema.Schema{
+			"metadata": namespacedMetadataSchema("service", false),
+			"spec": {
+				Type:        schema.TypeList,
+				Description: "Spec defines the behavior of a service. https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status",
+				MaxItems:    1,
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cluster_ip": {
+							Type:        schema.TypeString,
+							Description: "The IP address of the service. It is usually assigned randomly by the master. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. `None` can be specified for headless services when proxying is not required. Ignored if type is `ExternalName`. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies",
+							Computed:    true,
+						},
+						"external_ips": {
+							Type:        schema.TypeSet,
+							Description: "A list of IP addresses for which nodes in the cluster will also accept traffic for this service. These IPs are not managed by Kubernetes. The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         schema.HashString,
+							Computed:    true,
+						},
+						"external_name": {
+							Type:        schema.TypeString,
+							Description: "The external reference that kubedns or equivalent will return as a CNAME record for this service. No proxying will be involved. Must be a valid DNS name and requires `type` to be `ExternalName`.",
+							Computed:    true,
+						},
+						"load_balancer_ip": {
+							Type:        schema.TypeString,
+							Description: "Only applies to `type = LoadBalancer`. LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying this field when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.",
+							Computed:    true,
+						},
+						"load_balancer_source_ranges": {
+							Type:        schema.TypeSet,
+							Description: "If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature. More info: http://kubernetes.io/docs/user-guide/services-firewalls",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         schema.HashString,
+							Computed:    true,
+						},
+						"port": {
+							Type:        schema.TypeList,
+							Description: "The list of ports that are exposed by this service. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies",
+							MinItems:    1,
+							Computed:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Description: "The name of this port within the service. All ports within the service must have unique names. Optional if only one ServicePort is defined on this service.",
+										Computed:    true,
+									},
+									"node_port": {
+										Type:        schema.TypeInt,
+										Description: "The port on each node on which this service is exposed when `type` is `NodePort` or `LoadBalancer`. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the `type` of this service requires one. More info: http://kubernetes.io/docs/user-guide/services#type--nodeport",
+										Computed:    true,
+									},
+									"port": {
+										Type:        schema.TypeInt,
+										Description: "The port that will be exposed by this service.",
+										Computed:    true,
+									},
+									"protocol": {
+										Type:        schema.TypeString,
+										Description: "The IP protocol for this port. Supports `TCP` and `UDP`. Default is `TCP`.",
+										Computed:    true,
+									},
+									"target_port": {
+										Type:        schema.TypeInt,
+										Description: "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. This field is ignored for services with `cluster_ip = \"None\"`. More info: http://kubernetes.io/docs/user-guide/services#defining-a-service",
+										Computed:    true,
+									},
+								},
+							},
+						},
+						"selector": {
+							Type:        schema.TypeMap,
+							Description: "Route service traffic to pods with label keys and values matching this selector. Only applies to types `ClusterIP`, `NodePort`, and `LoadBalancer`. More info: http://kubernetes.io/docs/user-guide/services#overview",
+							Computed:    true,
+						},
+						"session_affinity": {
+							Type:        schema.TypeString,
+							Description: "Used to maintain session affinity. Supports `ClientIP` and `None`. Defaults to `None`. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies",
+							Computed:    true,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Description: "Determines how the service is exposed. Defaults to `ClusterIP`. Valid options are `ExternalName`, `ClusterIP`, `NodePort`, and `LoadBalancer`. `ExternalName` maps to the specified `external_name`. More info: http://kubernetes.io/docs/user-guide/services#overview",
+							Computed:    true,
+						},
+					},
+				},
+			},
+			"load_balancer_ingress": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"hostname": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceKubernetesServiceRead(d *schema.ResourceData, meta interface{}) error {
+	om := meta_v1.ObjectMeta{
+		Namespace: d.Get("metadata.0.namespace").(string),
+		Name:      d.Get("metadata.0.name").(string),
+	}
+	d.SetId(buildId(om))
+
+	return resourceKubernetesServiceRead(d, meta)
+}

--- a/kubernetes/data_source_kubernetes_service_test.go
+++ b/kubernetes/data_source_kubernetes_service_test.go
@@ -1,0 +1,50 @@
+package kubernetes
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccKubernetesDataSourceService_basic(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesDataSourceServiceConfig_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.kubernetes_service.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("data.kubernetes_service.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_service.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_service.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_service.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.#", "1"),
+					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.port.#", "1"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_service.test", "spec.0.cluster_ip"),
+					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.port.0.name", ""),
+					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.port.0.node_port", "0"),
+					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.port.0.port", "8080"),
+					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.port.0.protocol", "TCP"),
+					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.port.0.target_port", "80"),
+					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.session_affinity", "None"),
+					resource.TestCheckResourceAttr("data.kubernetes_service.test", "spec.0.type", "ClusterIP"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKubernetesDataSourceServiceConfig_basic(name string) string {
+	return testAccKubernetesServiceConfig_basic(name) + `
+data "kubernetes_service" "test" {
+	metadata {
+		name = "${kubernetes_service.test.metadata.0.name}"
+	}
+}
+`
+}

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -91,6 +91,10 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"kubernetes_service": dataSourceKubernetesService(),
+		},
+
 		ResourcesMap: map[string]*schema.Resource{
 			"kubernetes_config_map":                resourceKubernetesConfigMap(),
 			"kubernetes_horizontal_pod_autoscaler": resourceKubernetesHorizontalPodAutoscaler(),

--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -1,0 +1,82 @@
+---
+layout: "kubernetes"
+page_title: "Kubernetes: kubernetes_service"
+sidebar_current: "docs-kubernetes-data-source-service"
+description: |-
+  A Service is an abstraction which defines a logical set of pods and a policy by which to access them - sometimes called a micro-service.
+---
+
+# kubernetes_service
+
+A Service is an abstraction which defines a logical set of pods and a policy by which to access them - sometimes called a micro-service.
+This data source allows you to pull data about such service.
+
+## Example Usage
+
+```hcl
+data "kubernetes_service" "example" {
+  metadata {
+    name = "terraform-example"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `metadata` - (Required) Standard service's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
+
+## Attributes
+
+* `spec` - Spec defines the behavior of a service. https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
+* `load_balancer_ingress` - A list containing ingress points for the load-balancer (only valid if `type = "LoadBalancer"`)
+
+## Nested Blocks
+
+### `metadata`
+
+#### Arguments
+
+* `name` - (Optional) Name of the service, must be unique. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names
+* `namespace` - (Optional) Namespace defines the space within which name of the service must be unique.
+
+#### Attributes
+
+* `annotations` - (Optional) An unstructured key value map stored with the service that may be used to store arbitrary metadata. More info: http://kubernetes.io/docs/user-guide/annotations
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the service. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels
+* `generation` - A sequence number representing a specific generation of the desired state.
+* `resource_version` - An opaque value that represents the internal version of this service that can be used by clients to determine when service has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+* `self_link` - A URL representing this service.
+* `uid` - The unique in time and space value for this service. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+
+### `port`
+
+#### Attributes
+
+* `name` - The name of this port within the service. All ports within the service must have unique names. Optional if only one ServicePort is defined on this service.
+* `node_port` - The port on each node on which this service is exposed when `type` is `NodePort` or `LoadBalancer`. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the `type` of this service requires one. More info: http://kubernetes.io/docs/user-guide/services#type--nodeport
+* `port` - The port that will be exposed by this service.
+* `protocol` - The IP protocol for this port. Supports `TCP` and `UDP`. Default is `TCP`.
+* `target_port` - Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. This field is ignored for services with `cluster_ip = "None"`. More info: http://kubernetes.io/docs/user-guide/services#defining-a-service
+
+### `spec`
+
+#### Attributes
+
+* `cluster_ip` - The IP address of the service. It is usually assigned randomly by the master. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. `None` can be specified for headless services when proxying is not required. Ignored if type is `ExternalName`. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies
+* `external_ips` - A list of IP addresses for which nodes in the cluster will also accept traffic for this service. These IPs are not managed by Kubernetes. The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+* `external_name` - The external reference that kubedns or equivalent will return as a CNAME record for this service. No proxying will be involved. Must be a valid DNS name and requires `type` to be `ExternalName`.
+* `load_balancer_ip` - Only applies to `type = LoadBalancer`. LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying this field when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
+* `load_balancer_source_ranges` - If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature. More info: http://kubernetes.io/docs/user-guide/services-firewalls
+* `port` - The list of ports that are exposed by this service. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies
+* `selector` - Route service traffic to pods with label keys and values matching this selector. Only applies to types `ClusterIP`, `NodePort`, and `LoadBalancer`. More info: http://kubernetes.io/docs/user-guide/services#overview
+* `session_affinity` - Used to maintain session affinity. Supports `ClientIP` and `None`. Defaults to `None`. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies
+* `type` - Determines how the service is exposed. Defaults to `ClusterIP`. Valid options are `ExternalName`, `ClusterIP`, `NodePort`, and `LoadBalancer`. `ExternalName` maps to the specified `external_name`. More info: http://kubernetes.io/docs/user-guide/services#overview
+
+### `load_balancer_ingress`
+
+#### Attributes
+
+* `hostname` - Hostname which is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)
+* `ip` - IP which is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)

--- a/website/kubernetes.erb
+++ b/website/kubernetes.erb
@@ -10,6 +10,15 @@
           <a href="/docs/providers/kubernetes/index.html">Kubernetes Provider</a>
         </li>
 
+        <li<%= sidebar_current("docs-kubernetes-data-source") %>>
+          <a href="#">Data Sources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-kubernetes-data-source-service") %>>
+              <a href="/docs/providers/kubernetes/d/service.html">kubernetes_service</a>
+            </li>
+          </ul>
+        </li>
+
         <li<%= sidebar_current("docs-kubernetes-resource") %>>
           <a href="#">Resources</a>
           <ul class="nav nav-visible">


### PR DESCRIPTION
Closes https://github.com/terraform-providers/terraform-provider-kubernetes/issues/13

### Test Results

```
$ make testacc TEST=./kubernetes TESTARGS='-run=TestAccKubernetesDataSourceService_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./kubernetes -v -run=TestAccKubernetesDataSourceService_basic -timeout 120m
=== RUN   TestAccKubernetesDataSourceService_basic
--- PASS: TestAccKubernetesDataSourceService_basic (4.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	4.186s
```