### PR TITLE
resource/kubernetes_service: Update external_ips correctly on K8S 1.8+

### DIFF
--- a/kubernetes/resource_kubernetes_service.go
+++ b/kubernetes/resource_kubernetes_service.go
@@ -236,7 +236,14 @@ func resourceKubernetesServiceUpdate(d *schema.ResourceData, meta interface{}) e
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 	if d.HasChange("spec") {
-		diffOps := patchServiceSpec("spec.0.", "/spec/", d)
+		serverVersion, err := conn.ServerVersion()
+		if err != nil {
+			return err
+		}
+		diffOps, err := patchServiceSpec("spec.0.", "/spec/", d, serverVersion)
+		if err != nil {
+			return err
+		}
 		ops = append(ops, diffOps...)
 	}
 	data, err := ops.MarshalJSON()


### PR DESCRIPTION
This is mainly to address the following test failure:

```
=== RUN   TestAccKubernetesService_loadBalancer
--- FAIL: TestAccKubernetesService_loadBalancer (56.09s)
    testing.go:449: Step 1 error: Error applying: 1 error(s) occurred:
        
        * kubernetes_service.test: 1 error(s) occurred:
        
        * kubernetes_service.test: Failed to update service: jsonpatch replace operation does not apply: doc is missing key: /spec/deprecatedPublicIPs
```
Which occurs when testing against 1.8+.