### PR TITLE
Update Secret Volume to support `items`.

### DIFF
--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -353,6 +353,32 @@ func TestAccKubernetesPod_with_empty_dir_volume(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesPod_with_secret_vol_items(t *testing.T) {
+	var conf api.Pod
+
+	secretName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := "nginx:1.7.9"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesPodDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesPodConfigWithSecretItemsVolume(secretName, podName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.image", imageName),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.secret.0.items.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.secret.0.items.0.key", "one"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.secret.0.items.0.path", "path/to/one"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckKubernetesPodDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*kubernetes.Clientset)
 
@@ -683,6 +709,52 @@ resource "kubernetes_pod" "test" {
       name = "db"
       secret {
         secret_name = "${kubernetes_secret.test.metadata.0.name}"
+      }
+    }
+  }
+}
+	`, secretName, podName, imageName)
+}
+
+func testAccKubernetesPodConfigWithSecretItemsVolume(secretName, podName, imageName string) string {
+	return fmt.Sprintf(`
+
+resource "kubernetes_secret" "test" {
+  metadata {
+    name = "%s"
+  }
+
+  data {
+    one = "first"
+  }
+}
+
+resource "kubernetes_pod" "test" {
+  metadata {
+    labels {
+      app = "pod_label"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    container {
+      image = "%s"
+      name  = "containername"
+      volume_mount {
+        mount_path = "/tmp/my_path"
+        name       = "db"
+      }
+    }
+    volume {
+      name = "db"
+      secret {
+				secret_name = "${kubernetes_secret.test.metadata.0.name}"
+				items {
+					key = "one"
+					path = "path/to/one"
+				}
       }
     }
   }

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -360,7 +360,7 @@ func TestAccKubernetesPod_with_secret_vol_items(t *testing.T) {
 	secretName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	imageName := "nginx:1.7.9"
-  
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -386,7 +386,7 @@ func TestAccKubernetesPod_with_nodeSelector(t *testing.T) {
 	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	imageName := "nginx:1.7.9"
 	region := os.Getenv("GOOGLE_REGION")
-  
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -776,11 +776,11 @@ resource "kubernetes_pod" "test" {
     volume {
       name = "db"
       secret {
-				secret_name = "${kubernetes_secret.test.metadata.0.name}"
-				items {
-					key = "one"
-					path = "path/to/one"
-				}
+        secret_name = "${kubernetes_secret.test.metadata.0.name}"
+        items {
+          key = "one"
+          path = "path/to/one"
+        }
       }
     }
   }

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -359,11 +359,12 @@ func volumeSchema() *schema.Resource {
 					Type:         schema.TypeInt,
 					Description:  "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
 					Optional:     true,
+					Default:      0644,
 					ValidateFunc: validateModeBits,
 				},
 				"items": {
 					Type:        schema.TypeList,
-					Description: `If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'.`,
+					Description: "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
 					Optional:    true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
@@ -375,13 +376,13 @@ func volumeSchema() *schema.Resource {
 							"mode": {
 								Type:        schema.TypeInt,
 								Optional:    true,
-								Description: `Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.`,
+								Description: "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
 							},
 							"path": {
 								Type:         schema.TypeString,
 								Optional:     true,
 								ValidateFunc: validateAttributeValueDoesNotContain(".."),
-								Description:  `The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.`,
+								Description:  "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
 							},
 						},
 					},

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -355,6 +355,42 @@ func volumeSchema() *schema.Resource {
 		MaxItems:    1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
+				"default_mode": {
+					Type:         schema.TypeInt,
+					Description:  "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+					Optional:     true,
+					ValidateFunc: validateModeBits,
+				},
+				"items": {
+					Type:        schema.TypeList,
+					Description: `If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'.`,
+					Optional:    true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"key": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								Description: "The key to project.",
+							},
+							"mode": {
+								Type:        schema.TypeInt,
+								Optional:    true,
+								Description: `Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.`,
+							},
+							"path": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: validateAttributeValueDoesNotContain(".."),
+								Description:  `The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.`,
+							},
+						},
+					},
+				},
+				"optional": {
+					Type:        schema.TypeBool,
+					Description: "Optional: Specify whether the Secret or it's keys must be defined.",
+					Optional:    true,
+				},
 				"secret_name": {
 					Type:        schema.TypeString,
 					Description: "Name of the secret in the pod's namespace to use. More info: http://kubernetes.io/docs/user-guide/volumes#secrets",

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -290,13 +290,17 @@ func flattenSecretVolumeSource(in *v1.SecretVolumeSource) []interface{} {
 		for i, v := range in.Items {
 			m := map[string]interface{}{}
 			m["key"] = v.Key
-			m["mode"] = int(*v.Mode)
+			if v.Mode != nil {
+				m["mode"] = int(*v.Mode)
+			}
 			m["path"] = v.Path
 			items[i] = m
 		}
 		att["items"] = items
 	}
-	att["optional"] = *in.Optional
+	if in.Optional != nil {
+		att["optional"] = *in.Optional
+	}
 	return []interface{}{att}
 }
 
@@ -577,13 +581,12 @@ func expandSecretVolumeSource(l []interface{}) *v1.SecretVolumeSource {
 	obj := &v1.SecretVolumeSource{
 		DefaultMode: ptrToInt32(int32(in["default_mode"].(int))),
 		SecretName:  in["secret_name"].(string),
+		Optional:    ptrToBool(in["optional"].(bool)),
 	}
 
 	if v, ok := in["items"].([]interface{}); ok && len(v) > 0 {
 		obj.Items = expandKeyPath(v)
 	}
-
-	obj.Optional = ptrToBool(in["optional"].(bool))
 
 	return obj
 }

--- a/kubernetes/validators.go
+++ b/kubernetes/validators.go
@@ -176,7 +176,7 @@ func validateModeBits(value interface{}, key string) (ws []string, es []error) {
 func validateAttributeValueDoesNotContain(searchString string) schema.SchemaValidateFunc {
 	return func(v interface{}, k string) (ws []string, errors []error) {
 		input := v.(string)
-		if !strings.Contains(input, searchString) {
+		if strings.Contains(input, searchString) {
 			errors = append(errors, fmt.Errorf(
 				"%q must not contain %q",
 				k, searchString))

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -445,7 +445,16 @@ The following arguments are supported:
 
 #### Arguments
 
+* `default_mode` - (Optional) Mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+* `items` - (Optional) List of Secret Items to project into the volume. See `items` block definition below. If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked `optional`. Paths must be relative and may not contain the '..' path or start with '..'.
+* `optional` - (Optional) Specify whether the Secret or it's keys must be defined.
 * `secret_name` - (Optional) Name of the secret in the pod's namespace to use. More info: http://kubernetes.io/docs/user-guide/volumes#secrets
+
+The `items` block supports the following:
+
+* `key` - (Required) The key to project.
+* `mode` - (Optional) Mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used.
+* `path` - (Required) The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
 
 ### `secret_key_ref`
 

--- a/website/docs/r/replication_controller.html.markdown
+++ b/website/docs/r/replication_controller.html.markdown
@@ -472,7 +472,16 @@ The following arguments are supported:
 
 #### Arguments
 
+* `default_mode` - (Optional) Mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+* `items` - (Optional) List of Secret Items to project into the volume. See `items` block definition below. If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked `optional`. Paths must be relative and may not contain the '..' path or start with '..'.
+* `optional` - (Optional) Specify whether the Secret or it's keys must be defined.
 * `secret_name` - (Optional) Name of the secret in the pod's namespace to use. More info: http://kubernetes.io/docs/user-guide/volumes#secrets
+
+The `items` block supports:
+
+* `key` - (Required) The key to project.
+* `mode` - (Optional) Mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used.
+* `path` - (Required) The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
 
 ### `secret_key_ref`
 


### PR DESCRIPTION
This works the same as `config_map.items`.

I also fixed `validateAttributeValueDoesNotContain()` validator. It’s
logic was the reverse of intention.