### PR TITLE
r/kubernetes_service: Switch targetPort to string

### DIFF
--- a/kubernetes/resource_kubernetes_service.go
+++ b/kubernetes/resource_kubernetes_service.go
@@ -95,7 +95,7 @@ func resourceKubernetesService() *schema.Resource {
 										Default:     "TCP",
 									},
 									"target_port": {
-										Type:        schema.TypeInt,
+										Type:        schema.TypeString,
 										Description: "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. This field is ignored for services with `cluster_ip = \"None\"`. More info: http://kubernetes.io/docs/user-guide/services#defining-a-service",
 										Optional:    true,
 										Computed:    true,

--- a/kubernetes/structure_service_spec.go
+++ b/kubernetes/structure_service_spec.go
@@ -10,10 +10,6 @@ import (
 
 // Flatteners
 
-func flattenIntOrString(in intstr.IntOrString) int {
-	return in.IntValue()
-}
-
 func flattenServicePort(in []v1.ServicePort) []interface{} {
 	att := make([]interface{}, len(in), len(in))
 	for i, n := range in {
@@ -21,7 +17,7 @@ func flattenServicePort(in []v1.ServicePort) []interface{} {
 		m["name"] = n.Name
 		m["protocol"] = string(n.Protocol)
 		m["port"] = int(n.Port)
-		m["target_port"] = flattenIntOrString(n.TargetPort)
+		m["target_port"] = n.TargetPort.String()
 		m["node_port"] = int(n.NodePort)
 
 		att[i] = m
@@ -76,10 +72,6 @@ func flattenLoadBalancerIngress(in []v1.LoadBalancerIngress) []interface{} {
 
 // Expanders
 
-func expandIntOrString(in int) intstr.IntOrString {
-	return intstr.FromInt(in)
-}
-
 func expandServicePort(l []interface{}) []v1.ServicePort {
 	if len(l) == 0 || l[0] == nil {
 		return []v1.ServicePort{}
@@ -89,7 +81,7 @@ func expandServicePort(l []interface{}) []v1.ServicePort {
 		cfg := n.(map[string]interface{})
 		obj[i] = v1.ServicePort{
 			Port:       int32(cfg["port"].(int)),
-			TargetPort: expandIntOrString(cfg["target_port"].(int)),
+			TargetPort: intstr.Parse(cfg["target_port"].(string)),
 		}
 		if v, ok := cfg["name"].(string); ok {
 			obj[i].Name = v

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -98,7 +98,7 @@ The following arguments are supported:
 * `node_port` - (Optional) The port on each node on which this service is exposed when `type` is `NodePort` or `LoadBalancer`. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the `type` of this service requires one. More info: http://kubernetes.io/docs/user-guide/services#type--nodeport
 * `port` - (Required) The port that will be exposed by this service.
 * `protocol` - (Optional) The IP protocol for this port. Supports `TCP` and `UDP`. Default is `TCP`.
-* `target_port` - (Required) Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. This field is ignored for services with `cluster_ip = "None"`. More info: http://kubernetes.io/docs/user-guide/services#defining-a-service
+* `target_port` - (Optional) Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. This field is ignored for services with `cluster_ip = "None"`. More info: http://kubernetes.io/docs/user-guide/services#defining-a-service
 
 ## Attributes
 


### PR DESCRIPTION
Fix #134 
switch targetPort to string in schema
new acceptance test
update docs to reflect targetPort is optional