### PR TITLE
resource/kubernetes_persistent_volume: Use correct operation when updating persistent_volume_source (1.8)

### DIFF
--- a/kubernetes/structure_persistent_volume_spec.go
+++ b/kubernetes/structure_persistent_volume_spec.go
@@ -802,204 +802,374 @@ func patchPersistentVolumeSource(pathPrefix, prefix string, d *schema.ResourceDa
 
 	if d.HasChange(prefix + "gce_persistent_disk") {
 		oldIn, newIn := d.GetChange(prefix + "gce_persistent_disk")
-		if v, ok := newIn.([]interface{}); ok && len(v) > 0 {
-			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/gcePersistentDisk",
-				Value: expandGCEPersistentDiskVolumeSource(v),
-			})
-		} else if v, ok := oldIn.([]interface{}); ok && len(v) > 0 {
+		oldV, oldOk := oldIn.([]interface{})
+		newV, newOk := newIn.([]interface{})
+
+		if newOk && len(newV) > 0 {
+			if oldOk && len(oldV) > 0 {
+				ops = append(ops, &ReplaceOperation{
+					Path:  pathPrefix + "/gcePersistentDisk",
+					Value: expandGCEPersistentDiskVolumeSource(newV),
+				})
+			} else {
+				ops = append(ops, &AddOperation{
+					Path:  pathPrefix + "/gcePersistentDisk",
+					Value: expandGCEPersistentDiskVolumeSource(newV),
+				})
+			}
+		} else if oldOk && len(oldV) > 0 {
 			ops = append(ops, &RemoveOperation{Path: pathPrefix + "/gcePersistentDisk"})
 		}
 	}
 
 	if d.HasChange(prefix + "aws_elastic_block_store") {
 		oldIn, newIn := d.GetChange(prefix + "aws_elastic_block_store")
-		if v, ok := newIn.([]interface{}); ok && len(v) > 0 {
-			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/awsElasticBlockStore",
-				Value: expandAWSElasticBlockStoreVolumeSource(v),
-			})
-		} else if v, ok := oldIn.([]interface{}); ok && len(v) > 0 {
+		oldV, oldOk := oldIn.([]interface{})
+		newV, newOk := newIn.([]interface{})
+
+		if newOk && len(newV) > 0 {
+			if oldOk && len(oldV) > 0 {
+				ops = append(ops, &ReplaceOperation{
+					Path:  pathPrefix + "/awsElasticBlockStore",
+					Value: expandAWSElasticBlockStoreVolumeSource(newV),
+				})
+			} else {
+				ops = append(ops, &AddOperation{
+					Path:  pathPrefix + "/awsElasticBlockStore",
+					Value: expandAWSElasticBlockStoreVolumeSource(newV),
+				})
+			}
+		} else if oldOk && len(oldV) > 0 {
 			ops = append(ops, &RemoveOperation{Path: pathPrefix + "/awsElasticBlockStore"})
 		}
 	}
 
 	if d.HasChange(prefix + "host_path") {
 		oldIn, newIn := d.GetChange(prefix + "host_path")
-		if v, ok := newIn.([]interface{}); ok && len(v) > 0 {
-			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/hostPath",
-				Value: expandHostPathVolumeSource(v),
-			})
-		} else if v, ok := oldIn.([]interface{}); ok && len(v) > 0 {
+		oldV, oldOk := oldIn.([]interface{})
+		newV, newOk := newIn.([]interface{})
+
+		if newOk && len(newV) > 0 {
+			if oldOk && len(oldV) > 0 {
+				ops = append(ops, &ReplaceOperation{
+					Path:  pathPrefix + "/hostPath",
+					Value: expandHostPathVolumeSource(newV),
+				})
+			} else {
+				ops = append(ops, &AddOperation{
+					Path:  pathPrefix + "/hostPath",
+					Value: expandHostPathVolumeSource(newV),
+				})
+			}
+		} else if oldOk && len(oldV) > 0 {
 			ops = append(ops, &RemoveOperation{Path: pathPrefix + "/hostPath"})
 		}
 	}
 
 	if d.HasChange(prefix + "glusterfs") {
 		oldIn, newIn := d.GetChange(prefix + "glusterfs")
-		if v, ok := newIn.([]interface{}); ok && len(v) > 0 {
-			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/glusterfs",
-				Value: expandGlusterfsVolumeSource(v),
-			})
-		} else if v, ok := oldIn.([]interface{}); ok && len(v) > 0 {
+		oldV, oldOk := oldIn.([]interface{})
+		newV, newOk := newIn.([]interface{})
+
+		if newOk && len(newV) > 0 {
+			if oldOk && len(oldV) > 0 {
+				ops = append(ops, &ReplaceOperation{
+					Path:  pathPrefix + "/glusterfs",
+					Value: expandGlusterfsVolumeSource(newV),
+				})
+			} else {
+				ops = append(ops, &AddOperation{
+					Path:  pathPrefix + "/glusterfs",
+					Value: expandGlusterfsVolumeSource(newV),
+				})
+			}
+		} else if oldOk && len(oldV) > 0 {
 			ops = append(ops, &RemoveOperation{Path: pathPrefix + "/glusterfs"})
 		}
 	}
 
 	if d.HasChange(prefix + "nfs") {
 		oldIn, newIn := d.GetChange(prefix + "nfs")
-		if v, ok := newIn.([]interface{}); ok && len(v) > 0 {
-			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/nfs",
-				Value: expandNFSVolumeSource(v),
-			})
-		} else if v, ok := oldIn.([]interface{}); ok && len(v) > 0 {
+		oldV, oldOk := oldIn.([]interface{})
+		newV, newOk := newIn.([]interface{})
+
+		if newOk && len(newV) > 0 {
+			if oldOk && len(oldV) > 0 {
+				ops = append(ops, &ReplaceOperation{
+					Path:  pathPrefix + "/nfs",
+					Value: expandNFSVolumeSource(newV),
+				})
+			} else {
+				ops = append(ops, &AddOperation{
+					Path:  pathPrefix + "/nfs",
+					Value: expandNFSVolumeSource(newV),
+				})
+			}
+		} else if oldOk && len(oldV) > 0 {
 			ops = append(ops, &RemoveOperation{Path: pathPrefix + "/nfs"})
 		}
 	}
 
 	if d.HasChange(prefix + "rbd") {
 		oldIn, newIn := d.GetChange(prefix + "rbd")
-		if v, ok := newIn.([]interface{}); ok && len(v) > 0 {
-			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/rbd",
-				Value: expandRBDVolumeSource(v),
-			})
-		} else if v, ok := oldIn.([]interface{}); ok && len(v) > 0 {
+		oldV, oldOk := oldIn.([]interface{})
+		newV, newOk := newIn.([]interface{})
+
+		if newOk && len(newV) > 0 {
+			if oldOk && len(oldV) > 0 {
+				ops = append(ops, &ReplaceOperation{
+					Path:  pathPrefix + "/rbd",
+					Value: expandRBDVolumeSource(newV),
+				})
+			} else {
+				ops = append(ops, &AddOperation{
+					Path:  pathPrefix + "/rbd",
+					Value: expandRBDVolumeSource(newV),
+				})
+			}
+		} else if oldOk && len(oldV) > 0 {
 			ops = append(ops, &RemoveOperation{Path: pathPrefix + "/rbd"})
 		}
 	}
 
 	if d.HasChange(prefix + "iscsi") {
 		oldIn, newIn := d.GetChange(prefix + "iscsi")
-		if v, ok := newIn.([]interface{}); ok && len(v) > 0 {
-			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/iscsi",
-				Value: expandISCSIVolumeSource(v),
-			})
-		} else if v, ok := oldIn.([]interface{}); ok && len(v) > 0 {
+		oldV, oldOk := oldIn.([]interface{})
+		newV, newOk := newIn.([]interface{})
+
+		if newOk && len(newV) > 0 {
+			if oldOk && len(oldV) > 0 {
+				ops = append(ops, &ReplaceOperation{
+					Path:  pathPrefix + "/iscsi",
+					Value: expandISCSIVolumeSource(newV),
+				})
+			} else {
+				ops = append(ops, &AddOperation{
+					Path:  pathPrefix + "/iscsi",
+					Value: expandISCSIVolumeSource(newV),
+				})
+			}
+		} else if oldOk && len(oldV) > 0 {
 			ops = append(ops, &RemoveOperation{Path: pathPrefix + "/iscsi"})
 		}
 	}
 
 	if d.HasChange(prefix + "cinder") {
 		oldIn, newIn := d.GetChange(prefix + "cinder")
-		if v, ok := newIn.([]interface{}); ok && len(v) > 0 {
-			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/cinder",
-				Value: expandCinderVolumeSource(v),
-			})
-		} else if v, ok := oldIn.([]interface{}); ok && len(v) > 0 {
+		oldV, oldOk := oldIn.([]interface{})
+		newV, newOk := newIn.([]interface{})
+
+		if newOk && len(newV) > 0 {
+			if oldOk && len(oldV) > 0 {
+				ops = append(ops, &ReplaceOperation{
+					Path:  pathPrefix + "/cinder",
+					Value: expandCinderVolumeSource(newV),
+				})
+			} else {
+				ops = append(ops, &AddOperation{
+					Path:  pathPrefix + "/cinder",
+					Value: expandCinderVolumeSource(newV),
+				})
+			}
+		} else if oldOk && len(oldV) > 0 {
 			ops = append(ops, &RemoveOperation{Path: pathPrefix + "/cinder"})
 		}
 	}
 
 	if d.HasChange(prefix + "ceph_fs") {
 		oldIn, newIn := d.GetChange(prefix + "ceph_fs")
-		if v, ok := newIn.([]interface{}); ok && len(v) > 0 {
-			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/cephfs",
-				Value: expandCephFSVolumeSource(v),
-			})
-		} else if v, ok := oldIn.([]interface{}); ok && len(v) > 0 {
+		oldV, oldOk := oldIn.([]interface{})
+		newV, newOk := newIn.([]interface{})
+
+		if newOk && len(newV) > 0 {
+			if oldOk && len(oldV) > 0 {
+				ops = append(ops, &ReplaceOperation{
+					Path:  pathPrefix + "/cephfs",
+					Value: expandCephFSVolumeSource(newV),
+				})
+			} else {
+				ops = append(ops, &AddOperation{
+					Path:  pathPrefix + "/cephfs",
+					Value: expandCephFSVolumeSource(newV),
+				})
+			}
+		} else if oldOk && len(oldV) > 0 {
 			ops = append(ops, &RemoveOperation{Path: pathPrefix + "/cephfs"})
 		}
 	}
 
 	if d.HasChange(prefix + "fc") {
 		oldIn, newIn := d.GetChange(prefix + "fc")
-		if v, ok := newIn.([]interface{}); ok && len(v) > 0 {
-			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/fc",
-				Value: expandFCVolumeSource(v),
-			})
-		} else if v, ok := oldIn.([]interface{}); ok && len(v) > 0 {
+		oldV, oldOk := oldIn.([]interface{})
+		newV, newOk := newIn.([]interface{})
+
+		if newOk && len(newV) > 0 {
+			if oldOk && len(oldV) > 0 {
+				ops = append(ops, &ReplaceOperation{
+					Path:  pathPrefix + "/fc",
+					Value: expandFCVolumeSource(newV),
+				})
+			} else {
+				ops = append(ops, &AddOperation{
+					Path:  pathPrefix + "/fc",
+					Value: expandFCVolumeSource(newV),
+				})
+			}
+		} else if oldOk && len(oldV) > 0 {
 			ops = append(ops, &RemoveOperation{Path: pathPrefix + "/fc"})
 		}
 	}
 
 	if d.HasChange(prefix + "flocker") {
 		oldIn, newIn := d.GetChange(prefix + "flocker")
-		if v, ok := newIn.([]interface{}); ok && len(v) > 0 {
-			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/flocker",
-				Value: expandFlockerVolumeSource(v),
-			})
-		} else if v, ok := oldIn.([]interface{}); ok && len(v) > 0 {
+		oldV, oldOk := oldIn.([]interface{})
+		newV, newOk := newIn.([]interface{})
+
+		if newOk && len(newV) > 0 {
+			if oldOk && len(oldV) > 0 {
+				ops = append(ops, &ReplaceOperation{
+					Path:  pathPrefix + "/flocker",
+					Value: expandFlockerVolumeSource(newV),
+				})
+			} else {
+				ops = append(ops, &AddOperation{
+					Path:  pathPrefix + "/flocker",
+					Value: expandFlockerVolumeSource(newV),
+				})
+			}
+		} else if oldOk && len(oldV) > 0 {
 			ops = append(ops, &RemoveOperation{Path: pathPrefix + "/flocker"})
 		}
 	}
 
 	if d.HasChange(prefix + "flex_volume") {
 		oldIn, newIn := d.GetChange(prefix + "flex_volume")
-		if v, ok := newIn.([]interface{}); ok && len(v) > 0 {
-			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/flexVolume",
-				Value: expandFlexVolumeSource(v),
-			})
-		} else if v, ok := oldIn.([]interface{}); ok && len(v) > 0 {
+		oldV, oldOk := oldIn.([]interface{})
+		newV, newOk := newIn.([]interface{})
+
+		if newOk && len(newV) > 0 {
+			if oldOk && len(oldV) > 0 {
+				ops = append(ops, &ReplaceOperation{
+					Path:  pathPrefix + "/flexVolume",
+					Value: expandFlexVolumeSource(newV),
+				})
+			} else {
+				ops = append(ops, &AddOperation{
+					Path:  pathPrefix + "/flexVolume",
+					Value: expandFlexVolumeSource(newV),
+				})
+			}
+		} else if oldOk && len(oldV) > 0 {
 			ops = append(ops, &RemoveOperation{Path: pathPrefix + "/flexVolume"})
 		}
 	}
 
 	if d.HasChange(prefix + "azure_file") {
 		oldIn, newIn := d.GetChange(prefix + "azure_file")
-		if v, ok := newIn.([]interface{}); ok && len(v) > 0 {
-			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/azureFile",
-				Value: expandAzureFileVolumeSource(v),
-			})
-		} else if v, ok := oldIn.([]interface{}); ok && len(v) > 0 {
+		oldV, oldOk := oldIn.([]interface{})
+		newV, newOk := newIn.([]interface{})
+
+		if newOk && len(newV) > 0 {
+			if oldOk && len(oldV) > 0 {
+				ops = append(ops, &ReplaceOperation{
+					Path:  pathPrefix + "/azureFile",
+					Value: expandAzureFileVolumeSource(newV),
+				})
+			} else {
+				ops = append(ops, &AddOperation{
+					Path:  pathPrefix + "/azureFile",
+					Value: expandAzureFileVolumeSource(newV),
+				})
+			}
+		} else if oldOk && len(oldV) > 0 {
 			ops = append(ops, &RemoveOperation{Path: pathPrefix + "/azureFile"})
 		}
 	}
 
 	if d.HasChange(prefix + "vsphere_volume") {
 		oldIn, newIn := d.GetChange(prefix + "vsphere_volume")
-		if v, ok := newIn.([]interface{}); ok && len(v) > 0 {
-			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/vsphereVolume",
-				Value: expandVsphereVirtualDiskVolumeSource(v),
-			})
-		} else if v, ok := oldIn.([]interface{}); ok && len(v) > 0 {
+		oldV, oldOk := oldIn.([]interface{})
+		newV, newOk := newIn.([]interface{})
+
+		if newOk && len(newV) > 0 {
+			if oldOk && len(oldV) > 0 {
+				ops = append(ops, &ReplaceOperation{
+					Path:  pathPrefix + "/vsphereVolume",
+					Value: expandVsphereVirtualDiskVolumeSource(newV),
+				})
+			} else {
+				ops = append(ops, &AddOperation{
+					Path:  pathPrefix + "/vsphereVolume",
+					Value: expandVsphereVirtualDiskVolumeSource(newV),
+				})
+			}
+		} else if oldOk && len(oldV) > 0 {
 			ops = append(ops, &RemoveOperation{Path: pathPrefix + "/vsphereVolume"})
 		}
 	}
 
 	if d.HasChange(prefix + "quobyte") {
 		oldIn, newIn := d.GetChange(prefix + "quobyte")
-		if v, ok := newIn.([]interface{}); ok && len(v) > 0 {
-			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/quobyte",
-				Value: expandQuobyteVolumeSource(v),
-			})
-		} else if v, ok := oldIn.([]interface{}); ok && len(v) > 0 {
+		oldV, oldOk := oldIn.([]interface{})
+		newV, newOk := newIn.([]interface{})
+
+		if newOk && len(newV) > 0 {
+			if oldOk && len(oldV) > 0 {
+				ops = append(ops, &ReplaceOperation{
+					Path:  pathPrefix + "/quobyte",
+					Value: expandQuobyteVolumeSource(newV),
+				})
+			} else {
+				ops = append(ops, &AddOperation{
+					Path:  pathPrefix + "/quobyte",
+					Value: expandQuobyteVolumeSource(newV),
+				})
+			}
+		} else if oldOk && len(oldV) > 0 {
 			ops = append(ops, &RemoveOperation{Path: pathPrefix + "/quobyte"})
 		}
 	}
 
 	if d.HasChange(prefix + "azure_disk") {
 		oldIn, newIn := d.GetChange(prefix + "azure_disk")
-		if v, ok := newIn.([]interface{}); ok && len(v) > 0 {
-			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/azureDisk",
-				Value: expandAzureDiskVolumeSource(v),
-			})
-		} else if v, ok := oldIn.([]interface{}); ok && len(v) > 0 {
+		oldV, oldOk := oldIn.([]interface{})
+		newV, newOk := newIn.([]interface{})
+
+		if newOk && len(newV) > 0 {
+			if oldOk && len(oldV) > 0 {
+				ops = append(ops, &ReplaceOperation{
+					Path:  pathPrefix + "/azureDisk",
+					Value: expandAzureDiskVolumeSource(newV),
+				})
+			} else {
+				ops = append(ops, &AddOperation{
+					Path:  pathPrefix + "/azureDisk",
+					Value: expandAzureDiskVolumeSource(newV),
+				})
+			}
+		} else if oldOk && len(oldV) > 0 {
 			ops = append(ops, &RemoveOperation{Path: pathPrefix + "/azureDisk"})
 		}
 	}
 
 	if d.HasChange(prefix + "photon_persistent_disk") {
 		oldIn, newIn := d.GetChange(prefix + "photon_persistent_disk")
-		if v, ok := newIn.([]interface{}); ok && len(v) > 0 {
-			ops = append(ops, &ReplaceOperation{
-				Path:  pathPrefix + "/photonPersistentDisk",
-				Value: expandPhotonPersistentDiskVolumeSource(v),
-			})
-		} else if v, ok := oldIn.([]interface{}); ok && len(v) > 0 {
+		oldV, oldOk := oldIn.([]interface{})
+		newV, newOk := newIn.([]interface{})
+
+		if newOk && len(newV) > 0 {
+			if oldOk && len(oldV) > 0 {
+				ops = append(ops, &ReplaceOperation{
+					Path:  pathPrefix + "/photonPersistentDisk",
+					Value: expandPhotonPersistentDiskVolumeSource(newV),
+				})
+			} else {
+				ops = append(ops, &AddOperation{
+					Path:  pathPrefix + "/photonPersistentDisk",
+					Value: expandPhotonPersistentDiskVolumeSource(newV),
+				})
+			}
+		} else if oldOk && len(oldV) > 0 {
 			ops = append(ops, &RemoveOperation{Path: pathPrefix + "/photonPersistentDisk"})
 		}
 	}


### PR DESCRIPTION
This is to address the following test failure on `1.8`:

```
=== RUN   TestAccKubernetesPersistentVolume_googleCloud_volumeSource
--- FAIL: TestAccKubernetesPersistentVolume_googleCloud_volumeSource (23.81s)
    testing.go:513: Step 1 error: Error applying: 1 error(s) occurred:
        
        * kubernetes_persistent_volume.test: 1 error(s) occurred:
        
        * kubernetes_persistent_volume.test: jsonpatch replace operation does not apply: doc is missing key: /spec/hostPath
FAIL
```

## Test results

```
=== RUN   TestAccKubernetesPersistentVolume_googleCloud_volumeSource
--- PASS: TestAccKubernetesPersistentVolume_googleCloud_volumeSource (23.87s)
```