### PR TITLE
acc-tests: Fix faulty detection of environment

### DIFF
--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -171,6 +171,11 @@ func testAccPreCheck(t *testing.T) {
 				"KUBE_CLUSTER_CA_CERT_DATA",
 			}, ", "))
 	}
+
+	err := testAccProvider.Configure(terraform.NewResourceConfig(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func skipIfNoGoogleCloudSettingsFound(t *testing.T) {
@@ -184,7 +189,7 @@ func skipIfNoLoadBalancersAvailable(t *testing.T) {
 	// TODO: Support AWS ELBs
 	isInGke, err := isRunningInGke()
 	if err != nil {
-		t.Skip(err)
+		t.Fatal(err)
 	}
 	if !isInGke {
 		t.Skip("The Kubernetes endpoint must come from an environment which supports " +
@@ -195,7 +200,7 @@ func skipIfNoLoadBalancersAvailable(t *testing.T) {
 func skipIfNotRunningInGke(t *testing.T) {
 	isInGke, err := isRunningInGke()
 	if err != nil {
-		t.Skip(err)
+		t.Fatal(err)
 	}
 	if !isInGke {
 		t.Skip("The Kubernetes endpoint must come from GKE for this test to run - skipping")
@@ -221,8 +226,8 @@ func isRunningInGke() (bool, error) {
 		return false, err
 	}
 
-	annotations := node.GetAnnotations()
-	if _, ok := annotations["cloud.google.com/gke-nodepool"]; ok {
+	labels := node.GetLabels()
+	if _, ok := labels["cloud.google.com/gke-nodepool"]; ok {
 		return true, nil
 	}
 	return false, nil

--- a/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
@@ -130,8 +130,6 @@ func TestAccKubernetesPersistentVolumeClaim_basic(t *testing.T) {
 }
 
 func TestAccKubernetesPersistentVolumeClaim_googleCloud_importBasic(t *testing.T) {
-	skipIfNoGoogleCloudSettingsFound(t)
-
 	resourceName := "kubernetes_persistent_volume_claim.test"
 	volumeName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(10))
 	claimName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(10))
@@ -139,7 +137,7 @@ func TestAccKubernetesPersistentVolumeClaim_googleCloud_importBasic(t *testing.T
 	zone := os.Getenv("GOOGLE_ZONE")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); skipIfNoGoogleCloudSettingsFound(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKubernetesPersistentVolumeClaimDestroy,
 		Steps: []resource.TestStep{
@@ -156,8 +154,6 @@ func TestAccKubernetesPersistentVolumeClaim_googleCloud_importBasic(t *testing.T
 }
 
 func TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch(t *testing.T) {
-	skipIfNoGoogleCloudSettingsFound(t)
-
 	var pvcConf api.PersistentVolumeClaim
 	var pvConf api.PersistentVolume
 
@@ -168,7 +164,7 @@ func TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch(t *testing.T
 	zone := os.Getenv("GOOGLE_ZONE")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); skipIfNoGoogleCloudSettingsFound(t) },
 		IDRefreshName: "kubernetes_persistent_volume_claim.test",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckKubernetesPersistentVolumeClaimDestroy,
@@ -308,8 +304,6 @@ func TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch(t *testing.T
 // }
 
 func TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeUpdate(t *testing.T) {
-	skipIfNoGoogleCloudSettingsFound(t)
-
 	var pvcConf api.PersistentVolumeClaim
 	var pvConf api.PersistentVolume
 
@@ -319,7 +313,7 @@ func TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeUpdate(t *testing.
 	zone := os.Getenv("GOOGLE_ZONE")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); skipIfNoGoogleCloudSettingsFound(t) },
 		IDRefreshName: "kubernetes_persistent_volume_claim.test",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckKubernetesPersistentVolumeClaimDestroy,
@@ -377,8 +371,6 @@ func TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeUpdate(t *testing.
 }
 
 func TestAccKubernetesPersistentVolumeClaim_googleCloud_storageClass(t *testing.T) {
-	skipIfNoGoogleCloudSettingsFound(t)
-
 	var pvcConf api.PersistentVolumeClaim
 	var storageClass storageapi.StorageClass
 	var secondStorageClass storageapi.StorageClass
@@ -387,7 +379,7 @@ func TestAccKubernetesPersistentVolumeClaim_googleCloud_storageClass(t *testing.
 	claimName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); skipIfNoGoogleCloudSettingsFound(t) },
 		IDRefreshName: "kubernetes_persistent_volume_claim.test",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckKubernetesPersistentVolumeClaimDestroy,

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestAccKubernetesPersistentVolume_googleCloud_basic(t *testing.T) {
-	skipIfNoGoogleCloudSettingsFound(t)
-
 	var conf api.PersistentVolume
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	name := fmt.Sprintf("tf-acc-test-%s", randString)
@@ -25,7 +23,7 @@ func TestAccKubernetesPersistentVolume_googleCloud_basic(t *testing.T) {
 	zone := os.Getenv("GOOGLE_ZONE")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); skipIfNoGoogleCloudSettingsFound(t) },
 		IDRefreshName: "kubernetes_persistent_volume.test",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckKubernetesPersistentVolumeDestroy,
@@ -102,8 +100,6 @@ func TestAccKubernetesPersistentVolume_googleCloud_basic(t *testing.T) {
 }
 
 func TestAccKubernetesPersistentVolume_googleCloud_importBasic(t *testing.T) {
-	skipIfNoGoogleCloudSettingsFound(t)
-
 	resourceName := "kubernetes_persistent_volume.test"
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	name := fmt.Sprintf("tf-acc-test-import-%s", randString)
@@ -112,7 +108,7 @@ func TestAccKubernetesPersistentVolume_googleCloud_importBasic(t *testing.T) {
 	zone := os.Getenv("GOOGLE_ZONE")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); skipIfNoGoogleCloudSettingsFound(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKubernetesPersistentVolumeDestroy,
 		Steps: []resource.TestStep{
@@ -129,8 +125,6 @@ func TestAccKubernetesPersistentVolume_googleCloud_importBasic(t *testing.T) {
 }
 
 func TestAccKubernetesPersistentVolume_googleCloud_volumeSource(t *testing.T) {
-	skipIfNoGoogleCloudSettingsFound(t)
-
 	var conf api.PersistentVolume
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	name := fmt.Sprintf("tf-acc-test-%s", randString)
@@ -140,7 +134,7 @@ func TestAccKubernetesPersistentVolume_googleCloud_volumeSource(t *testing.T) {
 	zone := os.Getenv("GOOGLE_ZONE")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); skipIfNoGoogleCloudSettingsFound(t) },
 		IDRefreshName: "kubernetes_persistent_volume.test",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckKubernetesPersistentVolumeDestroy,

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -443,8 +443,6 @@ func TestAccKubernetesPod_with_secret_vol_items(t *testing.T) {
 }
 
 func TestAccKubernetesPod_gke_with_nodeSelector(t *testing.T) {
-	skipIfNotRunningInGke(t)
-
 	var conf api.Pod
 
 	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
@@ -452,7 +450,7 @@ func TestAccKubernetesPod_gke_with_nodeSelector(t *testing.T) {
 	region := os.Getenv("GOOGLE_REGION")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); skipIfNotRunningInGke(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKubernetesPodDestroy,
 		Steps: []resource.TestStep{

--- a/kubernetes/resource_kubernetes_service_test.go
+++ b/kubernetes/resource_kubernetes_service_test.go
@@ -86,13 +86,11 @@ func TestAccKubernetesService_basic(t *testing.T) {
 }
 
 func TestAccKubernetesService_loadBalancer(t *testing.T) {
-	skipIfNoLoadBalancersAvailable(t)
-
 	var conf api.Service
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); skipIfNoLoadBalancersAvailable(t) },
 		IDRefreshName: "kubernetes_service.test",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckKubernetesServiceDestroy,


### PR DESCRIPTION
Lifecycle issues ... 🤷‍♂️ 

Without this fix we'd never run the skipped tests, because the check is being performed too early, when the provider isn't configured yet.