### PR TITLE
r/kubernetes_pod: add support for init containers

### DIFF
--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 func TestAccKubernetesPod_basic(t *testing.T) {
-	var conf api.Pod
+	var conf1 api.Pod
+	var conf2 api.Pod
 
 	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	secretName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
@@ -32,7 +33,7 @@ func TestAccKubernetesPod_basic(t *testing.T) {
 			{
 				Config: testAccKubernetesPodConfigBasic(secretName, configMapName, podName, imageName1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf1),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.annotations.%", "0"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.labels.%", "1"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.labels.app", "pod_label"),
@@ -49,8 +50,63 @@ func TestAccKubernetesPod_basic(t *testing.T) {
 			{
 				Config: testAccKubernetesPodConfigBasic(secretName, configMapName, podName, imageName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf2),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.image", imageName2),
+					testAccCheckKubernetesPodForceNew(&conf1, &conf2, false),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesPod_initContainer_updateForcesNew(t *testing.T) {
+	var conf1 api.Pod
+	var conf2 api.Pod
+
+	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	image1 := "busybox:1.27"
+	image2 := "busybox:1.28"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesPodDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesPodConfigWithInitContainer(podName, image1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf1),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.annotations.%", "0"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.labels.%", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.labels.app", "pod_label"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.name", podName),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.init_container.0.name", "install"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.init_container.0.image", image1),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.init_container.0.command.0", "wget"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.init_container.0.command.1", "-O"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.init_container.0.command.2", "/work-dir/index.html"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.init_container.0.command.3", "http://kubernetes.io"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.init_container.0.volume_mount.0.name", "workdir"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.init_container.0.volume_mount.0.mount_path", "/work-dir"),
+				),
+			},
+			{
+				Config: testAccKubernetesPodConfigWithInitContainer(podName, image2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf2),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.annotations.%", "0"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.labels.%", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.labels.app", "pod_label"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.name", podName),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.init_container.0.name", "install"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.init_container.0.image", image2),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.init_container.0.command.0", "wget"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.init_container.0.command.1", "-O"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.init_container.0.command.2", "/work-dir/index.html"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.init_container.0.command.3", "http://kubernetes.io"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.init_container.0.volume_mount.0.name", "workdir"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.init_container.0.volume_mount.0.mount_path", "/work-dir"),
+					testAccCheckKubernetesPodForceNew(&conf1, &conf2, true),
 				),
 			},
 		},
@@ -58,7 +114,8 @@ func TestAccKubernetesPod_basic(t *testing.T) {
 }
 
 func TestAccKubernetesPod_updateArgsForceNew(t *testing.T) {
-	var conf api.Pod
+	var conf1 api.Pod
+	var conf2 api.Pod
 
 	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
@@ -74,7 +131,7 @@ func TestAccKubernetesPod_updateArgsForceNew(t *testing.T) {
 			{
 				Config: testAccKubernetesPodConfigArgsUpdate(podName, imageName, argsBefore),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf1),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.annotations.%", "0"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.name", podName),
 					resource.TestCheckResourceAttrSet("kubernetes_pod.test", "metadata.0.generation"),
@@ -91,7 +148,7 @@ func TestAccKubernetesPod_updateArgsForceNew(t *testing.T) {
 			{
 				Config: testAccKubernetesPodConfigArgsUpdate(podName, imageName, argsAfter),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf2),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.annotations.%", "0"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.name", podName),
 					resource.TestCheckResourceAttrSet("kubernetes_pod.test", "metadata.0.generation"),
@@ -103,6 +160,7 @@ func TestAccKubernetesPod_updateArgsForceNew(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.args.0", "-listen=:80"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.args.1", "-text='after modification'"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.name", "containername"),
+					testAccCheckKubernetesPodForceNew(&conf1, &conf2, true),
 				),
 			},
 		},
@@ -110,7 +168,8 @@ func TestAccKubernetesPod_updateArgsForceNew(t *testing.T) {
 }
 
 func TestAccKubernetesPod_updateEnvForceNew(t *testing.T) {
-	var conf api.Pod
+	var conf1 api.Pod
+	var conf2 api.Pod
 
 	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
@@ -126,7 +185,7 @@ func TestAccKubernetesPod_updateEnvForceNew(t *testing.T) {
 			{
 				Config: testAccKubernetesPodConfigEnvUpdate(podName, imageName, envBefore),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf1),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.annotations.%", "0"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.name", podName),
 					resource.TestCheckResourceAttrSet("kubernetes_pod.test", "metadata.0.generation"),
@@ -143,7 +202,7 @@ func TestAccKubernetesPod_updateEnvForceNew(t *testing.T) {
 			{
 				Config: testAccKubernetesPodConfigEnvUpdate(podName, imageName, envAfter),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf2),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.annotations.%", "0"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.name", podName),
 					resource.TestCheckResourceAttrSet("kubernetes_pod.test", "metadata.0.generation"),
@@ -155,6 +214,7 @@ func TestAccKubernetesPod_updateEnvForceNew(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env.0.name", "foo"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env.0.value", "baz"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.name", "containername"),
+					testAccCheckKubernetesPodForceNew(&conf1, &conf2, true),
 				),
 			},
 		},
