### PR TITLE
test-infra: Re-auth for kops@GCE deletion

### DIFF
--- a/kubernetes/test-infra/kops-on-gce/kops-delete.sh
+++ b/kubernetes/test-infra/kops-on-gce/kops-delete.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
+export KOPS_STATE_STORE="gs://${BUCKET_NAME}"
+export KOPS_FEATURE_FLAGS=AlphaAllowGCE
+
+# Auth for kops
+echo $GOOGLE_CREDENTIALS > $TMP_CREDS_PATH
+export GOOGLE_APPLICATION_CREDENTIALS=$TMP_CREDS_PATH
+
+# Auth for gsutil/gcloud
+gcloud auth activate-service-account $(echo $GOOGLE_CREDENTIALS | jq -r .client_email) --key-file=$TMP_CREDS_PATH
+gcloud config set pass_credentials_to_gsutil true
+
 kops delete cluster \
   --name=${CLUSTER_NAME} \
-  --state=gs://${BUCKET_NAME} \
+  --state=${KOPS_STATE_STORE} \
   --yes && \
-gsutil rm -r gs://${BUCKET_NAME}
+gsutil rm -r ${KOPS_STATE_STORE}

--- a/kubernetes/test-infra/kops-on-gce/main.tf
+++ b/kubernetes/test-infra/kops-on-gce/main.tf
@@ -51,6 +51,7 @@ EOF
   provisioner "local-exec" {
     when = "destroy"
     command = <<EOF
+export TMP_CREDS_PATH=${local.tmp_creds_location}
 export CLUSTER_NAME=${local.cluster_name}
 export BUCKET_NAME=${local.bucket_name}
 ./kops-delete.sh


### PR DESCRIPTION
This is to address the following failure (causing leaks in GCP) discovered from build log after all tests have finished:

```
[10:13:22]	[Step 6/6] Starting: /opt/teamcity-agent/temp/agentTmp/custom_script2207769590328911975
[10:13:22]	[Step 6/6] in directory: /opt/teamcity-agent/work/5774063e0179f459/src/github.com/terraform-providers/terraform-provider-kubernetes/kubernetes/test-infra/kops-on-gce
[10:13:22]	[Step 6/6] data.http.ipinfo: Refreshing state...
[10:13:22]	[Step 6/6] random_id.name: Refreshing state... (ID: Yk4)
[10:13:22]	[Step 6/6] data.google_compute_zones.available: Refreshing state...
[10:13:23]	[Step 6/6] null_resource.kops: Refreshing state... (ID: 5963930724280710677)
[10:13:23]	[Step 6/6] null_resource.kops: Destroying... (ID: 5963930724280710677)
[10:13:23]	[Step 6/6] null_resource.kops: Provisioning with 'local-exec'...
[10:13:23]	[Step 6/6] null_resource.kops (local-exec): Executing: ["/bin/sh" "-c" "export CLUSTER_NAME=k.624e.k8s.tfacc.hashicorptest.com\nexport BUCKET_NAME=kops-tfacc-624e\n./kops-delete.sh\nrm -f /opt/teamcity-agent/work/5774063e0179f459/src/github.com/terraform-providers/terraform-provider-kubernetes/kubernetes/test-infra/kops-on-gce/google-creds.json\n"]
[10:13:23]	[Step 6/6] 
[10:13:23]	[Step 6/6] null_resource.kops (local-exec): error building path for "gs://kops-tfacc-624e": error building GCS HTTP client: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
[10:13:23]	[Step 6/6] null_resource.kops: Destruction complete after 0s
[10:13:23]	[Step 6/6] random_id.name: Destroying... (ID: Yk4)
[10:13:23]	[Step 6/6] random_id.name: Destruction complete after 0s
[10:13:23]	[Step 6/6] 
[10:13:23]	[Step 6/6] Destroy complete! Resources: 2 destroyed.
[10:13:23]	[Step 6/6] Process exited with code 0
```
Interestingly it seems to be intermittent, which is possibly related to the fact that it's shared auth as discussed originally in https://github.com/terraform-providers/terraform-provider-kubernetes/pull/120#discussion_r170123484