### PR TITLE
Add support of token in auth

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -90,6 +90,12 @@ func Provider() terraform.ResourceProvider {
 				Description: "",
 			},
 		},
+		"token": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("KUBE_TOKEN", ""),
+			Description: "Token to authentifcate an service account",
+		},
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"kubernetes_service":       dataSourceKubernetesService(),
@@ -148,6 +154,9 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 	if v, ok := d.GetOk("client_key"); ok {
 		cfg.KeyData = bytes.NewBufferString(v.(string)).Bytes()
+	}
+	if v, ok := d.GetOk("token"); ok {
+		cfg.BearerToken = v.(string)
 	}
 
 	k, err := kubernetes.NewForConfig(cfg)

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -89,12 +89,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("KUBE_CTX_CLUSTER", ""),
 				Description: "",
 			},
-		},
-		"token": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			DefaultFunc: schema.EnvDefaultFunc("KUBE_TOKEN", ""),
-			Description: "Token to authentifcate an service account",
+			"token": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("KUBE_TOKEN", ""),
+				Description: "Token to authentifcate an service account",
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -97,3 +97,4 @@ The following arguments are supported:
 * `config_context` - (Optional) Context to choose from the config file. Can be sourced from `KUBE_CTX`.
 * `config_context_auth_info` - (Optional) Authentication info context of the kube config (name of the kubeconfig user, `--user` flag in `kubectl`). Can be sourced from `KUBE_CTX_AUTH_INFO`.
 * `config_context_cluster` - (Optional) Cluster context of the kube config (name of the kubeconfig cluster, `--cluster` flag in `kubectl`). Can be sourced from `KUBE_CTX_CLUSTER`.
+* `token` - (Optional) Token of your service account


### PR DESCRIPTION
With this PR, I want to add the support of token for authentication.

We can use it like that :
`
provider "kubernetes" {
   host          = "https://api.k8s.domain.com"
   token    = "xxxxxxxxxxxxxxxxxxxxx"
}`

I use it for our jenkins deployment.