@@ -566,6 +626,21 @@ func testAccCheckKubernetesPodExists(n string, obj *api.Pod) resource.TestCheckF
 	}
 }
 
+func testAccCheckKubernetesPodForceNew(old, new *api.Pod, wantNew bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if wantNew {
+			if old.ObjectMeta.UID == new.ObjectMeta.UID {
+				return fmt.Errorf("Expecting new resource for pod %s", old.ObjectMeta.UID)
+			}
+		} else {
+			if old.ObjectMeta.UID != new.ObjectMeta.UID {
+				return fmt.Errorf("Expecting pod UIDs to be the same: expected %s got %s", old.ObjectMeta.UID, new.ObjectMeta.UID)
+			}
+		}
+		return nil
+	}
+}
+
 func testAccKubernetesPodConfigBasic(secretName, configMapName, podName, imageName string) string {
 	return fmt.Sprintf(`
 
@@ -634,6 +709,47 @@ resource "kubernetes_pod" "test" {
   }
 }
 	`, secretName, configMapName, podName, imageName)
+}
+
+func testAccKubernetesPodConfigWithInitContainer(podName string, image string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_pod" "test" {
+	metadata {
+		labels {
+			app = "pod_label"
+		}
+
+		name = "%s"
+	}
+	spec {
+		container {
+			name = "nginx"
+			image = "nginx"
+			port {
+				container_port = 80
+			}
+			volume_mount {
+				name = "workdir"
+				mount_path = "/usr/share/nginx/html"
+			}
+		}
+		init_container {
+			name = "install"
+			image = "%s"
+			command = ["wget", "-O", "/work-dir/index.html", "http://kubernetes.io"]
+			volume_mount {
+				name = "workdir"
+				mount_path = "/work-dir"
+			}
+		}
+		dns_policy = "Default"
+		volume {
+			name = "workdir"
+			empty_dir {}
+		}
+	}
+}
+	`, podName, image)
 }
 
 func testAccKubernetesPodConfigWithSecurityContext(podName, imageName string) string {

--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -194,7 +194,7 @@ func volumeMountFields() map[string]*schema.Schema {
 	}
 }
 
-func containerFields(isUpdatable bool) map[string]*schema.Schema {
+func containerFields(isUpdatable, isInitContainer bool) map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"args": {
 			Type:        schema.TypeList,
@@ -477,8 +477,8 @@ func containerFields(isUpdatable bool) map[string]*schema.Schema {
 
 	if !isUpdatable {
 		for k, _ := range s {
-			if k == "image" {
-				// This field is always updatable
+			if k == "image" && !isInitContainer {
+				// this field is updatable for non-init containers
 				continue
 			}
 			s[k].ForceNew = true

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -17,7 +17,16 @@ func podSpecFields(isUpdatable bool) map[string]*schema.Schema {
 			Optional:    true,
 			Description: "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/containers",
 			Elem: &schema.Resource{
-				Schema: containerFields(isUpdatable),
+				Schema: containerFields(isUpdatable, false),
+			},
+		},
+		"init_container": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			ForceNew:    true,
+			Description: "List of init containers belonging to the pod. Init containers always run to completion and each must complete succesfully before the next is started. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
+			Elem: &schema.Resource{
+				Schema: containerFields(isUpdatable, true),
 			},
 		},
 		"dns_policy": {

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -14,11 +14,18 @@ func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
 	if in.ActiveDeadlineSeconds != nil {
 		att["active_deadline_seconds"] = *in.ActiveDeadlineSeconds
 	}
+
 	containers, err := flattenContainers(in.Containers)
 	if err != nil {
 		return nil, err
 	}
 	att["container"] = containers
+
+	initContainers, err := flattenContainers(in.InitContainers)
+	if err != nil {
+		return nil, err
+	}
+	att["init_container"] = initContainers
 
 	att["dns_policy"] = in.DNSPolicy
 
@@ -323,6 +330,14 @@ func expandPodSpec(p []interface{}) (v1.PodSpec, error) {
 			return obj, err
 		}
 		obj.Containers = cs
+	}
+
+	if v, ok := in["init_container"].([]interface{}); ok && len(v) > 0 {
+		cs, err := expandContainers(v)
+		if err != nil {
+			return obj, err
+		}
+		obj.InitContainers = cs
 	}
 
 	if v, ok := in["dns_policy"].(string); ok {

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -69,6 +69,7 @@ The following arguments are supported:
 
 * `active_deadline_seconds` - (Optional) Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
 * `container` - (Optional) List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/containers
+* `init_container` - (Optional) List of init containers belonging to the pod. Init containers always run to completion and each must complete succesfully before the next is started. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 * `dns_policy` - (Optional) Set DNS policy for containers within the pod. One of 'ClusterFirst' or 'Default'. Defaults to 'ClusterFirst'.
 * `host_ipc` - (Optional) Use the host's ipc namespace. Optional: Default to false.
 * `host_network` - (Optional) Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified.

--- a/website/docs/r/replication_controller.html.markdown
+++ b/website/docs/r/replication_controller.html.markdown
@@ -88,6 +88,7 @@ The following arguments are supported:
 
 * `active_deadline_seconds` - (Optional) Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
 * `container` - (Optional) List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/containers
+* `init_container` - (Optional) List of init containers belonging to the pod. Init containers always run to completion and each must complete succesfully before the next is started. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 * `dns_policy` - (Optional) Set DNS policy for containers within the pod. One of 'ClusterFirst' or 'Default'. Defaults to 'ClusterFirst'.
 * `host_ipc` - (Optional) Use the host's ipc namespace. Optional: Default to false.
 * `host_network` - (Optional) Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified.


### PR DESCRIPTION
Fix #61

Implement init containers. Docs and Api for K8s list it follows the exact same schema as a normal container but there are some subtle behavioural differences
>Init Containers support all the fields and features of app Containers, including resource limits, volumes, and security settings. However, the resource requests and limits for an Init Container are handled slightly differently, which are documented in Resources below. Also, Init Containers do not support readiness probes because they must run to completion before the Pod can be ready.

Please let me know if we want acceptance tests that try to validate those things or if we want special validations on the init_container schema. The path of least resistance was to just piggyback the `container` schema
```
make testacc TEST=./kubernetes TESTARGS='-run=TestAccKubernetesPod'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./kubernetes -v -run=TestAccKubernetesPod -timeout 120m
=== RUN   TestAccKubernetesPod_basic
--- PASS: TestAccKubernetesPod_basic (8.39s)
=== RUN   TestAccKubernetesPod_initContainer_updateForcesNew
--- PASS: TestAccKubernetesPod_initContainer_updateForcesNew (80.98s)
=== RUN   TestAccKubernetesPod_updateArgsForceNew
--- PASS: TestAccKubernetesPod_updateArgsForceNew (90.99s)
=== RUN   TestAccKubernetesPod_updateEnvForceNew
--- PASS: TestAccKubernetesPod_updateEnvForceNew (24.49s)
=== RUN   TestAccKubernetesPod_importBasic
--- PASS: TestAccKubernetesPod_importBasic (9.58s)
=== RUN   TestAccKubernetesPod_with_pod_security_context
--- PASS: TestAccKubernetesPod_with_pod_security_context (60.32s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_exec
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_exec (38.77s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_http_get
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_http_get (18.53s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_tcp
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_tcp (10.39s)
=== RUN   TestAccKubernetesPod_with_container_lifecycle
--- PASS: TestAccKubernetesPod_with_container_lifecycle (50.49s)
=== RUN   TestAccKubernetesPod_with_container_security_context
--- PASS: TestAccKubernetesPod_with_container_security_context (6.42s)
=== RUN   TestAccKubernetesPod_with_volume_mount
--- PASS: TestAccKubernetesPod_with_volume_mount (6.84s)
=== RUN   TestAccKubernetesPod_with_cfg_map_volume_mount
--- PASS: TestAccKubernetesPod_with_cfg_map_volume_mount (7.52s)
=== RUN   TestAccKubernetesPod_with_resource_requirements
--- PASS: TestAccKubernetesPod_with_resource_requirements (5.51s)
=== RUN   TestAccKubernetesPod_with_empty_dir_volume
--- PASS: TestAccKubernetesPod_with_empty_dir_volume (18.98s)
=== RUN   TestAccKubernetesPod_with_secret_vol_items
--- PASS: TestAccKubernetesPod_with_secret_vol_items (11.04s)
=== RUN   TestAccKubernetesPod_gke_with_nodeSelector
--- PASS: TestAccKubernetesPod_gke_with_nodeSelector (18.63s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	467.969s
```

UPDATE: I might need to test the updating behaviour
>A Pod can restart, causing re-execution of Init Containers, for the following reasons:
>A user updates the PodSpec causing the Init Container image to change. App Container image changes only restart the app Container.

FINAL NOTES:
As far as I can tell updates are not permitted to an init container's spec. I needed to ForceNew on the Pod if that is changed. Unfortunately just adding that attribute on the list `init_container` was not enough, it appears the `container` spec I was piggy backing allows changes to the `image` always, which does not hold true for InitContainers, so I introduced a new boolean in the spec functions to forceNew for init containers and added some acceptance checks that actually check the UID of the pod (as a method of proving if it remained the same or a new one was made).

@paddycarver if you could do a quick second check since I changed the code a decent amount since your last review that would be aweseome!