### PR TITLE
Avoid crash when importing invalid ID

### DIFF
--- a/kubernetes/resource_kubernetes_config_map.go
+++ b/kubernetes/resource_kubernetes_config_map.go
@@ -56,7 +56,10 @@ func resourceKubernetesConfigMapCreate(d *schema.ResourceData, meta interface{})
 func resourceKubernetesConfigMapRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
 	log.Printf("[INFO] Reading config map %s", name)
 	cfgMap, err := conn.CoreV1().ConfigMaps(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
@@ -76,7 +79,10 @@ func resourceKubernetesConfigMapRead(d *schema.ResourceData, meta interface{}) e
 func resourceKubernetesConfigMapUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 	if d.HasChange("data") {
@@ -102,9 +108,12 @@ func resourceKubernetesConfigMapUpdate(d *schema.ResourceData, meta interface{})
 func resourceKubernetesConfigMapDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
 	log.Printf("[INFO] Deleting config map: %#v", name)
-	err := conn.CoreV1().ConfigMaps(namespace).Delete(name, &metav1.DeleteOptions{})
+	err = conn.CoreV1().ConfigMaps(namespace).Delete(name, &metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -118,9 +127,13 @@ func resourceKubernetesConfigMapDelete(d *schema.ResourceData, meta interface{})
 func resourceKubernetesConfigMapExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return false, err
+	}
+
 	log.Printf("[INFO] Checking config map %s", name)
-	_, err := conn.CoreV1().ConfigMaps(namespace).Get(name, metav1.GetOptions{})
+	_, err = conn.CoreV1().ConfigMaps(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return false, nil

--- a/kubernetes/resource_kubernetes_config_map_test.go
+++ b/kubernetes/resource_kubernetes_config_map_test.go
@@ -187,7 +187,10 @@ func testAccCheckKubernetesConfigMapDestroy(s *terraform.State) error {
 		if rs.Type != "kubernetes_config_map" {
 			continue
 		}
-		namespace, name := idParts(rs.Primary.ID)
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 		resp, err := conn.CoreV1().ConfigMaps(namespace).Get(name, meta_v1.GetOptions{})
 		if err == nil {
 			if resp.Name == rs.Primary.ID {
@@ -207,7 +210,10 @@ func testAccCheckKubernetesConfigMapExists(n string, obj *api.ConfigMap) resourc
 		}
 
 		conn := testAccProvider.Meta().(*kubernetes.Clientset)
-		namespace, name := idParts(rs.Primary.ID)
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 		out, err := conn.CoreV1().ConfigMaps(namespace).Get(name, meta_v1.GetOptions{})
 		if err != nil {
 			return err

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
@@ -104,7 +104,10 @@ func resourceKubernetesHorizontalPodAutoscalerCreate(d *schema.ResourceData, met
 func resourceKubernetesHorizontalPodAutoscalerRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
 	log.Printf("[INFO] Reading horizontal pod autoscaler %s", name)
 	svc, err := conn.AutoscalingV1().HorizontalPodAutoscalers(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
@@ -130,7 +133,10 @@ func resourceKubernetesHorizontalPodAutoscalerRead(d *schema.ResourceData, meta 
 func resourceKubernetesHorizontalPodAutoscalerUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 	if d.HasChange("spec") {
@@ -155,9 +161,12 @@ func resourceKubernetesHorizontalPodAutoscalerUpdate(d *schema.ResourceData, met
 func resourceKubernetesHorizontalPodAutoscalerDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
 	log.Printf("[INFO] Deleting horizontal pod autoscaler: %#v", name)
-	err := conn.AutoscalingV1().HorizontalPodAutoscalers(namespace).Delete(name, &meta_v1.DeleteOptions{})
+	err = conn.AutoscalingV1().HorizontalPodAutoscalers(namespace).Delete(name, &meta_v1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -171,9 +180,13 @@ func resourceKubernetesHorizontalPodAutoscalerDelete(d *schema.ResourceData, met
 func resourceKubernetesHorizontalPodAutoscalerExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return false, err
+	}
+
 	log.Printf("[INFO] Checking horizontal pod autoscaler %s", name)
-	_, err := conn.AutoscalingV1().HorizontalPodAutoscalers(namespace).Get(name, meta_v1.GetOptions{})
+	_, err = conn.AutoscalingV1().HorizontalPodAutoscalers(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return false, nil

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_test.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_test.go
@@ -161,7 +161,12 @@ func testAccCheckKubernetesHorizontalPodAutoscalerDestroy(s *terraform.State) er
 		if rs.Type != "kubernetes_horizontal_pod_autoscaler" {
 			continue
 		}
-		namespace, name := idParts(rs.Primary.ID)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		resp, err := conn.AutoscalingV1().HorizontalPodAutoscalers(namespace).Get(name, meta_v1.GetOptions{})
 		if err == nil {
 			if resp.Namespace == namespace && resp.Name == name {
@@ -181,7 +186,12 @@ func testAccCheckKubernetesHorizontalPodAutoscalerExists(n string, obj *api.Hori
 		}
 
 		conn := testAccProvider.Meta().(*kubernetes.Clientset)
-		namespace, name := idParts(rs.Primary.ID)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		out, err := conn.AutoscalingV1().HorizontalPodAutoscalers(namespace).Get(name, meta_v1.GetOptions{})
 		if err != nil {
 			return err

--- a/kubernetes/resource_kubernetes_limit_range.go
+++ b/kubernetes/resource_kubernetes_limit_range.go
@@ -105,7 +105,10 @@ func resourceKubernetesLimitRangeCreate(d *schema.ResourceData, meta interface{}
 func resourceKubernetesLimitRangeRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
 	log.Printf("[INFO] Reading limit range %s", name)
 	limitRange, err := conn.CoreV1().LimitRanges(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
@@ -129,7 +132,10 @@ func resourceKubernetesLimitRangeRead(d *schema.ResourceData, meta interface{}) 
 func resourceKubernetesLimitRangeUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 	if d.HasChange("spec") {
@@ -160,9 +166,13 @@ func resourceKubernetesLimitRangeUpdate(d *schema.ResourceData, meta interface{}
 func resourceKubernetesLimitRangeDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
 	log.Printf("[INFO] Deleting limit range: %#v", name)
-	err := conn.CoreV1().LimitRanges(namespace).Delete(name, &meta_v1.DeleteOptions{})
+	err = conn.CoreV1().LimitRanges(namespace).Delete(name, &meta_v1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -176,9 +186,13 @@ func resourceKubernetesLimitRangeDelete(d *schema.ResourceData, meta interface{}
 func resourceKubernetesLimitRangeExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return false, err
+	}
+
 	log.Printf("[INFO] Checking limit range %s", name)
-	_, err := conn.CoreV1().LimitRanges(namespace).Get(name, meta_v1.GetOptions{})
+	_, err = conn.CoreV1().LimitRanges(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return false, nil

--- a/kubernetes/resource_kubernetes_limit_range_test.go
+++ b/kubernetes/resource_kubernetes_limit_range_test.go
@@ -263,7 +263,12 @@ func testAccCheckKubernetesLimitRangeDestroy(s *terraform.State) error {
 		if rs.Type != "kubernetes_limit_range" {
 			continue
 		}
-		namespace, name := idParts(rs.Primary.ID)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		resp, err := conn.CoreV1().LimitRanges(namespace).Get(name, meta_v1.GetOptions{})
 		if err == nil {
 			if resp.Namespace == namespace && resp.Name == name {
@@ -283,7 +288,12 @@ func testAccCheckKubernetesLimitRangeExists(n string, obj *api.LimitRange) resou
 		}
 
 		conn := testAccProvider.Meta().(*kubernetes.Clientset)
-		namespace, name := idParts(rs.Primary.ID)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		out, err := conn.CoreV1().LimitRanges(namespace).Get(name, meta_v1.GetOptions{})
 		if err != nil {
 			return err

--- a/kubernetes/resource_kubernetes_persistent_volume_claim.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim.go
@@ -205,7 +205,11 @@ func resourceKubernetesPersistentVolumeClaimCreate(d *schema.ResourceData, meta 
 func resourceKubernetesPersistentVolumeClaimRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
 	log.Printf("[INFO] Reading persistent volume claim %s", name)
 	claim, err := conn.CoreV1().PersistentVolumeClaims(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
@@ -227,7 +231,11 @@ func resourceKubernetesPersistentVolumeClaimRead(d *schema.ResourceData, meta in
 
 func resourceKubernetesPersistentVolumeClaimUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
-	namespace, name := idParts(d.Id())
+
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 	// The whole spec is ForceNew = nothing to update there
@@ -249,9 +257,13 @@ func resourceKubernetesPersistentVolumeClaimUpdate(d *schema.ResourceData, meta 
 func resourceKubernetesPersistentVolumeClaimDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
 	log.Printf("[INFO] Deleting persistent volume claim: %#v", name)
-	err := conn.CoreV1().PersistentVolumeClaims(namespace).Delete(name, &meta_v1.DeleteOptions{})
+	err = conn.CoreV1().PersistentVolumeClaims(namespace).Delete(name, &meta_v1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -265,9 +277,13 @@ func resourceKubernetesPersistentVolumeClaimDelete(d *schema.ResourceData, meta 
 func resourceKubernetesPersistentVolumeClaimExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return false, err
+	}
+
 	log.Printf("[INFO] Checking persistent volume claim %s", name)
-	_, err := conn.CoreV1().PersistentVolumeClaims(namespace).Get(name, meta_v1.GetOptions{})
+	_, err = conn.CoreV1().PersistentVolumeClaims(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return false, nil

--- a/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
@@ -406,7 +406,12 @@ func testAccCheckKubernetesPersistentVolumeClaimDestroy(s *terraform.State) erro
 		if rs.Type != "kubernetes_persistent_volume_claim" {
 			continue
 		}
-		namespace, name := idParts(rs.Primary.ID)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		resp, err := conn.CoreV1().PersistentVolumeClaims(namespace).Get(name, meta_v1.GetOptions{})
 		if err == nil {
 			if resp.Namespace == namespace && resp.Name == name {
@@ -426,7 +431,12 @@ func testAccCheckKubernetesPersistentVolumeClaimExists(n string, obj *api.Persis
 		}
 
 		conn := testAccProvider.Meta().(*kubernetes.Clientset)
-		namespace, name := idParts(rs.Primary.ID)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		out, err := conn.CoreV1().PersistentVolumeClaims(namespace).Get(name, meta_v1.GetOptions{})
 		if err != nil {
 			return err

--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -95,7 +95,12 @@ func resourceKubernetesPodCreate(d *schema.ResourceData, meta interface{}) error
 
 func resourceKubernetesPodUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
-	namespace, name := idParts(d.Id())
+
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 	if d.HasChange("spec") {
 		specOps, err := patchPodSpec("/spec", "spec.0.", d)
@@ -123,7 +128,11 @@ func resourceKubernetesPodUpdate(d *schema.ResourceData, meta interface{}) error
 
 func resourceKubernetesPodRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
-	namespace, name := idParts(d.Id())
+
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading pod %s", name)
 	pod, err := conn.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
@@ -153,9 +162,14 @@ func resourceKubernetesPodRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceKubernetesPodDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
-	namespace, name := idParts(d.Id())
+
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
 	log.Printf("[INFO] Deleting pod: %#v", name)
-	err := conn.CoreV1().Pods(namespace).Delete(name, nil)
+	err = conn.CoreV1().Pods(namespace).Delete(name, nil)
 	if err != nil {
 		return err
 	}
@@ -186,9 +200,13 @@ func resourceKubernetesPodDelete(d *schema.ResourceData, meta interface{}) error
 func resourceKubernetesPodExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return false, err
+	}
+
 	log.Printf("[INFO] Checking pod %s", name)
-	_, err := conn.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
+	_, err = conn.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return false, nil

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -386,7 +386,12 @@ func testAccCheckKubernetesPodDestroy(s *terraform.State) error {
 		if rs.Type != "kubernetes_pod" {
 			continue
 		}
-		namespace, name := idParts(rs.Primary.ID)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		resp, err := conn.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
 		if err == nil {
 			if resp.Namespace == namespace && resp.Name == name {
@@ -407,7 +412,11 @@ func testAccCheckKubernetesPodExists(n string, obj *api.Pod) resource.TestCheckF
 
 		conn := testAccProvider.Meta().(*kubernetes.Clientset)
 
-		namespace, name := idParts(rs.Primary.ID)
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		out, err := conn.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			return err

--- a/kubernetes/resource_kubernetes_replication_controller.go
+++ b/kubernetes/resource_kubernetes_replication_controller.go
@@ -117,7 +117,11 @@ func resourceKubernetesReplicationControllerCreate(d *schema.ResourceData, meta 
 func resourceKubernetesReplicationControllerRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
 	log.Printf("[INFO] Reading replication controller %s", name)
 	rc, err := conn.CoreV1().ReplicationControllers(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
@@ -147,7 +151,10 @@ func resourceKubernetesReplicationControllerRead(d *schema.ResourceData, meta in
 func resourceKubernetesReplicationControllerUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 
@@ -185,7 +192,11 @@ func resourceKubernetesReplicationControllerUpdate(d *schema.ResourceData, meta 
 func resourceKubernetesReplicationControllerDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
 	log.Printf("[INFO] Deleting replication controller: %#v", name)
 
 	// Drain all replicas before deleting
@@ -224,9 +235,13 @@ func resourceKubernetesReplicationControllerDelete(d *schema.ResourceData, meta 
 func resourceKubernetesReplicationControllerExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return false, err
+	}
+
 	log.Printf("[INFO] Checking replication controller %s", name)
-	_, err := conn.CoreV1().ReplicationControllers(namespace).Get(name, metav1.GetOptions{})
+	_, err = conn.CoreV1().ReplicationControllers(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return false, nil

--- a/kubernetes/resource_kubernetes_replication_controller_test.go
+++ b/kubernetes/resource_kubernetes_replication_controller_test.go
@@ -393,7 +393,12 @@ func testAccCheckKubernetesReplicationControllerDestroy(s *terraform.State) erro
 		if rs.Type != "kubernetes_replication_controller" {
 			continue
 		}
-		namespace, name := idParts(rs.Primary.ID)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		resp, err := conn.CoreV1().ReplicationControllers(namespace).Get(name, meta_v1.GetOptions{})
 		if err == nil {
 			if resp.Name == rs.Primary.ID {
@@ -413,7 +418,12 @@ func testAccCheckKubernetesReplicationControllerExists(n string, obj *api.Replic
 		}
 
 		conn := testAccProvider.Meta().(*kubernetes.Clientset)
-		namespace, name := idParts(rs.Primary.ID)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		out, err := conn.CoreV1().ReplicationControllers(namespace).Get(name, meta_v1.GetOptions{})
 		if err != nil {
 			return err

--- a/kubernetes/resource_kubernetes_resource_quota.go
+++ b/kubernetes/resource_kubernetes_resource_quota.go
@@ -98,7 +98,11 @@ func resourceKubernetesResourceQuotaCreate(d *schema.ResourceData, meta interfac
 func resourceKubernetesResourceQuotaRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
 	log.Printf("[INFO] Reading resource quota %s", name)
 	resQuota, err := conn.CoreV1().ResourceQuotas(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
@@ -130,7 +134,10 @@ func resourceKubernetesResourceQuotaRead(d *schema.ResourceData, meta interface{
 func resourceKubernetesResourceQuotaUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 	var spec api.ResourceQuotaSpec
@@ -183,9 +190,13 @@ func resourceKubernetesResourceQuotaUpdate(d *schema.ResourceData, meta interfac
 func resourceKubernetesResourceQuotaDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
 	log.Printf("[INFO] Deleting resource quota: %#v", name)
-	err := conn.CoreV1().ResourceQuotas(namespace).Delete(name, &meta_v1.DeleteOptions{})
+	err = conn.CoreV1().ResourceQuotas(namespace).Delete(name, &meta_v1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -199,9 +210,13 @@ func resourceKubernetesResourceQuotaDelete(d *schema.ResourceData, meta interfac
 func resourceKubernetesResourceQuotaExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return false, err
+	}
+
 	log.Printf("[INFO] Checking resource quota %s", name)
-	_, err := conn.CoreV1().ResourceQuotas(namespace).Get(name, meta_v1.GetOptions{})
+	_, err = conn.CoreV1().ResourceQuotas(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return false, nil

--- a/kubernetes/resource_kubernetes_resource_quota_test.go
+++ b/kubernetes/resource_kubernetes_resource_quota_test.go
@@ -205,7 +205,12 @@ func testAccCheckKubernetesResourceQuotaDestroy(s *terraform.State) error {
 		if rs.Type != "kubernetes_resource_quota" {
 			continue
 		}
-		namespace, name := idParts(rs.Primary.ID)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		resp, err := conn.CoreV1().ResourceQuotas(namespace).Get(name, meta_v1.GetOptions{})
 		if err == nil {
 			if resp.Namespace == namespace && resp.Name == name {
@@ -225,7 +230,12 @@ func testAccCheckKubernetesResourceQuotaExists(n string, obj *api.ResourceQuota)
 		}
 
 		conn := testAccProvider.Meta().(*kubernetes.Clientset)
-		namespace, name := idParts(rs.Primary.ID)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		out, err := conn.CoreV1().ResourceQuotas(namespace).Get(name, meta_v1.GetOptions{})
 		if err != nil {
 			return err

--- a/kubernetes/resource_kubernetes_secret.go
+++ b/kubernetes/resource_kubernetes_secret.go
@@ -70,7 +70,10 @@ func resourceKubernetesSecretCreate(d *schema.ResourceData, meta interface{}) er
 func resourceKubernetesSecretRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading secret %s", name)
 	secret, err := conn.CoreV1().Secrets(namespace).Get(name, meta_v1.GetOptions{})
@@ -93,7 +96,10 @@ func resourceKubernetesSecretRead(d *schema.ResourceData, meta interface{}) erro
 func resourceKubernetesSecretUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 	if d.HasChange("data") {
@@ -127,10 +133,13 @@ func resourceKubernetesSecretUpdate(d *schema.ResourceData, meta interface{}) er
 func resourceKubernetesSecretDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting secret: %q", name)
-	err := conn.CoreV1().Secrets(namespace).Delete(name, &meta_v1.DeleteOptions{})
+	err = conn.CoreV1().Secrets(namespace).Delete(name, &meta_v1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -145,10 +154,13 @@ func resourceKubernetesSecretDelete(d *schema.ResourceData, meta interface{}) er
 func resourceKubernetesSecretExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return false, err
+	}
 
 	log.Printf("[INFO] Checking secret %s", name)
-	_, err := conn.CoreV1().Secrets(namespace).Get(name, meta_v1.GetOptions{})
+	_, err = conn.CoreV1().Secrets(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return false, nil

--- a/kubernetes/resource_kubernetes_secret_test.go
+++ b/kubernetes/resource_kubernetes_secret_test.go
@@ -209,7 +209,12 @@ func testAccCheckKubernetesSecretDestroy(s *terraform.State) error {
 		if rs.Type != "kubernetes_secret" {
 			continue
 		}
-		namespace, name := idParts(rs.Primary.ID)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		resp, err := conn.CoreV1().Secrets(namespace).Get(name, meta_v1.GetOptions{})
 		if err == nil {
 			if resp.Name == rs.Primary.ID {
@@ -229,7 +234,12 @@ func testAccCheckKubernetesSecretExists(n string, obj *api.Secret) resource.Test
 		}
 
 		conn := testAccProvider.Meta().(*kubernetes.Clientset)
-		namespace, name := idParts(rs.Primary.ID)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		out, err := conn.CoreV1().Secrets(namespace).Get(name, meta_v1.GetOptions{})
 		if err != nil {
 			return err

--- a/kubernetes/resource_kubernetes_service.go
+++ b/kubernetes/resource_kubernetes_service.go
@@ -193,7 +193,11 @@ func resourceKubernetesServiceCreate(d *schema.ResourceData, meta interface{}) e
 func resourceKubernetesServiceRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
 	log.Printf("[INFO] Reading service %s", name)
 	svc, err := conn.CoreV1().Services(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
@@ -224,7 +228,10 @@ func resourceKubernetesServiceRead(d *schema.ResourceData, meta interface{}) err
 func resourceKubernetesServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 	if d.HasChange("spec") {
@@ -249,9 +256,13 @@ func resourceKubernetesServiceUpdate(d *schema.ResourceData, meta interface{}) e
 func resourceKubernetesServiceDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
 	log.Printf("[INFO] Deleting service: %#v", name)
-	err := conn.CoreV1().Services(namespace).Delete(name, &meta_v1.DeleteOptions{})
+	err = conn.CoreV1().Services(namespace).Delete(name, &meta_v1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -265,9 +276,13 @@ func resourceKubernetesServiceDelete(d *schema.ResourceData, meta interface{}) e
 func resourceKubernetesServiceExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return false, err
+	}
+
 	log.Printf("[INFO] Checking service %s", name)
-	_, err := conn.CoreV1().Services(namespace).Get(name, meta_v1.GetOptions{})
+	_, err = conn.CoreV1().Services(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return false, nil

--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -128,7 +128,11 @@ func diffObjectReferences(origOrs []api.ObjectReference, ors []api.ObjectReferen
 func resourceKubernetesServiceAccountRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
 	log.Printf("[INFO] Reading service account %s", name)
 	svcAcc, err := conn.CoreV1().ServiceAccounts(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
@@ -154,7 +158,10 @@ func resourceKubernetesServiceAccountRead(d *schema.ResourceData, meta interface
 func resourceKubernetesServiceAccountUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 	if d.HasChange("image_pull_secret") {
@@ -191,9 +198,13 @@ func resourceKubernetesServiceAccountUpdate(d *schema.ResourceData, meta interfa
 func resourceKubernetesServiceAccountDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
 	log.Printf("[INFO] Deleting service account: %#v", name)
-	err := conn.CoreV1().ServiceAccounts(namespace).Delete(name, &metav1.DeleteOptions{})
+	err = conn.CoreV1().ServiceAccounts(namespace).Delete(name, &metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -207,9 +218,13 @@ func resourceKubernetesServiceAccountDelete(d *schema.ResourceData, meta interfa
 func resourceKubernetesServiceAccountExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name := idParts(d.Id())
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return false, err
+	}
+
 	log.Printf("[INFO] Checking service account %s", name)
-	_, err := conn.CoreV1().ServiceAccounts(namespace).Get(name, metav1.GetOptions{})
+	_, err = conn.CoreV1().ServiceAccounts(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return false, nil

--- a/kubernetes/resource_kubernetes_service_account_test.go
+++ b/kubernetes/resource_kubernetes_service_account_test.go
@@ -246,7 +246,12 @@ func testAccCheckKubernetesServiceAccountDestroy(s *terraform.State) error {
 		if rs.Type != "kubernetes_service_account" {
 			continue
 		}
-		namespace, name := idParts(rs.Primary.ID)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		resp, err := conn.CoreV1().ServiceAccounts(namespace).Get(name, meta_v1.GetOptions{})
 		if err == nil {
 			if resp.Name == rs.Primary.ID {
@@ -266,7 +271,12 @@ func testAccCheckKubernetesServiceAccountExists(n string, obj *api.ServiceAccoun
 		}
 
 		conn := testAccProvider.Meta().(*kubernetes.Clientset)
-		namespace, name := idParts(rs.Primary.ID)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		out, err := conn.CoreV1().ServiceAccounts(namespace).Get(name, meta_v1.GetOptions{})
 		if err != nil {
 			return err

--- a/kubernetes/resource_kubernetes_service_test.go
+++ b/kubernetes/resource_kubernetes_service_test.go
@@ -356,7 +356,12 @@ func testAccCheckKubernetesServiceDestroy(s *terraform.State) error {
 		if rs.Type != "kubernetes_service" {
 			continue
 		}
-		namespace, name := idParts(rs.Primary.ID)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		resp, err := conn.CoreV1().Services(namespace).Get(name, meta_v1.GetOptions{})
 		if err == nil {
 			if resp.Name == rs.Primary.ID {
@@ -376,7 +381,12 @@ func testAccCheckKubernetesServiceExists(n string, obj *api.Service) resource.Te
 		}
 
 		conn := testAccProvider.Meta().(*kubernetes.Clientset)
-		namespace, name := idParts(rs.Primary.ID)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		out, err := conn.CoreV1().Services(namespace).Get(name, meta_v1.GetOptions{})
 		if err != nil {
 			return err

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -12,9 +12,14 @@ import (
 	api "k8s.io/kubernetes/pkg/api/v1"
 )
 
-func idParts(id string) (string, string) {
+func idParts(id string) (string, string, error) {
 	parts := strings.Split(id, "/")
-	return parts[0], parts[1]
+	if len(parts) != 2 {
+		err := fmt.Errorf("Unexpected ID format (%q), expected %q.", id, "namespace/name")
+		return "", "", err
+	}
+
+	return parts[0], parts[1], nil
 }
 
 func buildId(meta metav1.ObjectMeta) string {


### PR DESCRIPTION
Fixes #41

### Before
```
$ terraform import kubernetes_pod.test terraform-nginx-example-43zkw
kubernetes_pod.test: Importing from ID "terraform-nginx-example-43zkw"...
kubernetes_pod.test: Import complete!
  Imported kubernetes_pod (ID: terraform-nginx-example-43zkw)
kubernetes_pod.test: Refreshing state... (ID: terraform-nginx-example-43zkw)
Error importing: 1 error(s) occurred:

* kubernetes_pod.test (import id: terraform-nginx-example-43zkw): 1 error(s) occurred:

* import kubernetes_pod.test result: terraform-nginx-example-43zkw: kubernetes_pod.test: unexpected EOF
panic: runtime error: index out of range
2017/08/11 15:02:10 [DEBUG] plugin: terraform-provider-kubernetes:
2017/08/11 15:02:10 [DEBUG] plugin: terraform-provider-kubernetes: goroutine 32 [running]:
2017/08/11 15:02:10 [DEBUG] plugin: terraform-provider-kubernetes: github.com/terraform-providers/terraform-provider-kubernetes/kubernetes.idParts(0xc4205d5b00, 0x1d, 0x68, 0x26d1000, 0xc4202a70f8, 0x0)
2017/08/11 15:02:10 [DEBUG] plugin: terraform-provider-kubernetes: 	/Users/radeksimko/gopath/src/github.com/terraform-providers/terraform-provider-kubernetes/kubernetes/structures.go:17 +0x95
...
```

### After
```
$ terraform import kubernetes_pod.test terraform-nginx-example-43zkw
kubernetes_pod.test: Importing from ID "terraform-nginx-example-43zkw"...
kubernetes_pod.test: Import complete!
  Imported kubernetes_pod (ID: terraform-nginx-example-43zkw)
kubernetes_pod.test: Refreshing state... (ID: terraform-nginx-example-43zkw)
Error importing: 1 error(s) occurred:

* kubernetes_pod.test (import id: terraform-nginx-example-43zkw): 1 error(s) occurred:

* import kubernetes_pod.test result: terraform-nginx-example-43zkw: kubernetes_pod.test: Unexpected ID format ("terraform-nginx-example-43zkw"), expected "namespace/name".
```