### PR TITLE
Updated example of providers block

### DIFF
--- a/website/docs/guides/getting-started.html.markdown
+++ b/website/docs/guides/getting-started.html.markdown
@@ -60,17 +60,26 @@ provider block completely empty.
 provider "kubernetes" {}
 ```
 
-If you wish to configure the provider statically you can do so
+If you wish to configure the provider statically you can do so by providing TLS certificates:
 
 ```hcl
 provider "kubernetes" {
-  host     = "https://104.196.242.174"
-  username = "ClusterMaster"
-  password = "MindTheGap"
+  host = "https://104.196.242.174"
 
   client_certificate     = "${file("~/.kube/client-cert.pem")}"
   client_key             = "${file("~/.kube/client-key.pem")}"
   cluster_ca_certificate = "${file("~/.kube/cluster-ca-cert.pem")}"
+}
+```
+
+or by providing username and password (HTTP Basic Authorization):
+
+```hcl
+provider "kubernetes" {
+  host = "https://104.196.242.174"
+
+  username = "ClusterMaster"
+  password = "MindTheGap"
 }
 ```
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -65,19 +65,30 @@ Read [more about `kubectl` in the official docs](https://kubernetes.io/docs/user
 
 ### Statically defined credentials
 
-The other way is **statically** define all the credentials:
+The other way is **statically** define TLS certificate credentials:
 
 ```hcl
 provider "kubernetes" {
-  host     = "https://104.196.242.174"
-  username = "ClusterMaster"
-  password = "MindTheGap"
+  host = "https://104.196.242.174"
 
   client_certificate     = "${file("~/.kube/client-cert.pem")}"
   client_key             = "${file("~/.kube/client-key.pem")}"
   cluster_ca_certificate = "${file("~/.kube/cluster-ca-cert.pem")}"
 }
 ```
+
+or username and password (HTTP Basic Authorization):
+
+```hcl
+provider "kubernetes" {
+  host = "https://104.196.242.174"
+
+  client_certificate     = "${file("~/.kube/client-cert.pem")}"
+  client_key             = "${file("~/.kube/client-key.pem")}"
+  cluster_ca_certificate = "${file("~/.kube/cluster-ca-cert.pem")}"
+}
+```
+
 
 If you have **both** valid configuration in a config file and static configuration, the static one is used as override.
 i.e. any static field will override its counterpart loaded from the config.


### PR DESCRIPTION
When having both of these section specified like this:

```hcl
provider "kubernetes" {
  host                   = "${azurerm_kubernetes_cluster.test.kube_config.0.host}"
  username               = "${azurerm_kubernetes_cluster.test.kube_config.0.username}"
  password               = "${azurerm_kubernetes_cluster.test.kube_config.0.password}"
  client_certificate     = "${base64decode(azurerm_kubernetes_cluster.test.kube_config.0.client_certificate)}"
  client_key             = "${base64decode(azurerm_kubernetes_cluster.test.kube_config.0.client_key)}"
  cluster_ca_certificate = "${base64decode(azurerm_kubernetes_cluster.test.kube_config.0.cluster_ca_certificate)}"
}
```

I get this error:
```
Error: Error refreshing state: 1 error(s) occurred:

* provider.kubernetes: Failed to configure: username/password or bearer token may be set, but not both
```

The error comes from here:
https://github.com/kubernetes/client-go/blob/8d6e3480fc03b7337a24f349d35733190655e2ad/transport/round_trippers.go#L45


```
$ terraform version
Terraform v0.11.7
+ provider.azurerm v1.7.0
+ provider.kubernetes v1.1.0
```