### PR TITLE
tests: Skip GCloud tests if no ENV vars provided

### DIFF
--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -167,9 +167,12 @@ func testAccPreCheck(t *testing.T) {
 				"KUBE_CLUSTER_CA_CERT_DATA",
 			}, ", "))
 	}
+}
 
+func skipIfNoGoogleCloudSettingsFound(t *testing.T) {
 	if os.Getenv("GOOGLE_PROJECT") == "" || os.Getenv("GOOGLE_REGION") == "" || os.Getenv("GOOGLE_ZONE") == "" {
-		t.Fatal("GOOGLE_PROJECT, GOOGLE_REGION and GOOGLE_ZONE must be set for acceptance tests")
+		t.Skip("The environment variables GOOGLE_PROJECT, GOOGLE_REGION and GOOGLE_ZONE" +
+			" must be set to run Google Cloud tests - skipping")
 	}
 }
 

--- a/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
@@ -84,7 +84,9 @@ func TestAccKubernetesPersistentVolumeClaim_basic(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesPersistentVolumeClaim_importBasic(t *testing.T) {
+func TestAccKubernetesPersistentVolumeClaim_googleCloud_importBasic(t *testing.T) {
+	skipIfNoGoogleCloudSettingsFound(t)
+
 	resourceName := "kubernetes_persistent_volume_claim.test"
 	volumeName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(10))
 	claimName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(10))
@@ -108,7 +110,9 @@ func TestAccKubernetesPersistentVolumeClaim_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesPersistentVolumeClaim_volumeMatch(t *testing.T) {
+func TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch(t *testing.T) {
+	skipIfNoGoogleCloudSettingsFound(t)
+
 	var pvcConf api.PersistentVolumeClaim
 	var pvConf api.PersistentVolume
 
@@ -258,7 +262,9 @@ func TestAccKubernetesPersistentVolumeClaim_volumeMatch(t *testing.T) {
 // 	})
 // }
 
-func TestAccKubernetesPersistentVolumeClaim_volumeUpdate(t *testing.T) {
+func TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeUpdate(t *testing.T) {
+	skipIfNoGoogleCloudSettingsFound(t)
+
 	var pvcConf api.PersistentVolumeClaim
 	var pvConf api.PersistentVolume
 
@@ -325,7 +331,9 @@ func TestAccKubernetesPersistentVolumeClaim_volumeUpdate(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesPersistentVolumeClaim_storageClass(t *testing.T) {
+func TestAccKubernetesPersistentVolumeClaim_googleCloud_storageClass(t *testing.T) {
+	skipIfNoGoogleCloudSettingsFound(t)
+
 	var pvcConf api.PersistentVolumeClaim
 	var storageClass storageapi.StorageClass
 	var secondStorageClass storageapi.StorageClass

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -13,7 +13,9 @@ import (
 	kubernetes "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 )
 
-func TestAccKubernetesPersistentVolume_basic(t *testing.T) {
+func TestAccKubernetesPersistentVolume_googleCloud_basic(t *testing.T) {
+	skipIfNoGoogleCloudSettingsFound(t)
+
 	var conf api.PersistentVolume
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	name := fmt.Sprintf("tf-acc-test-%s", randString)
@@ -99,7 +101,9 @@ func TestAccKubernetesPersistentVolume_basic(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesPersistentVolume_importBasic(t *testing.T) {
+func TestAccKubernetesPersistentVolume_googleCloud_importBasic(t *testing.T) {
+	skipIfNoGoogleCloudSettingsFound(t)
+
 	resourceName := "kubernetes_persistent_volume.test"
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	name := fmt.Sprintf("tf-acc-test-import-%s", randString)
@@ -124,7 +128,9 @@ func TestAccKubernetesPersistentVolume_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesPersistentVolume_volumeSource(t *testing.T) {
+func TestAccKubernetesPersistentVolume_googleCloud_volumeSource(t *testing.T) {
+	skipIfNoGoogleCloudSettingsFound(t)
+
 	var conf api.PersistentVolume
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	name := fmt.Sprintf("tf-acc-test-%s", randString)


### PR DESCRIPTION
This is a first step in making the provider work outside of GKE/GCloud, e.g. minikube, minishift and generally in most popular k8s environments.

There's loads of failing tests on the mentioned platforms atm, but here we can at least isolate those which won't ever pass.