### PR TITLE
test-infra: Expose google_zone from kops @ GCE

### DIFF
--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -43,7 +43,7 @@ resource "google_container_cluster" "primary" {
   }
 }
 
-output "zone" {
+output "google_zone" {
   value = "${data.google_compute_zones.available.names[0]}"
 }
 

--- a/kubernetes/test-infra/kops-on-gce/main.tf
+++ b/kubernetes/test-infra/kops-on-gce/main.tf
@@ -62,3 +62,7 @@ EOF
 output "cluster_name" {
   value = "${local.cluster_name}"
 }
+
+output "google_zone" {
+  value = "${data.google_compute_zones.available.names[0]}"
+}


### PR DESCRIPTION
This is to unify the output name and to allow setting the zone dynamically in kops jobs.