### PR TITLE
r/pod: Represent update-ability of spec correctly

### DIFF
--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -32,7 +32,7 @@ func resourceKubernetesPod() *schema.Resource {
 				Required:    true,
 				MaxItems:    1,
 				Elem: &schema.Resource{
-					Schema: podSpecFields(),
+					Schema: podSpecFields(false),
 				},
 			},
 		},
@@ -109,7 +109,7 @@ func resourceKubernetesPodUpdate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Failed to marshal update operations: %s", err)
 	}
 
-	log.Printf("[INFO] Updating  pod %s: %s", d.Id(), ops)
+	log.Printf("[INFO] Updating pod %s: %s", d.Id(), ops)
 
 	out, err := conn.CoreV1().Pods(namespace).Patch(name, pkgApi.JSONPatchType, data)
 	if err != nil {

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -57,6 +57,58 @@ func TestAccKubernetesPod_basic(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesPod_updateForceNew(t *testing.T) {
+	var conf api.Pod
+
+	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	imageName := "hashicorp/http-echo:latest"
+	argsBefore := `["-listen=:80", "-text='before modification'"]`
+	argsAfter := `["-listen=:80", "-text='after modification'"]`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesPodDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesPodConfigArgsUpdate(podName, imageName, argsBefore),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.annotations.%", "0"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.name", podName),
+					resource.TestCheckResourceAttrSet("kubernetes_pod.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_pod.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_pod.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_pod.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.image", imageName),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.args.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.args.0", "-listen=:80"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.args.1", "-text='before modification'"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.name", "containername"),
+				),
+			},
+			{
+				Config: testAccKubernetesPodConfigArgsUpdate(podName, imageName, argsAfter),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.annotations.%", "0"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.name", podName),
+					resource.TestCheckResourceAttrSet("kubernetes_pod.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_pod.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_pod.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_pod.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.image", imageName),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.args.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.args.0", "-listen=:80"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.args.1", "-text='after modification'"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.name", "containername"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKubernetesPod_importBasic(t *testing.T) {
 	resourceName := "kubernetes_pod.test"
 	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
@@ -913,4 +965,22 @@ resource "kubernetes_pod" "test" {
   }
 }
 `, podName, imageName, region)
+}
+
+func testAccKubernetesPodConfigArgsUpdate(podName, imageName, args string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_pod" "test" {
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    container {
+      image = "%s"
+      args = %s
+      name  = "containername"
+    }
+  }
+}
+`, podName, imageName, args)
 }

--- a/kubernetes/resource_kubernetes_replication_controller.go
+++ b/kubernetes/resource_kubernetes_replication_controller.go
@@ -63,7 +63,7 @@ func resourceKubernetesReplicationController() *schema.Resource {
 							Required:    true,
 							MaxItems:    1,
 							Elem: &schema.Resource{
-								Schema: podSpecFields(),
+								Schema: podSpecFields(true),
 							},
 						},
 					},

--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -194,8 +194,8 @@ func volumeMountFields() map[string]*schema.Schema {
 	}
 }
 
-func containerFields() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
+func containerFields(isUpdatable bool) map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
 		"args": {
 			Type:        schema.TypeList,
 			Optional:    true,
@@ -473,6 +473,18 @@ func containerFields() map[string]*schema.Schema {
 			Description: "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
 		},
 	}
+
+	if !isUpdatable {
+		for k, _ := range s {
+			if k == "image" {
+				// This field is always updatable
+				continue
+			}
+			s[k].ForceNew = true
+		}
+	}
+
+	return s
 }
 
 func probeSchema() *schema.Resource {

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -703,10 +703,6 @@ func patchPodSpec(pathPrefix, prefix string, d *schema.ResourceData) (PatchOpera
 				Path:  pathPrefix + "/containers/" + strconv.Itoa(i) + "/image",
 				Value: v.Image,
 			})
-			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/containers/" + strconv.Itoa(i) + "/name",
-				Value: v.Name,
-			})
 
 		}
 


### PR DESCRIPTION
Fixes #20 

## Test results

```
make testacc TEST=./kubernetes TESTARGS='-run=TestAccKubernetesPod_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./kubernetes -v -run=TestAccKubernetesPod_ -timeout 120m
=== RUN   TestAccKubernetesPod_basic
--- PASS: TestAccKubernetesPod_basic (11.48s)
=== RUN   TestAccKubernetesPod_updateForceNew
--- PASS: TestAccKubernetesPod_updateForceNew (83.46s)
=== RUN   TestAccKubernetesPod_importBasic
--- PASS: TestAccKubernetesPod_importBasic (5.99s)
=== RUN   TestAccKubernetesPod_with_pod_security_context
--- PASS: TestAccKubernetesPod_with_pod_security_context (5.71s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_exec
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_exec (39.94s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_http_get
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_http_get (5.03s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_tcp
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_tcp (20.05s)
=== RUN   TestAccKubernetesPod_with_container_lifecycle
--- PASS: TestAccKubernetesPod_with_container_lifecycle (5.12s)
=== RUN   TestAccKubernetesPod_with_container_security_context
--- PASS: TestAccKubernetesPod_with_container_security_context (5.53s)
=== RUN   TestAccKubernetesPod_with_volume_mount
--- PASS: TestAccKubernetesPod_with_volume_mount (21.52s)
=== RUN   TestAccKubernetesPod_with_cfg_map_volume_mount
--- PASS: TestAccKubernetesPod_with_cfg_map_volume_mount (13.94s)
=== RUN   TestAccKubernetesPod_with_resource_requirements
--- PASS: TestAccKubernetesPod_with_resource_requirements (11.65s)
=== RUN   TestAccKubernetesPod_with_empty_dir_volume
--- PASS: TestAccKubernetesPod_with_empty_dir_volume (6.35s)
=== RUN   TestAccKubernetesPod_with_secret_vol_items
--- PASS: TestAccKubernetesPod_with_secret_vol_items (13.62s)
=== RUN   TestAccKubernetesPod_with_nodeSelector
--- PASS: TestAccKubernetesPod_with_nodeSelector (20.07s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	269.548s
```