### PR TITLE
r/service: Make port optional field

### DIFF
--- a/kubernetes/resource_kubernetes_service.go
+++ b/kubernetes/resource_kubernetes_service.go
@@ -68,7 +68,7 @@ func resourceKubernetesService() *schema.Resource {
 						"port": {
 							Type:        schema.TypeList,
 							Description: "The list of ports that are exposed by this service. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies",
-							Required:    true,
+							Optional:    true,
 							MinItems:    1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-kubernetes/issues/26

```
make testacc TEST=./kubernetes TESTARGS='-run=TestAccKubernetesService_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./kubernetes -v -run=TestAccKubernetesService_ -timeout 120m
=== RUN   TestAccKubernetesService_basic
--- PASS: TestAccKubernetesService_basic (0.69s)
=== RUN   TestAccKubernetesService_loadBalancer
--- PASS: TestAccKubernetesService_loadBalancer (56.37s)
=== RUN   TestAccKubernetesService_nodePort
--- PASS: TestAccKubernetesService_nodePort (0.33s)
=== RUN   TestAccKubernetesService_externalName
--- PASS: TestAccKubernetesService_externalName (0.30s)
=== RUN   TestAccKubernetesService_importBasic
--- PASS: TestAccKubernetesService_importBasic (0.36s)
=== RUN   TestAccKubernetesService_generatedName
--- PASS: TestAccKubernetesService_generatedName (0.32s)
=== RUN   TestAccKubernetesService_importGeneratedName
--- PASS: TestAccKubernetesService_importGeneratedName (0.49s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	58.939s
```