### PR TITLE
Fix mode conversion with config_map volume items

### DIFF
--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -897,6 +897,31 @@ resource "kubernetes_pod" "test" {
         default_mode = 0777
       }
     }
+
+    volume {
+      name = "cfg-item"
+      config_map {
+        name = "${kubernetes_config_map.test.metadata.0.name}"
+
+        items {
+          key  = "one"
+          path = "one.txt"
+        }
+      }
+    }
+
+    volume {
+      name = "cfg-item-with-mode"
+      config_map {
+        name = "${kubernetes_config_map.test.metadata.0.name}"
+
+        items {
+          key  = "one"
+          path = "one-with-mode.txt"
+          mode = "0444"
+        }
+      }
+    }
   }
 }
 	`, secretName, podName, imageName)

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -261,7 +261,7 @@ func flattenConfigMapVolumeSource(in *v1.ConfigMapVolumeSource) []interface{} {
 		for i, v := range in.Items {
 			m := map[string]interface{}{}
 			m["key"] = v.Key
-			m["mode"] = v.Mode
+			m["mode"] = *v.Mode
 			m["path"] = v.Path
 			items[i] = m
 		}


### PR DESCRIPTION
I added a test case that reveals an issue with config_map volume items mode:

```
make testacc TEST=./kubernetes/ TESTARGS='-run=TestAccKubernetesPod_with_cfg_map_volume_mount'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./kubernetes/ -v -run=TestAccKubernetesPod_with_cfg_map_volume_mount -timeout 120m
=== RUN   TestAccKubernetesPod_with_cfg_map_volume_mount
--- FAIL: TestAccKubernetesPod_with_cfg_map_volume_mount (3.17s)testing.go:449: Step 0 error: Error applying: 1 error(s) occurred:
                * kubernetes_pod.test: 1 error(s) occurred:

                * kubernetes_pod.test: spec.0.volume.1.config_map.0.items.0.mode: '' expected type 'int', got unconvertible type '*int32'
        testing.go:509: Error destroying resource! WARNING: Dangling resources
                may exist. The full state and error is shown below.

                Error: Error refreshing: 1 error(s) occurred:
* kubernetes_pod.test: 1 error(s) occurred:

                * kubernetes_pod.test: kubernetes_pod.test: spec.0.volume.1.config_map.0.items.0.mode: '' expected type 'int', got unconvertible type '*int32'

                State: <nil>
FAIL
exit status 1
FAIL    github.com/terraform-providers/terraform-provider-kubernetes/kubernetes 3.330s
GNUmakefile:15: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```