### PR TITLE
test-infra: Add DNS check to kops

### DIFF
--- a/kubernetes/test-infra/kops-on-aws/kops-create.sh
+++ b/kubernetes/test-infra/kops-on-aws/kops-create.sh
@@ -16,23 +16,8 @@ kops create cluster --cloud=aws \
   --yes
 
 EXIT_CODE=$?
-
 if [ $EXIT_CODE == 0 ]; then
-  RETRIES=1
-  while [ 1 ]; do
-    kops validate cluster --state=s3://${BUCKET_NAME}
-    if [ $? == 0 ]; then
-      break
-    fi
-
-    sleep 5
-    echo "Retrying validation... ($RETRIES)"
-    ((RETRIES++))
-    if [ $RETRIES -gt 120 ]; then
-      echo "Bailing out after 120 retries"
-      break
-    fi
-  done
+  ../kops-waiter.sh 120
 else
   exit $EXIT_CODE
 fi

--- a/kubernetes/test-infra/kops-on-gce/kops-create.sh
+++ b/kubernetes/test-infra/kops-on-gce/kops-create.sh
@@ -28,23 +28,8 @@ kops create cluster --cloud=gce \
   --yes
 
 EXIT_CODE=$?
-
 if [ $EXIT_CODE == 0 ]; then
-  RETRIES=1
-  while [ 1 ]; do
-    kops validate cluster --state=$KOPS_STATE_STORE
-    if [ $? == 0 ]; then
-      break
-    fi
-
-    sleep 5
-    echo "Retrying validation... ($RETRIES)"
-    ((RETRIES++))
-    if [ $RETRIES -gt 120 ]; then
-      echo "Bailing out after 120 retries"
-      break
-    fi
-  done
+  ../kops-waiter.sh 120
 else
   exit $EXIT_CODE
 fi

--- a/kubernetes/test-infra/kops-waiter.sh
+++ b/kubernetes/test-infra/kops-waiter.sh
@@ -1,0 +1,35 @@
+MAX_RETRIES=$1
+
+RETRIES=1
+while [ 1 ]; do
+  kops validate cluster --state=s3://${BUCKET_NAME}
+  if [ $? == 0 ]; then
+    break
+  fi
+
+  sleep 5
+  echo "Retrying kube validation... ($RETRIES)"
+  ((RETRIES++))
+  if [ $RETRIES -gt $MAX_RETRIES ]; then
+    echo "Bailing out after $MAX_RETRIES retries"
+    break
+  fi
+done
+
+RETRIES=1
+KUBE_HOST=$(kubectl config view -o jsonpath="{.clusters[?(@.name == \"${CLUSTER_NAME}\")].cluster.server}")
+while [ 1 ]; do
+  echo "Trying to resolve $KUBE_HOST"
+  host $KUBE_HOST
+  if [ $? == 0 ]; then
+    break
+  fi
+
+  sleep 5
+  echo "Retrying DNS query... ($RETRIES)"
+  ((RETRIES++))
+  if [ $RETRIES -gt $MAX_RETRIES ]; then
+    echo "Bailing out after $MAX_RETRIES retries"
+    break
+  fi
+done


### PR DESCRIPTION
This is to address intermittent test failures, which only occur when running tests against kops environments.

```
=== RUN   TestAccKubernetesPod_basic
--- FAIL: TestAccKubernetesPod_basic (0.05s)
    testing.go:513: Step 0 error: Error applying: 2 error(s) occurred:
        
        * kubernetes_secret.test: 1 error(s) occurred:
        
        * kubernetes_secret.test: Post https://api.3e5b0195d4607a8f.kops.aws.tfacc.hashicorptest.com/api/v1/namespaces/default/secrets: dial tcp: lookup api.3e5b0195d4607a8f.kops.aws.tfacc.hashicorptest.com on 192.168.22.2:53: no such host
        * kubernetes_config_map.test: 1 error(s) occurred:
        
        * kubernetes_config_map.test: Post https://api.3e5b0195d4607a8f.kops.aws.tfacc.hashicorptest.com/api/v1/namespaces/default/configmaps: dial tcp: lookup api.3e5b0195d4607a8f.kops.aws.tfacc.hashicorptest.com on 192.168.22.2:53: no such host
FAIL
```

![its-always-dns](https://user-images.githubusercontent.com/287584/36976491-c4b4e698-2075-11e8-9fea-d73af2ccfbbf.jpg)