### PR TITLE
tests: Ignore internal k8s annotations+labels

### DIFF
--- a/kubernetes/resource_kubernetes_namespace_test.go
+++ b/kubernetes/resource_kubernetes_namespace_test.go
@@ -200,7 +200,17 @@ func testAccCheckMetaAnnotations(om *meta_v1.ObjectMeta, expected map[string]str
 		if len(expected) == 0 && len(om.Annotations) == 0 {
 			return nil
 		}
-		if !reflect.DeepEqual(om.Annotations, expected) {
+
+		// Remove any internal k8s annotations unless we expect them
+		annotations := om.Annotations
+		for key, _ := range annotations {
+			_, isExpected := expected[key]
+			if isInternalKey(key) && !isExpected {
+				delete(annotations, key)
+			}
+		}
+
+		if !reflect.DeepEqual(annotations, expected) {
 			return fmt.Errorf("%s annotations don't match.\nExpected: %q\nGiven: %q",
 				om.Name, expected, om.Annotations)
 		}
@@ -213,7 +223,17 @@ func testAccCheckMetaLabels(om *meta_v1.ObjectMeta, expected map[string]string) 
 		if len(expected) == 0 && len(om.Labels) == 0 {
 			return nil
 		}
-		if !reflect.DeepEqual(om.Labels, expected) {
+
+		// Remove any internal k8s labels unless we expect them
+		labels := om.Labels
+		for key, _ := range labels {
+			_, isExpected := expected[key]
+			if isInternalKey(key) && !isExpected {
+				delete(labels, key)
+			}
+		}
+
+		if !reflect.DeepEqual(labels, expected) {
 			return fmt.Errorf("%s labels don't match.\nExpected: %q\nGiven: %q",
 				om.Name, expected, om.Labels)
 		}


### PR DESCRIPTION
This is to address the following intermittent test failures:

```
TestAccKubernetesPersistentVolumeClaim_basic
 testing.go:449: Step 2 error: Check failed: 1 error(s) occurred:
	
	* Check 1/1 error: tf-acc-test-njyphktx1p annotations don't match.
	Expected: map["TestAnnotationOne":"one" "volume.beta.kubernetes.io/storage-provisioner":"k8s.io/minikube-hostpath"]
	Given: map["TestAnnotationOne":"one" "control-plane.alpha.kubernetes.io/leader":"{\"holderIdentity\":\"90e7fb17-18ad-11e8-bb9b-080027a46414\",\"leaseDurationSeconds\":15,\"acquireTime\":\"2018-02-23T15:25:58Z\",\"renewTime\":\"2018-02-23T15:25:58Z\",\"leaderTransitions\":1}" "pv.kubernetes.io/bind-completed":"yes" "pv.kubernetes.io/bound-by-controller":"yes" "volume.beta.kubernetes.io/storage-provisioner":"k8s.io/minikube-hostpath"]

```