### PR TITLE
resource/*: Treat non-string label values as invalid

### DIFF
--- a/kubernetes/resource_kubernetes_namespace_test.go
+++ b/kubernetes/resource_kubernetes_namespace_test.go
@@ -111,6 +111,22 @@ func TestAccKubernetesNamespace_basic(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesNamespace_invalidLabelValueType(t *testing.T) {
+	nsName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccKubernetesNamespaceConfig_invalidLabelValueType(nsName),
+				ExpectError: regexp.MustCompile("Expected value to be string"),
+			},
+		},
+	})
+}
+
 func TestAccKubernetesNamespace_importBasic(t *testing.T) {
 	resourceName := "kubernetes_namespace.test"
 	nsName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
@@ -396,6 +412,20 @@ resource "kubernetes_namespace" "test" {
 			"TestLabelThree"        = "three"
 		}
 
+		name = "%s"
+	}
+}`, nsName)
+}
+
+func testAccKubernetesNamespaceConfig_invalidLabelValueType(nsName string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_namespace" "test" {
+	metadata {
+		labels {
+			"first"   = "one"
+			"integer" = 2
+			"bool"    = true
+		}
 		name = "%s"
 	}
 }`, nsName)

--- a/kubernetes/schema_metadata.go
+++ b/kubernetes/schema_metadata.go
@@ -12,6 +12,7 @@ func metadataFields(objectName string) map[string]*schema.Schema {
 			Type:         schema.TypeMap,
 			Description:  fmt.Sprintf("An unstructured key value map stored with the %s that may be used to store arbitrary metadata. More info: http://kubernetes.io/docs/user-guide/annotations", objectName),
 			Optional:     true,
+			Elem:         &schema.Schema{Type: schema.TypeString},
 			ValidateFunc: validateAnnotations,
 		},
 		"generation": {
@@ -23,6 +24,7 @@ func metadataFields(objectName string) map[string]*schema.Schema {
 			Type:         schema.TypeMap,
 			Description:  fmt.Sprintf("Map of string keys and values that can be used to organize and categorize (scope and select) the %s. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels", objectName),
 			Optional:     true,
+			Elem:         &schema.Schema{Type: schema.TypeString},
 			ValidateFunc: validateLabels,
 		},
 		"name": {

--- a/kubernetes/validators.go
+++ b/kubernetes/validators.go
@@ -59,7 +59,11 @@ func validateLabels(value interface{}, key string) (ws []string, es []error) {
 		for _, msg := range utilValidation.IsQualifiedName(k) {
 			es = append(es, fmt.Errorf("%s (%q) %s", key, k, msg))
 		}
-		val := v.(string)
+		val, isString := v.(string)
+		if !isString {
+			es = append(es, fmt.Errorf("%s.%s (%#v): Expected value to be string", key, k, v))
+			return
+		}
 		for _, msg := range utilValidation.IsValidLabelValue(val) {
 			es = append(es, fmt.Errorf("%s (%q) %s", key, val, msg))
 		}


### PR DESCRIPTION
Fixes #108

This is merely a simple stop gap, the proper fix is upstream: https://github.com/hashicorp/terraform/pull/17499

## Test results

```
=== RUN   TestAccKubernetesNamespace_invalidLabelValueType
--- PASS: TestAccKubernetesNamespace_invalidLabelValueType (0.01s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	0.098s
```