### PR TITLE
d/kubernetes_service: fix broken schema

### DIFF
--- a/kubernetes/data_source_kubernetes_service.go
+++ b/kubernetes/data_source_kubernetes_service.go
@@ -75,7 +75,7 @@ func dataSourceKubernetesService() *schema.Resource {
 										Computed:    true,
 									},
 									"target_port": {
-										Type:        schema.TypeInt,
+										Type:        schema.TypeString,
 										Description: "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. This field is ignored for services with `cluster_ip = \"None\"`. More info: http://kubernetes.io/docs/user-guide/services#defining-a-service",
 										Computed:    true,
 									},


### PR DESCRIPTION
switch target_port to string

This broke from another PR
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./kubernetes -v -run=TestAccKubernetesDataSourceService_basic -timeout 120m
=== RUN   TestAccKubernetesDataSourceService_basic
--- PASS: TestAccKubernetesDataSourceService_basic (1.26s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	1.355s
```