### PR TITLE
Add switch to disable kubeconfig

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -99,7 +99,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("KUBE_LOAD_CONFIG_FILE", true),
-				Description: "Do not load local kubeconfig.",
+				Description: "Load local kubeconfig.",
 			},
 		},
 

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -95,6 +95,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("KUBE_TOKEN", ""),
 				Description: "Token to authentifcate an service account",
 			},
+			"disable_local_config": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("KUBE_DISABLE_LOCAL_CONFIG", false),
+				Description: "Do not load local kubeconfig.",
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -122,8 +128,19 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	// Config file loading
-	cfg, err := tryLoadingConfigFile(d)
+
+	var disableLocalConf bool
+	if v, ok := d.GetOk("disable_local_config"); ok {
+		disableLocalConf = v.(bool)
+	}
+
+	var cfg *restclient.Config
+	var err error
+	if disableLocalConf == false {
+		// Config file loading
+		cfg, err = tryLoadingConfigFile(d)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -95,10 +95,10 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("KUBE_TOKEN", ""),
 				Description: "Token to authentifcate an service account",
 			},
-			"disable_local_config": {
+			"load_config_file": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("KUBE_DISABLE_LOCAL_CONFIG", false),
+				DefaultFunc: schema.EnvDefaultFunc("KUBE_LOAD_CONFIG_FILE", true),
 				Description: "Do not load local kubeconfig.",
 			},
 		},
@@ -129,14 +129,9 @@ func Provider() terraform.ResourceProvider {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
-	var disableLocalConf bool
-	if v, ok := d.GetOk("disable_local_config"); ok {
-		disableLocalConf = v.(bool)
-	}
-
 	var cfg *restclient.Config
 	var err error
-	if disableLocalConf == false {
+	if d.Get("load_config_file").(bool) {
 		// Config file loading
 		cfg, err = tryLoadingConfigFile(d)
 	}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -98,3 +98,4 @@ The following arguments are supported:
 * `config_context_auth_info` - (Optional) Authentication info context of the kube config (name of the kubeconfig user, `--user` flag in `kubectl`). Can be sourced from `KUBE_CTX_AUTH_INFO`.
 * `config_context_cluster` - (Optional) Cluster context of the kube config (name of the kubeconfig cluster, `--cluster` flag in `kubectl`). Can be sourced from `KUBE_CTX_CLUSTER`.
 * `token` - (Optional) Token of your service account
+* `disable_local_config` - (Optional) By default the local config (~/.kube/config) is loaded when you use this provider. This option disable this behaviour.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -97,5 +97,5 @@ The following arguments are supported:
 * `config_context` - (Optional) Context to choose from the config file. Can be sourced from `KUBE_CTX`.
 * `config_context_auth_info` - (Optional) Authentication info context of the kube config (name of the kubeconfig user, `--user` flag in `kubectl`). Can be sourced from `KUBE_CTX_AUTH_INFO`.
 * `config_context_cluster` - (Optional) Cluster context of the kube config (name of the kubeconfig cluster, `--cluster` flag in `kubectl`). Can be sourced from `KUBE_CTX_CLUSTER`.
-* `token` - (Optional) Token of your service account
-* `disable_local_config` - (Optional) By default the local config (~/.kube/config) is loaded when you use this provider. This option disable this behaviour.
+* `token` - (Optional) Token of your service account.
+* `load_config_file` - (Optional) By default the local config (~/.kube/config) is loaded when you use this provider. This option at false disable this behaviour.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -97,6 +97,6 @@ The following arguments are supported:
 * `config_context` - (Optional) Context to choose from the config file. Can be sourced from `KUBE_CTX`.
 * `config_context_auth_info` - (Optional) Authentication info context of the kube config (name of the kubeconfig user, `--user` flag in `kubectl`). Can be sourced from `KUBE_CTX_AUTH_INFO`.
 * `config_context_cluster` - (Optional) Cluster context of the kube config (name of the kubeconfig cluster, `--cluster` flag in `kubectl`). Can be sourced from `KUBE_CTX_CLUSTER`.
-* `token` - (Optional) Token of your service account.
-* `load_config_file` - (Optional) By default the local config (~/.kube/config) is loaded when you use this provider. This option at false disable this behaviour.
+* `token` - (Optional) Token of your service account.  Can be sourced from `KUBE_TOKEN`.
+* `load_config_file` - (Optional) By default the local config (~/.kube/config) is loaded when you use this provider. This option at false disable this behaviour. Can be sourced from `KUBE_LOAD_CONFIG_FILE`.
 


### PR DESCRIPTION
The provider load by default the kubeconfig and merge it with the conf in Terraform.

We want do all the settings in terraform for that we don't want to include the conf local. The merge have some odd behaviour. So we want to have a way to disable it. 

This pr add just a switch to disable the local config.

Exemple:
```
provider "kubernetes" {
    host                        = "${data.aws_ssm_parameter.k8s_url.value}"
    token                       = "${data.aws_ssm_parameter.jenkins_password.value}"
    insecure                    = true
    disable_local_config = true
}
```



