### PR TITLE
resource/kubernetes_pod: Bump timeout to 5 mins

### DIFF
--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -174,7 +174,7 @@ func resourceKubernetesPodDelete(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
 		out, err := conn.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {


### PR DESCRIPTION
This is to address the following intermittent test failure:

```
=== RUN   TestAccKubernetesPod_with_container_lifecycle
--- FAIL: TestAccKubernetesPod_with_container_lifecycle (63.13s)
    testing.go:573: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * kubernetes_pod.test (destroy): 1 error(s) occurred:
        
        * kubernetes_pod.test: Pod tf-acc-test-djgqopng0d still exists (Running)
```