### PR TITLE
meta: Treat internal k8s annotations as invalid

### DIFF
--- a/kubernetes/validators.go
+++ b/kubernetes/validators.go
@@ -21,6 +21,10 @@ func validateAnnotations(value interface{}, key string) (ws []string, es []error
 				es = append(es, fmt.Errorf("%s (%q) %s", key, k, e))
 			}
 		}
+
+		if isInternalKey(k) {
+			es = append(es, fmt.Errorf("%s: %q is internal Kubernetes annotation", key, k))
+		}
 	}
 	return
 }


### PR DESCRIPTION
We always ignored internal annotations and we never allowed users to update them either as an effect of [another bug](https://github.com/terraform-providers/terraform-provider-kubernetes/pull/40). This is making it much more explicit and upfront and hopefully less confusing.

Closes #37

## Why we don't support internal annotations

Annotations are more often (compared to labels) used by the scheduler or machine generally rather than a human. We cannot tell the difference between annotation specified by a user and machine-managed one from the API. This may be "by design" and we're not complaining about the K8S annotations design here by any means. It's a design preventing Terraform from detecting drifts between reality and config nonetheless.

This conflict of ownership presents a problem for any field of any resource and provider. Internal (`kubernetes.io/*`) annotations are just well known to be used by kubelet out of the box.

If you have any tools/scripts outside of Terraform which add, remove or modify annotations for objects managed by Terraform, you may use [`ignore_changes`](https://www.terraform.io/docs/configuration/resources.html#ignore_changes), i.e.
```hcl
  lifecycle {
    ignore_changes = ["metadata.0.annotations"]
  }
```
This is a way to tell Terraform that you manage annotations separately and want Terraform to ignore any changes your tools/scripts make to annotations.

Vast majority of custom user-specifyable annotations are also related to alpha or beta features which we currently don't intend to support as mentioned [in Readme](https://github.com/terraform-providers/terraform-provider-kubernetes#contributing-resources) with further explanation in https://github.com/terraform-providers/terraform-provider-kubernetes/pull/1#issuecomment-307940033

## Before

```
$ terraform apply
...
$ terraform plan

  ~ kubernetes_pod.echo
      metadata.0.annotations.%:                      "0" => "1"
      metadata.0.annotations.kubernetes.io/anything: "" => "blablah"

```

## After

```
$ terraform plan
1 error(s) occurred:

* kubernetes_pod.echo: metadata.0.annotations: "kubernetes.io/anything" is internal Kubernetes annotation
```
