### PR TITLE
r/pod+rc: Avoid crash in reading container.security_context capability

### DIFF
--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -148,7 +148,9 @@ func TestAccKubernetesPod_with_pod_security_context(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.security_context.0.run_as_non_root", "true"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.security_context.0.run_as_user", "101"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.security_context.0.supplemental_groups.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.security_context.0.supplemental_groups.988695518", "101"),
 				),
 			},
 		},
@@ -286,6 +288,14 @@ func TestAccKubernetesPod_with_container_security_context(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.security_context.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.security_context.0.privileged", "true"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.security_context.0.run_as_user", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.security_context.0.se_linux_options.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.security_context.0.se_linux_options.0.level", "s0:c123,c456"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.security_context.0.capabilities.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.security_context.0.capabilities.0.add.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.security_context.0.capabilities.0.add.0", "NET_ADMIN"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.security_context.0.capabilities.0.add.1", "SYS_TIME"),
 				),
 			},
 		},
@@ -752,13 +762,14 @@ resource "kubernetes_pod" "test" {
         se_linux_options {
           level = "s0:c123,c456"
         }
+        capabilities {
+          add = ["NET_ADMIN", "SYS_TIME"]
+        }
       }
     }
   }
 }
-
-
-	`, podName, imageName)
+`, podName, imageName)
 }
 
 func testAccKubernetesPodConfigWithVolumeMounts(secretName, podName, imageName string) string {

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -8,7 +8,7 @@ import (
 )
 
 func flattenCapability(in []v1.Capability) []string {
-	att := make([]string, 0, len(in))
+	att := make([]string, len(in), len(in))
 	for i, v := range in {
 		att[i] = string(v)
 	}
@@ -510,7 +510,7 @@ func expandContainerSecurityContext(l []interface{}) *v1.SecurityContext {
 func expandCapabilitySlice(s []interface{}) []v1.Capability {
 	result := make([]v1.Capability, len(s), len(s))
 	for k, v := range s {
-		result[k] = v.(v1.Capability)
+		result[k] = v1.Capability(v.(string))
 	}
 	return result
 }


### PR DESCRIPTION
## Test results

```
make testacc TEST=./kubernetes TESTARGS='-run=TestAccKubernetesPod'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./kubernetes -v -run=TestAccKubernetesPod -timeout 120m
=== RUN   TestAccKubernetesPod_basic
--- PASS: TestAccKubernetesPod_basic (24.63s)
=== RUN   TestAccKubernetesPod_updateForceNew
--- PASS: TestAccKubernetesPod_updateForceNew (103.62s)
=== RUN   TestAccKubernetesPod_importBasic
--- PASS: TestAccKubernetesPod_importBasic (7.68s)
=== RUN   TestAccKubernetesPod_with_pod_security_context
--- PASS: TestAccKubernetesPod_with_pod_security_context (4.74s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_exec
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_exec (50.10s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_http_get
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_http_get (5.51s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_tcp
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_tcp (6.22s)
=== RUN   TestAccKubernetesPod_with_container_lifecycle
--- PASS: TestAccKubernetesPod_with_container_lifecycle (7.67s)
=== RUN   TestAccKubernetesPod_with_container_security_context
--- PASS: TestAccKubernetesPod_with_container_security_context (4.72s)
=== RUN   TestAccKubernetesPod_with_volume_mount
--- PASS: TestAccKubernetesPod_with_volume_mount (20.90s)
=== RUN   TestAccKubernetesPod_with_cfg_map_volume_mount
--- PASS: TestAccKubernetesPod_with_cfg_map_volume_mount (6.81s)
=== RUN   TestAccKubernetesPod_with_resource_requirements
--- PASS: TestAccKubernetesPod_with_resource_requirements (6.80s)
=== RUN   TestAccKubernetesPod_with_empty_dir_volume
--- PASS: TestAccKubernetesPod_with_empty_dir_volume (11.94s)
=== RUN   TestAccKubernetesPod_with_secret_vol_items
--- PASS: TestAccKubernetesPod_with_secret_vol_items (10.18s)
=== RUN   TestAccKubernetesPod_with_nodeSelector
--- PASS: TestAccKubernetesPod_with_nodeSelector (11.99s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	283.576s
```