### PR TITLE
Make acceptance tests compatible w/ minikube

### DIFF
--- a/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
@@ -30,10 +30,6 @@ func TestAccKubernetesPersistentVolumeClaim_basic(t *testing.T) {
 					testAccCheckKubernetesPersistentVolumeClaimExists("kubernetes_persistent_volume_claim.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "metadata.0.annotations.%", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "metadata.0.annotations.TestAnnotationOne", "one"),
-					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{
-						"TestAnnotationOne":                             "one",
-						"volume.beta.kubernetes.io/storage-provisioner": "kubernetes.io/gce-pd",
-					}),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "metadata.0.labels.%", "3"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "metadata.0.labels.TestLabelOne", "one"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "metadata.0.labels.TestLabelThree", "three"),
@@ -51,6 +47,32 @@ func TestAccKubernetesPersistentVolumeClaim_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.storage", "5Gi"),
 				),
 			},
+			{ // GKE specific check
+				Config: testAccKubernetesPersistentVolumeClaimConfig_basic(name),
+				SkipFunc: func() (bool, error) {
+					isInGke, err := isRunningInGke()
+					return !isInGke, err
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{
+						"TestAnnotationOne":                             "one",
+						"volume.beta.kubernetes.io/storage-provisioner": "kubernetes.io/gce-pd",
+					}),
+				),
+			},
+			{ // minikube specific check
+				Config: testAccKubernetesPersistentVolumeClaimConfig_basic(name),
+				SkipFunc: func() (bool, error) {
+					isInMinikube, err := isRunningInMinikube()
+					return !isInMinikube, err
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{
+						"TestAnnotationOne":                             "one",
+						"volume.beta.kubernetes.io/storage-provisioner": "k8s.io/minikube-hostpath",
+					}),
+				),
+			},
 			{
 				Config: testAccKubernetesPersistentVolumeClaimConfig_metaModified(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -58,11 +80,6 @@ func TestAccKubernetesPersistentVolumeClaim_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "metadata.0.annotations.%", "2"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "metadata.0.annotations.TestAnnotationOne", "one"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "metadata.0.annotations.TestAnnotationTwo", "two"),
-					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{
-						"TestAnnotationOne":                             "one",
-						"TestAnnotationTwo":                             "two",
-						"volume.beta.kubernetes.io/storage-provisioner": "kubernetes.io/gce-pd",
-					}),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "metadata.0.labels.%", "3"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "metadata.0.labels.TestLabelOne", "one"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "metadata.0.labels.TestLabelTwo", "two"),
@@ -78,6 +95,34 @@ func TestAccKubernetesPersistentVolumeClaim_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.%", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.storage", "5Gi"),
+				),
+			},
+			{ // GKE specific check
+				Config: testAccKubernetesPersistentVolumeClaimConfig_basic(name),
+				SkipFunc: func() (bool, error) {
+					isInGke, err := isRunningInGke()
+					return !isInGke, err
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{
+						"TestAnnotationOne":                             "one",
+						"TestAnnotationTwo":                             "two",
+						"volume.beta.kubernetes.io/storage-provisioner": "kubernetes.io/gce-pd",
+					}),
+				),
+			},
+			{ // minikube specific check
+				Config: testAccKubernetesPersistentVolumeClaimConfig_basic(name),
+				SkipFunc: func() (bool, error) {
+					isInMinikube, err := isRunningInMinikube()
+					return !isInMinikube, err
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{
+						"TestAnnotationOne":                             "one",
+						"TestAnnotationTwo":                             "two",
+						"volume.beta.kubernetes.io/storage-provisioner": "k8s.io/minikube-hostpath",
+					}),
 				),
 			},
 		},

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -442,7 +442,9 @@ func TestAccKubernetesPod_with_secret_vol_items(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesPod_with_nodeSelector(t *testing.T) {
+func TestAccKubernetesPod_gke_with_nodeSelector(t *testing.T) {
+	skipIfNotRunningInGke(t)
+
 	var conf api.Pod
 
 	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))

--- a/kubernetes/resource_kubernetes_service_test.go
+++ b/kubernetes/resource_kubernetes_service_test.go
@@ -86,6 +86,8 @@ func TestAccKubernetesService_basic(t *testing.T) {
 }
 
 func TestAccKubernetesService_loadBalancer(t *testing.T) {
+	skipIfNoLoadBalancersAvailable(t)
+
 	var conf api.Service
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 


### PR DESCRIPTION
This is to lower the barrier for contributors by making it easier and cheaper to run acceptance tests via [minikube](https://github.com/kubernetes/minikube).

It's also the first step towards testing in multiple environments we intend to support eventually (AWS, raw GCE, _maybe_ OpenStack). This may also exercise more codepaths with different contexts and make the code eventually more robust.

**Disclaimer:** A few tests may still be a bit flaky, because unlike GKE, minikube may have higher latency when it comes to assigning annotations after resources are submitted, but we're at least skipping the ones which would never pass.

```
$ minikube start
Starting local Kubernetes v1.7.0 cluster...
Starting VM...
Getting VM IP address...
Moving files into cluster...
Setting up certs...
Starting cluster components...
Connecting to cluster...
Setting up kubeconfig...
Kubectl is now configured to use the cluster.
```

```
KUBE_CTX_AUTH_INFO=minikube KUBE_CTX_CLUSTER=minikube make testacc TEST=./kubernetes
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./kubernetes -v  -timeout 120m
=== RUN   TestAccKubernetesDataSourceService_basic
--- PASS: TestAccKubernetesDataSourceService_basic (0.37s)
=== RUN   TestAccKubernetesDataSourceStorageClass_basic
--- PASS: TestAccKubernetesDataSourceStorageClass_basic (0.21s)
=== RUN   TestDiffStringMap
=== RUN   TestDiffStringMap/0
=== RUN   TestDiffStringMap/1
=== RUN   TestDiffStringMap/2
=== RUN   TestDiffStringMap/3
=== RUN   TestDiffStringMap/4
=== RUN   TestDiffStringMap/5
=== RUN   TestDiffStringMap/6
--- PASS: TestDiffStringMap (0.00s)
    --- PASS: TestDiffStringMap/0 (0.00s)
    --- PASS: TestDiffStringMap/1 (0.00s)
    --- PASS: TestDiffStringMap/2 (0.00s)
    --- PASS: TestDiffStringMap/3 (0.00s)
    --- PASS: TestDiffStringMap/4 (0.00s)
    --- PASS: TestDiffStringMap/5 (0.00s)
    --- PASS: TestDiffStringMap/6 (0.00s)
=== RUN   TestEscapeJsonPointer
--- PASS: TestEscapeJsonPointer (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.01s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestProvider_configure
--- PASS: TestProvider_configure (0.00s)
=== RUN   TestAccKubernetesConfigMap_basic
--- PASS: TestAccKubernetesConfigMap_basic (0.41s)
=== RUN   TestAccKubernetesConfigMap_importBasic
--- PASS: TestAccKubernetesConfigMap_importBasic (0.16s)
=== RUN   TestAccKubernetesConfigMap_generatedName
--- PASS: TestAccKubernetesConfigMap_generatedName (0.14s)
=== RUN   TestAccKubernetesConfigMap_importGeneratedName
--- PASS: TestAccKubernetesConfigMap_importGeneratedName (0.09s)
=== RUN   TestAccKubernetesHorizontalPodAutoscaler_basic
--- PASS: TestAccKubernetesHorizontalPodAutoscaler_basic (0.20s)
=== RUN   TestAccKubernetesHorizontalPodAutoscaler_generatedName
--- PASS: TestAccKubernetesHorizontalPodAutoscaler_generatedName (0.09s)
=== RUN   TestAccKubernetesHorizontalPodAutoscaler_importBasic
--- PASS: TestAccKubernetesHorizontalPodAutoscaler_importBasic (0.11s)
=== RUN   TestAccKubernetesLimitRange_basic
--- PASS: TestAccKubernetesLimitRange_basic (0.20s)
=== RUN   TestAccKubernetesLimitRange_generatedName
--- PASS: TestAccKubernetesLimitRange_generatedName (0.08s)
=== RUN   TestAccKubernetesLimitRange_typeChange
--- PASS: TestAccKubernetesLimitRange_typeChange (0.15s)
=== RUN   TestAccKubernetesLimitRange_multipleLimits
--- PASS: TestAccKubernetesLimitRange_multipleLimits (0.09s)
=== RUN   TestAccKubernetesLimitRange_importBasic
--- PASS: TestAccKubernetesLimitRange_importBasic (0.10s)
=== RUN   TestAccKubernetesNamespace_basic
--- PASS: TestAccKubernetesNamespace_basic (6.47s)
=== RUN   TestAccKubernetesNamespace_importBasic
--- PASS: TestAccKubernetesNamespace_importBasic (6.36s)
=== RUN   TestAccKubernetesNamespace_generatedName
--- PASS: TestAccKubernetesNamespace_generatedName (6.35s)
=== RUN   TestAccKubernetesNamespace_withSpecialCharacters
--- PASS: TestAccKubernetesNamespace_withSpecialCharacters (6.34s)
=== RUN   TestAccKubernetesNamespace_importGeneratedName
--- PASS: TestAccKubernetesNamespace_importGeneratedName (6.35s)
=== RUN   TestAccKubernetesPersistentVolumeClaim_basic
--- PASS: TestAccKubernetesPersistentVolumeClaim_basic (0.66s)
=== RUN   TestAccKubernetesPersistentVolumeClaim_googleCloud_importBasic
--- SKIP: TestAccKubernetesPersistentVolumeClaim_googleCloud_importBasic (0.00s)
	provider_test.go:178: The environment variables GOOGLE_PROJECT, GOOGLE_REGION and GOOGLE_ZONE must be set to run Google Cloud tests - skipping
=== RUN   TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch
--- SKIP: TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch (0.00s)
	provider_test.go:178: The environment variables GOOGLE_PROJECT, GOOGLE_REGION and GOOGLE_ZONE must be set to run Google Cloud tests - skipping
=== RUN   TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeUpdate
--- SKIP: TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeUpdate (0.00s)
	provider_test.go:178: The environment variables GOOGLE_PROJECT, GOOGLE_REGION and GOOGLE_ZONE must be set to run Google Cloud tests - skipping
=== RUN   TestAccKubernetesPersistentVolumeClaim_googleCloud_storageClass
--- SKIP: TestAccKubernetesPersistentVolumeClaim_googleCloud_storageClass (0.00s)
	provider_test.go:178: The environment variables GOOGLE_PROJECT, GOOGLE_REGION and GOOGLE_ZONE must be set to run Google Cloud tests - skipping
=== RUN   TestAccKubernetesPersistentVolume_googleCloud_basic
--- SKIP: TestAccKubernetesPersistentVolume_googleCloud_basic (0.00s)
	provider_test.go:178: The environment variables GOOGLE_PROJECT, GOOGLE_REGION and GOOGLE_ZONE must be set to run Google Cloud tests - skipping
=== RUN   TestAccKubernetesPersistentVolume_googleCloud_importBasic
--- SKIP: TestAccKubernetesPersistentVolume_googleCloud_importBasic (0.00s)
	provider_test.go:178: The environment variables GOOGLE_PROJECT, GOOGLE_REGION and GOOGLE_ZONE must be set to run Google Cloud tests - skipping
=== RUN   TestAccKubernetesPersistentVolume_googleCloud_volumeSource
--- SKIP: TestAccKubernetesPersistentVolume_googleCloud_volumeSource (0.00s)
	provider_test.go:178: The environment variables GOOGLE_PROJECT, GOOGLE_REGION and GOOGLE_ZONE must be set to run Google Cloud tests - skipping
=== RUN   TestAccKubernetesPersistentVolume_cephFsSecretRef
--- PASS: TestAccKubernetesPersistentVolume_cephFsSecretRef (0.45s)
=== RUN   TestAccKubernetesPod_basic
--- PASS: TestAccKubernetesPod_basic (17.25s)
=== RUN   TestAccKubernetesPod_updateForceNew
--- PASS: TestAccKubernetesPod_updateForceNew (83.75s)
=== RUN   TestAccKubernetesPod_importBasic
--- PASS: TestAccKubernetesPod_importBasic (2.25s)
=== RUN   TestAccKubernetesPod_with_pod_security_context
--- PASS: TestAccKubernetesPod_with_pod_security_context (6.67s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_exec
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_exec (38.69s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_http_get
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_http_get (18.77s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_tcp
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_tcp (18.66s)
=== RUN   TestAccKubernetesPod_with_container_lifecycle
--- PASS: TestAccKubernetesPod_with_container_lifecycle (6.68s)
=== RUN   TestAccKubernetesPod_with_container_security_context
--- PASS: TestAccKubernetesPod_with_container_security_context (5.49s)
=== RUN   TestAccKubernetesPod_with_volume_mount
--- PASS: TestAccKubernetesPod_with_volume_mount (17.11s)
=== RUN   TestAccKubernetesPod_with_cfg_map_volume_mount
--- PASS: TestAccKubernetesPod_with_cfg_map_volume_mount (5.12s)
=== RUN   TestAccKubernetesPod_with_resource_requirements
--- PASS: TestAccKubernetesPod_with_resource_requirements (17.08s)
=== RUN   TestAccKubernetesPod_with_empty_dir_volume
--- PASS: TestAccKubernetesPod_with_empty_dir_volume (5.12s)
=== RUN   TestAccKubernetesPod_with_secret_vol_items
--- PASS: TestAccKubernetesPod_with_secret_vol_items (9.14s)
=== RUN   TestAccKubernetesPod_gke_with_nodeSelector
--- SKIP: TestAccKubernetesPod_gke_with_nodeSelector (0.00s)
	provider_test.go:201: The Kuberenetes endpoint must come from GKE for this test to run - skipping
=== RUN   TestAccKubernetesReplicationController_basic
--- PASS: TestAccKubernetesReplicationController_basic (262.25s)
=== RUN   TestAccKubernetesReplicationController_importBasic
--- PASS: TestAccKubernetesReplicationController_importBasic (258.79s)
=== RUN   TestAccKubernetesReplicationController_generatedName
--- PASS: TestAccKubernetesReplicationController_generatedName (7.47s)
=== RUN   TestAccKubernetesReplicationController_importGeneratedName
--- PASS: TestAccKubernetesReplicationController_importGeneratedName (2.31s)
=== RUN   TestAccKubernetesReplicationController_with_security_context
--- PASS: TestAccKubernetesReplicationController_with_security_context (1.72s)
=== RUN   TestAccKubernetesReplicationController_with_container_liveness_probe_using_exec
--- PASS: TestAccKubernetesReplicationController_with_container_liveness_probe_using_exec (1.76s)
=== RUN   TestAccKubernetesReplicationController_with_container_liveness_probe_using_http_get
--- PASS: TestAccKubernetesReplicationController_with_container_liveness_probe_using_http_get (1.67s)
=== RUN   TestAccKubernetesReplicationController_with_container_liveness_probe_using_tcp
--- PASS: TestAccKubernetesReplicationController_with_container_liveness_probe_using_tcp (1.62s)
=== RUN   TestAccKubernetesReplicationController_with_container_lifecycle
--- PASS: TestAccKubernetesReplicationController_with_container_lifecycle (6.88s)
=== RUN   TestAccKubernetesReplicationController_with_container_security_context
--- PASS: TestAccKubernetesReplicationController_with_container_security_context (1.38s)
=== RUN   TestAccKubernetesReplicationController_with_volume_mount
--- PASS: TestAccKubernetesReplicationController_with_volume_mount (6.98s)
=== RUN   TestAccKubernetesReplicationController_with_resource_requirements
--- PASS: TestAccKubernetesReplicationController_with_resource_requirements (1.53s)
=== RUN   TestAccKubernetesReplicationController_with_empty_dir_volume
--- PASS: TestAccKubernetesReplicationController_with_empty_dir_volume (1.33s)
=== RUN   TestAccKubernetesResourceQuota_basic
--- PASS: TestAccKubernetesResourceQuota_basic (2.85s)
=== RUN   TestAccKubernetesResourceQuota_generatedName
--- PASS: TestAccKubernetesResourceQuota_generatedName (0.76s)
=== RUN   TestAccKubernetesResourceQuota_withScopes
--- PASS: TestAccKubernetesResourceQuota_withScopes (1.88s)
=== RUN   TestAccKubernetesResourceQuota_importBasic
--- PASS: TestAccKubernetesResourceQuota_importBasic (0.85s)
=== RUN   TestAccKubernetesSecret_basic
--- PASS: TestAccKubernetesSecret_basic (0.60s)
=== RUN   TestAccKubernetesSecret_importBasic
--- PASS: TestAccKubernetesSecret_importBasic (0.17s)
=== RUN   TestAccKubernetesSecret_generatedName
--- PASS: TestAccKubernetesSecret_generatedName (0.17s)
=== RUN   TestAccKubernetesSecret_importGeneratedName
--- PASS: TestAccKubernetesSecret_importGeneratedName (0.12s)
=== RUN   TestAccKubernetesServiceAccount_basic
--- PASS: TestAccKubernetesServiceAccount_basic (1.41s)
=== RUN   TestAccKubernetesServiceAccount_update
--- PASS: TestAccKubernetesServiceAccount_update (3.97s)
=== RUN   TestAccKubernetesServiceAccount_generatedName
--- PASS: TestAccKubernetesServiceAccount_generatedName (5.31s)
=== RUN   TestAccKubernetesService_basic
--- PASS: TestAccKubernetesService_basic (2.19s)
=== RUN   TestAccKubernetesService_loadBalancer
--- SKIP: TestAccKubernetesService_loadBalancer (0.20s)
	provider_test.go:190: The Kuberenetes endpoint must come from an environment which supports load balancer provisioning for this test to run - skipping
=== RUN   TestAccKubernetesService_nodePort
--- PASS: TestAccKubernetesService_nodePort (2.29s)
=== RUN   TestAccKubernetesService_externalName
--- PASS: TestAccKubernetesService_externalName (0.28s)
=== RUN   TestAccKubernetesService_importBasic
--- PASS: TestAccKubernetesService_importBasic (0.29s)
=== RUN   TestAccKubernetesService_generatedName
--- PASS: TestAccKubernetesService_generatedName (0.30s)
=== RUN   TestAccKubernetesService_importGeneratedName
--- PASS: TestAccKubernetesService_importGeneratedName (0.25s)
=== RUN   TestAccKubernetesStorageClass_basic
--- PASS: TestAccKubernetesStorageClass_basic (0.67s)
=== RUN   TestAccKubernetesStorageClass_importBasic
--- PASS: TestAccKubernetesStorageClass_importBasic (0.18s)
=== RUN   TestAccKubernetesStorageClass_generatedName
--- PASS: TestAccKubernetesStorageClass_generatedName (0.15s)
=== RUN   TestAccKubernetesStorageClass_importGeneratedName
--- PASS: TestAccKubernetesStorageClass_importGeneratedName (0.15s)
=== RUN   TestFlattenLabelSelector
--- PASS: TestFlattenLabelSelector (0.00s)
=== RUN   TestIsInternalKey
=== RUN   TestIsInternalKey/0
=== RUN   TestIsInternalKey/1
=== RUN   TestIsInternalKey/2
=== RUN   TestIsInternalKey/3
=== RUN   TestIsInternalKey/4
=== RUN   TestIsInternalKey/5
=== RUN   TestIsInternalKey/6
--- PASS: TestIsInternalKey (0.00s)
    --- PASS: TestIsInternalKey/0 (0.00s)
    --- PASS: TestIsInternalKey/1 (0.00s)
    --- PASS: TestIsInternalKey/2 (0.00s)
    --- PASS: TestIsInternalKey/3 (0.00s)
    --- PASS: TestIsInternalKey/4 (0.00s)
    --- PASS: TestIsInternalKey/5 (0.00s)
    --- PASS: TestIsInternalKey/6 (0.00s)
=== RUN   TestValidateModeBits
--- PASS: TestValidateModeBits (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	867.964s
```