### PR TITLE
Add `automount_service_account_token` to podSpec.

### DIFF
--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -47,8 +47,6 @@ func resourceKubernetesPodCreate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	spec.AutomountServiceAccountToken = ptrToBool(false)
-
 	pod := api.Pod{
 		ObjectMeta: metadata,
 		Spec:       spec,

--- a/kubernetes/resource_kubernetes_replication_controller.go
+++ b/kubernetes/resource_kubernetes_replication_controller.go
@@ -82,8 +82,6 @@ func resourceKubernetesReplicationControllerCreate(d *schema.ResourceData, meta 
 		return err
 	}
 
-	spec.Template.Spec.AutomountServiceAccountToken = ptrToBool(false)
-
 	rc := api.ReplicationController{
 		ObjectMeta: metadata,
 		Spec:       spec,

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -132,6 +132,12 @@ func podSpecFields(isUpdatable bool) map[string]*schema.Schema {
 			Computed:    true,
 			Description: "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: http://releases.k8s.io/HEAD/docs/design/service_accounts.md.",
 		},
+		"automount_service_account_token": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.",
+		},
 		"subdomain": {
 			Type:        schema.TypeString,
 			Optional:    true,

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -72,6 +72,7 @@ The following arguments are supported:
 * `restart_policy` - (Optional) Restart policy for all containers within the pod. One of Always, OnFailure, Never. More info: http://kubernetes.io/docs/user-guide/pod-states#restartpolicy.
 * `security_context` - (Optional) SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty
 * `service_account_name` - (Optional) ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: http://releases.k8s.io/HEAD/docs/design/service_accounts.md.
+* `automount_service_account_token` - (Optional) Indicates whether a service account token should be automatically mounted. Defaults to true.
 * `subdomain` - (Optional) If specified, the fully qualified Pod hostname will be "...svc.". If not specified, the pod will not have a domainname at all..
 * `termination_grace_period_seconds` - (Optional) Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.
 * `volume` - (Optional) List of volumes that can be mounted by containers belonging to the pod. More info: http://kubernetes.io/docs/user-guide/volumes

--- a/website/docs/r/replication_controller.html.markdown
+++ b/website/docs/r/replication_controller.html.markdown
@@ -100,6 +100,7 @@ The following arguments are supported:
 * `security_context` - (Optional) SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty
 * `service_account_name` - (Optional) ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: http://releases.k8s.io/HEAD/docs/design/service_accounts.md.
 * `subdomain` - (Optional) If specified, the fully qualified Pod hostname will be "...svc.". If not specified, the pod will not have a domainname at all..
+* `automount_service_account_token` - (Optional) Indicates whether a service account token should be automatically mounted. Defaults to true.
 * `termination_grace_period_seconds` - (Optional) Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.
 * `volume` - (Optional) List of volumes that can be mounted by containers belonging to the pod. More info: http://kubernetes.io/docs/user-guide/volumes
 


### PR DESCRIPTION
The automountServiceAccountToken attribute was added to the Kubernetes
podSpec in 1.6+ and is intended as a way to opt out of the default pre
1.6 behaviour of always mounting the service account token.
For this reason, I’ve set the default to True.

Additional Info
https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/