### PR TITLE
Escape '/' in JSON Patch path correctly

### DIFF
--- a/kubernetes/patch_operations.go
+++ b/kubernetes/patch_operations.go
@@ -21,7 +21,9 @@ func diffStringMap(pathPrefix string, oldV, newV map[string]interface{}) PatchOp
 		if _, ok := newV[k]; ok {
 			continue
 		}
-		ops = append(ops, &RemoveOperation{Path: pathPrefix + "/" + k})
+		ops = append(ops, &RemoveOperation{
+			Path: pathPrefix + "/" + escapeJsonPointer(k),
+		})
 	}
 
 	for k, v := range newV {
@@ -33,19 +35,27 @@ func diffStringMap(pathPrefix string, oldV, newV map[string]interface{}) PatchOp
 			}
 
 			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/" + k,
+				Path:  pathPrefix + "/" + escapeJsonPointer(k),
 				Value: newValue,
 			})
 			continue
 		}
 
 		ops = append(ops, &AddOperation{
-			Path:  pathPrefix + "/" + k,
+			Path:  pathPrefix + "/" + escapeJsonPointer(k),
 			Value: newValue,
 		})
 	}
 
 	return ops
+}
+
+// escapeJsonPointer escapes string per RFC 6901
+// so it can be used as path in JSON patch operations
+func escapeJsonPointer(path string) string {
+	path = strings.Replace(path, "~", "~0", -1)
+	path = strings.Replace(path, "/", "~1", -1)
+	return path
 }
 
 type PatchOperations []PatchOperation


### PR DESCRIPTION
This is to address the main part of https://github.com/terraform-providers/terraform-provider-kubernetes/issues/37 but I'm intentionally not closing it yet.

```
=== RUN   TestAccKubernetesNamespace_withSpecialCharacters
--- PASS: TestAccKubernetesNamespace_withSpecialCharacters (6.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	6.575s
```

There's another issue causing spurious diffs when internal annotations are specified which still needs addressing.