### PR TITLE
resource/kubernetes_persistent_volume: Add support for storage_class_name

### DIFF
--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -60,6 +60,11 @@ func resourceKubernetesPersistentVolume() *schema.Resource {
 							MaxItems:    1,
 							Elem:        persistentVolumeSourceSchema(),
 						},
+						"storage_class_name": {
+							Type:        schema.TypeString,
+							Description: "A description of the persistent volume's class. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class",
+							Optional:    true,
+						},
 					},
 				},
 			},

--- a/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
@@ -594,6 +594,7 @@ resource "kubernetes_persistent_volume" "test" {
 			storage = "10Gi"
 		}
 		access_modes = ["ReadWriteOnce"]
+		storage_class_name = "standard"
 		persistent_volume_source {
 			gce_persistent_disk {
 				pd_name = "${google_compute_disk.test.name}"
@@ -616,6 +617,7 @@ resource "kubernetes_persistent_volume_claim" "test" {
 	}
 	spec {
 		access_modes = ["ReadWriteOnce"]
+		storage_class_name = "standard"
 		resources {
 			requests {
 				storage = "5Gi"
@@ -638,6 +640,7 @@ resource "kubernetes_persistent_volume" "test" {
 			storage = "10Gi"
 		}
 		access_modes = ["ReadWriteOnce"]
+		storage_class_name = "standard"
 		persistent_volume_source {
 			gce_persistent_disk {
 				pd_name = "${google_compute_disk.test.name}"
@@ -660,6 +663,7 @@ resource "kubernetes_persistent_volume_claim" "test" {
 	}
 	spec {
 		access_modes = ["ReadWriteOnce"]
+		storage_class_name = "standard"
 		resources {
 			requests {
 				storage = "5Gi"
@@ -682,6 +686,7 @@ resource "kubernetes_persistent_volume" "test2" {
 			storage = "10Gi"
 		}
 		access_modes = ["ReadWriteOnce"]
+		storage_class_name = "standard"
 		persistent_volume_source {
 			gce_persistent_disk {
 				pd_name = "${google_compute_disk.test.name}"
@@ -704,6 +709,7 @@ resource "kubernetes_persistent_volume_claim" "test" {
 	}
 	spec {
 		access_modes = ["ReadWriteOnce"]
+		storage_class_name = "standard"
 		resources {
 			requests {
 				storage = "5Gi"
@@ -814,6 +820,7 @@ resource "kubernetes_persistent_volume" "test" {
 			storage = "%s"
 		}
 		access_modes = ["ReadWriteOnce"]
+		storage_class_name = "standard"
 		persistent_volume_source {
 			gce_persistent_disk {
 				pd_name = "${google_compute_disk.test.name}"
@@ -836,6 +843,7 @@ resource "kubernetes_persistent_volume_claim" "test" {
 	}
 	spec {
 		access_modes = ["ReadWriteOnce"]
+		storage_class_name = "standard"
 		resources {
 			requests {
 				storage = "5Gi"

--- a/kubernetes/structure_persistent_volume_spec.go
+++ b/kubernetes/structure_persistent_volume_spec.go
@@ -259,6 +259,9 @@ func flattenPersistentVolumeSpec(in v1.PersistentVolumeSpec) []interface{} {
 	if in.PersistentVolumeReclaimPolicy != "" {
 		att["persistent_volume_reclaim_policy"] = in.PersistentVolumeReclaimPolicy
 	}
+	if in.StorageClassName != "" {
+		att["storage_class_name"] = in.StorageClassName
+	}
 	return []interface{}{att}
 }
 
@@ -653,6 +656,9 @@ func expandPersistentVolumeSpec(l []interface{}) (v1.PersistentVolumeSpec, error
 	if v, ok := in["persistent_volume_reclaim_policy"].(string); ok {
 		obj.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimPolicy(v)
 	}
+	if v, ok := in["storage_class_name"].(string); ok {
+		obj.StorageClassName = v
+	}
 	return obj, nil
 }
 
@@ -766,12 +772,26 @@ func patchPersistentVolumeSpec(pathPrefix, prefix string, d *schema.ResourceData
 			Value: expandPersistentVolumeAccessModes(v.List()),
 		})
 	}
-	if d.HasChange(prefix + "access_modes") {
+	if d.HasChange(prefix + "persistent_volume_reclaim_policy") {
 		v := d.Get(prefix + "persistent_volume_reclaim_policy").(string)
 		ops = append(ops, &ReplaceOperation{
 			Path:  pathPrefix + "/persistentVolumeReclaimPolicy",
 			Value: v1.PersistentVolumeReclaimPolicy(v),
 		})
+	}
+	if d.HasChange(prefix + "storage_class_name") {
+		o, n := d.GetChange(prefix + "storage_class_name")
+		if v, ok := o.(string); ok && len(v) > 0 {
+			ops = append(ops, &ReplaceOperation{
+				Path:  pathPrefix + "/storageClassName",
+				Value: n.(string),
+			})
+		} else {
+			ops = append(ops, &AddOperation{
+				Path:  pathPrefix + "/storageClassName",
+				Value: n.(string),
+			})
+		}
 	}
 
 	return ops, nil

--- a/website/docs/r/persistent_volume.html.markdown
+++ b/website/docs/r/persistent_volume.html.markdown
@@ -50,6 +50,7 @@ The following arguments are supported:
 * `capacity` - (Required) A description of the persistent volume's resources and capacity. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#capacity
 * `persistent_volume_reclaim_policy` - (Optional) What happens to a persistent volume when released from its claim. Valid options are Retain (default) and Recycle. Recycling must be supported by the volume plugin underlying this persistent volume. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#recycling-policy
 * `persistent_volume_source` - (Required) The specification of a persistent volume.
+* `storage_class_name` - (Optional) The name of the persistent volume's storage class. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class
 
 ### `persistent_volume_source`
 


### PR DESCRIPTION
It is basically a partial rebase of #72 plus a few additional fixes to make it actually work.

I have tested it against minikube by creating PVs with the source `host_path`, which is the simplest setup I could produce locally without hitting the cloud.

The testing revealed that creating a PV _without_ a storage class and then amending it to the one _with_ a storage class did not work because Kubernetes sent back a JSON without `/spec/storageClassName` path in it. That resulted in:
```
Error: Error applying plan:
1 error(s) occurred:
* kubernetes_persistent_volume.example: 1 error(s) occurred:
* kubernetes_persistent_volume.example: jsonpatch replace operation does not apply: doc is missing key: /spec/storageClassName
```

I had to tweak `patchPersistentVolumeSpec` a bit to produce either `add` or `replace` operation, which worked a treat in the end: I could add, change or remove storage class in the terraform manifest, and kubernetes applied the changes to the persistent volume.
I am not very experienced in Go, and there may be a more elegant way of doing what I've done,
so please feel free to correct me here.

Closes #72 