### PR TITLE
tests: Fix wrong access_modes for PVC

### DIFF
--- a/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
@@ -41,7 +41,7 @@ func TestAccKubernetesPersistentVolumeClaim_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1254135962", "ReadWriteMany"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.%", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.storage", "5Gi"),
@@ -91,7 +91,7 @@ func TestAccKubernetesPersistentVolumeClaim_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1254135962", "ReadWriteMany"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.%", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.storage", "5Gi"),
@@ -184,7 +184,7 @@ func TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch(t *testing.T
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1254135962", "ReadWriteMany"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.%", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.storage", "5Gi"),
@@ -207,7 +207,7 @@ func TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch(t *testing.T
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1254135962", "ReadWriteMany"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.%", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.storage", "5Gi"),
@@ -248,7 +248,7 @@ func TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch(t *testing.T
 // 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.self_link"),
 // 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.uid"),
 // 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.#", "1"),
-// 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1254135962", "ReadWriteMany"),
+// 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 // 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.#", "1"),
 // 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.%", "1"),
 // 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.storage", "5Gi"),
@@ -286,7 +286,7 @@ func TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch(t *testing.T
 // 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.self_link"),
 // 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.uid"),
 // 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.#", "1"),
-// 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1254135962", "ReadWriteMany"),
+// 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 // 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.#", "1"),
 // 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.%", "1"),
 // 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.storage", "5Gi"),
@@ -333,7 +333,7 @@ func TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeUpdate(t *testing.
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1254135962", "ReadWriteMany"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.%", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.storage", "5Gi"),
@@ -357,7 +357,7 @@ func TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeUpdate(t *testing.
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1254135962", "ReadWriteMany"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.%", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.storage", "5Gi"),
@@ -403,7 +403,7 @@ func TestAccKubernetesPersistentVolumeClaim_googleCloud_storageClass(t *testing.
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1254135962", "ReadWriteMany"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.%", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.storage", "5Gi"),
@@ -430,7 +430,7 @@ func TestAccKubernetesPersistentVolumeClaim_googleCloud_storageClass(t *testing.
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume_claim.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1254135962", "ReadWriteMany"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.%", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume_claim.test", "spec.0.resources.0.requests.storage", "5Gi"),
@@ -529,7 +529,7 @@ resource "kubernetes_persistent_volume_claim" "test" {
 		name = "%s"
 	}
 	spec {
-		access_modes = ["ReadWriteMany"]
+		access_modes = ["ReadWriteOnce"]
 		resources {
 			requests {
 				storage = "5Gi"
@@ -564,7 +564,7 @@ resource "kubernetes_persistent_volume_claim" "test" {
 		name = "%s"
 	}
 	spec {
-		access_modes = ["ReadWriteMany"]
+		access_modes = ["ReadWriteOnce"]
 		resources {
 			requests {
 				storage = "5Gi"
@@ -593,7 +593,7 @@ resource "kubernetes_persistent_volume" "test" {
 		capacity {
 			storage = "10Gi"
 		}
-		access_modes = ["ReadWriteMany"]
+		access_modes = ["ReadWriteOnce"]
 		persistent_volume_source {
 			gce_persistent_disk {
 				pd_name = "${google_compute_disk.test.name}"
@@ -615,7 +615,7 @@ resource "kubernetes_persistent_volume_claim" "test" {
 		name = "%s"
 	}
 	spec {
-		access_modes = ["ReadWriteMany"]
+		access_modes = ["ReadWriteOnce"]
 		resources {
 			requests {
 				storage = "5Gi"
@@ -637,7 +637,7 @@ resource "kubernetes_persistent_volume" "test" {
 		capacity {
 			storage = "10Gi"
 		}
-		access_modes = ["ReadWriteMany"]
+		access_modes = ["ReadWriteOnce"]
 		persistent_volume_source {
 			gce_persistent_disk {
 				pd_name = "${google_compute_disk.test.name}"
@@ -659,7 +659,7 @@ resource "kubernetes_persistent_volume_claim" "test" {
 		name = "%s"
 	}
 	spec {
-		access_modes = ["ReadWriteMany"]
+		access_modes = ["ReadWriteOnce"]
 		resources {
 			requests {
 				storage = "5Gi"
@@ -681,7 +681,7 @@ resource "kubernetes_persistent_volume" "test2" {
 		capacity {
 			storage = "10Gi"
 		}
-		access_modes = ["ReadWriteMany"]
+		access_modes = ["ReadWriteOnce"]
 		persistent_volume_source {
 			gce_persistent_disk {
 				pd_name = "${google_compute_disk.test.name}"
@@ -703,7 +703,7 @@ resource "kubernetes_persistent_volume_claim" "test" {
 		name = "%s"
 	}
 	spec {
-		access_modes = ["ReadWriteMany"]
+		access_modes = ["ReadWriteOnce"]
 		resources {
 			requests {
 				storage = "5Gi"
@@ -728,7 +728,7 @@ resource "kubernetes_persistent_volume_claim" "test" {
 // 		capacity {
 // 			storage = "10Gi"
 // 		}
-// 		access_modes = ["ReadWriteMany"]
+// 		access_modes = ["ReadWriteOnce"]
 // 		persistent_volume_source {
 // 			gce_persistent_disk {
 // 				pd_name = "test123"
@@ -742,7 +742,7 @@ resource "kubernetes_persistent_volume_claim" "test" {
 // 		name = "%s"
 // 	}
 // 	spec {
-// 		access_modes = ["ReadWriteMany"]
+// 		access_modes = ["ReadWriteOnce"]
 // 		resources {
 // 			requests {
 // 				storage = "5Gi"
@@ -771,7 +771,7 @@ resource "kubernetes_persistent_volume_claim" "test" {
 // 		capacity {
 // 			storage = "10Gi"
 // 		}
-// 		access_modes = ["ReadWriteMany"]
+// 		access_modes = ["ReadWriteOnce"]
 // 		persistent_volume_source {
 // 			gce_persistent_disk {
 // 				pd_name = "test123"
@@ -785,7 +785,7 @@ resource "kubernetes_persistent_volume_claim" "test" {
 // 		name = "%s"
 // 	}
 // 	spec {
-// 		access_modes = ["ReadWriteMany"]
+// 		access_modes = ["ReadWriteOnce"]
 // 		resources {
 // 			requests {
 // 				storage = "5Gi"
@@ -813,7 +813,7 @@ resource "kubernetes_persistent_volume" "test" {
 		capacity {
 			storage = "%s"
 		}
-		access_modes = ["ReadWriteMany"]
+		access_modes = ["ReadWriteOnce"]
 		persistent_volume_source {
 			gce_persistent_disk {
 				pd_name = "${google_compute_disk.test.name}"
@@ -835,7 +835,7 @@ resource "kubernetes_persistent_volume_claim" "test" {
 		name = "%s"
 	}
 	spec {
-		access_modes = ["ReadWriteMany"]
+		access_modes = ["ReadWriteOnce"]
 		resources {
 			requests {
 				storage = "5Gi"
@@ -864,7 +864,7 @@ resource "kubernetes_persistent_volume_claim" "test" {
 		name = "%s"
 	}
 	spec {
-		access_modes = ["ReadWriteMany"]
+		access_modes = ["ReadWriteOnce"]
 		resources {
 			requests {
 				storage = "5Gi"
@@ -903,7 +903,7 @@ resource "kubernetes_persistent_volume_claim" "test" {
 		name = "%s"
 	}
 	spec {
-		access_modes = ["ReadWriteMany"]
+		access_modes = ["ReadWriteOnce"]
 		resources {
 			requests {
 				storage = "5Gi"

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -55,7 +55,7 @@ func TestAccKubernetesPersistentVolume_googleCloud_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.%", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "123Gi"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1254135962", "ReadWriteMany"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.gce_persistent_disk.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.gce_persistent_disk.0.pd_name", diskName),
 				),
@@ -88,7 +88,7 @@ func TestAccKubernetesPersistentVolume_googleCloud_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "42Mi"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.#", "2"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1254135962", "ReadWriteMany"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.3887104832", "ReadOnlyMany"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.gce_persistent_disk.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.gce_persistent_disk.0.fs_type", "ntfs"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.gce_persistent_disk.0.pd_name", diskName),
@@ -158,7 +158,7 @@ func TestAccKubernetesPersistentVolume_googleCloud_volumeSource(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.%", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "123Gi"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1254135962", "ReadWriteMany"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.gce_persistent_disk.#", "1"),
 					resource.TestCheckResourceAttrSet("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.gce_persistent_disk.0.pd_name"),
 				),
@@ -182,7 +182,7 @@ func TestAccKubernetesPersistentVolume_googleCloud_volumeSource(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.%", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.capacity.storage", "123Gi"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1254135962", "ReadWriteMany"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.host_path.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.host_path.0.path", "/custom/testing/path"),
 				),
@@ -288,7 +288,7 @@ resource "kubernetes_persistent_volume" "test" {
 		capacity {
 			storage = "123Gi"
 		}
-		access_modes = ["ReadWriteMany"]
+		access_modes = ["ReadWriteOnce"]
 		persistent_volume_source {
 			gce_persistent_disk {
 				pd_name = "${google_compute_disk.test.name}"
@@ -326,7 +326,7 @@ resource "kubernetes_persistent_volume" "test" {
 		capacity {
 			storage = "42Mi"
 		}
-		access_modes = ["ReadWriteMany", "ReadWriteOnce"]
+		access_modes = ["ReadWriteOnce", "ReadOnlyMany"]
 		persistent_volume_source {
 			gce_persistent_disk {
 				fs_type = "ntfs"
@@ -357,7 +357,7 @@ resource "kubernetes_persistent_volume" "test" {
 		capacity {
 			storage = "123Gi"
 		}
-		access_modes = ["ReadWriteMany"]
+		access_modes = ["ReadWriteOnce"]
 		persistent_volume_source {
 			gce_persistent_disk {
 				pd_name = "${google_compute_disk.test.name}"
@@ -386,7 +386,7 @@ resource "kubernetes_persistent_volume" "test" {
 		capacity {
 			storage = "123Gi"
 		}
-		access_modes = ["ReadWriteMany"]
+		access_modes = ["ReadWriteOnce"]
 		persistent_volume_source {
 			host_path {
 				path = "/custom/testing/path"


### PR DESCRIPTION
This is to address the following test failure on K8S 1.7+:

```
=== RUN   TestAccKubernetesPersistentVolumeClaim_googleCloud_storageClass
--- FAIL: TestAccKubernetesPersistentVolumeClaim_googleCloud_storageClass (300.25s)
    testing.go:449: Step 0 error: Error applying: 1 error(s) occurred:
        
        * kubernetes_persistent_volume_claim.test: 1 error(s) occurred:
        
        * kubernetes_persistent_volume_claim.test: timeout while waiting for state to become 'Bound' (last state: 'Pending', timeout: 5m0s)
           * ProvisioningFailed: Failed to provision volume with StorageClass "tf-acc-test-iwum1dthd9": invalid AccessModes [ReadWriteMany]: only AccessModes [ReadWriteOnce ReadOnlyMany] are supported
```

`ReadWriteMany` access mode was never allowed for GCE PDs per [docs](https://v1-6.docs.kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) but the validation apparently became stricter with `1.7`.

## Test Results

![screen shot 2018-02-26 at 12 39 17](https://user-images.githubusercontent.com/287584/36671390-6404ef28-1af3-11e8-946a-2388c43de1e8.png)

```
=== RUN   TestAccKubernetesPersistentVolumeClaim_googleCloud_storageClass
--- PASS: TestAccKubernetesPersistentVolumeClaim_googleCloud_storageClass (13.42s)
```