### PR TITLE
tests: Ignore resource_version in import tests

### DIFF
--- a/kubernetes/resource_kubernetes_config_map_test.go
+++ b/kubernetes/resource_kubernetes_config_map_test.go
@@ -107,9 +107,10 @@ func TestAccKubernetesConfigMap_importBasic(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
 			},
 		},
 	})

--- a/kubernetes/resource_kubernetes_limit_range_test.go
+++ b/kubernetes/resource_kubernetes_limit_range_test.go
@@ -248,9 +248,10 @@ func TestAccKubernetesLimitRange_importBasic(t *testing.T) {
 				Config: testAccKubernetesLimitRangeConfig_basic(name),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
 			},
 		},
 	})

--- a/kubernetes/resource_kubernetes_namespace_test.go
+++ b/kubernetes/resource_kubernetes_namespace_test.go
@@ -96,9 +96,10 @@ func TestAccKubernetesNamespace_importBasic(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
 			},
 		},
 	})
@@ -187,9 +188,10 @@ func TestAccKubernetesNamespace_importGeneratedName(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
 			},
 		},
 	})

--- a/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
@@ -145,9 +145,10 @@ func TestAccKubernetesPersistentVolumeClaim_googleCloud_importBasic(t *testing.T
 				Config: testAccKubernetesPersistentVolumeClaimConfig_import(volumeName, claimName, diskName, zone),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
 			},
 		},
 	})

--- a/kubernetes/resource_kubernetes_replication_controller_test.go
+++ b/kubernetes/resource_kubernetes_replication_controller_test.go
@@ -83,9 +83,10 @@ func TestAccKubernetesReplicationController_importBasic(t *testing.T) {
 				Config: testAccKubernetesReplicationControllerConfig_basic(name),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
 			},
 		},
 	})
@@ -134,9 +135,10 @@ func TestAccKubernetesReplicationController_importGeneratedName(t *testing.T) {
 				Config: testAccKubernetesReplicationControllerConfig_generatedName(prefix),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
 			},
 		},
 	})

--- a/kubernetes/resource_kubernetes_resource_quota_test.go
+++ b/kubernetes/resource_kubernetes_resource_quota_test.go
@@ -190,9 +190,10 @@ func TestAccKubernetesResourceQuota_importBasic(t *testing.T) {
 				Config: testAccKubernetesResourceQuotaConfig_basic(name),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
 			},
 		},
 	})

--- a/kubernetes/resource_kubernetes_secret_test.go
+++ b/kubernetes/resource_kubernetes_secret_test.go
@@ -129,9 +129,10 @@ func TestAccKubernetesSecret_importBasic(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
 			},
 		},
 	})
@@ -181,9 +182,10 @@ func TestAccKubernetesSecret_importGeneratedName(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
 			},
 		},
 	})

--- a/kubernetes/resource_kubernetes_service_test.go
+++ b/kubernetes/resource_kubernetes_service_test.go
@@ -320,9 +320,10 @@ func TestAccKubernetesService_importBasic(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
 			},
 		},
 	})
@@ -372,9 +373,10 @@ func TestAccKubernetesService_importGeneratedName(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
 			},
 		},
 	})

--- a/kubernetes/resource_kubernetes_storage_class_test.go
+++ b/kubernetes/resource_kubernetes_storage_class_test.go
@@ -108,9 +108,10 @@ func TestAccKubernetesStorageClass_importBasic(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
 			},
 		},
 	})
@@ -160,9 +161,10 @@ func TestAccKubernetesStorageClass_importGeneratedName(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
 			},
 		},
 	})


### PR DESCRIPTION
This is to address the following intermittent failures:

```
TestAccKubernetesResourceQuota_importBasic
testing.go:449: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
    
    (map[string]string) (len=1) {
     (string) (len=27) "metadata.0.resource_version": (string) (len=5) "17422"
    }
    
    
    (map[string]string) (len=1) {
     (string) (len=27) "metadata.0.resource_version": (string) (len=5) "17417"
    }
```