### PR TITLE
kubernetes/resource_kubernetes_persistent_volume: storage_class_name is now computed

### DIFF
--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -101,8 +101,9 @@ func resourceKubernetesPersistentVolume() *schema.Resource {
 						},
 						"storage_class_name": {
 							Type:        schema.TypeString,
-							Description: "A description of the persistent volume's class. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class",
+							Description: "The name of the persistent volume's storage class. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class",
 							Optional:    true,
+							Computed:    true,
 						},
 					},
 				},

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -19,6 +19,10 @@ func TestAccKubernetesPersistentVolume_googleCloud_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-test-%s", randString)
 	diskName := fmt.Sprintf("tf-acc-test-disk-%s", randString)
 
+	// By default, this is the name of the automatically created
+	// StorageClass in Kubernetes
+	defaultStorageClassName := "standard"
+
 	region := os.Getenv("GOOGLE_REGION")
 	zone := os.Getenv("GOOGLE_ZONE")
 
@@ -58,6 +62,7 @@ func TestAccKubernetesPersistentVolume_googleCloud_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.access_modes.1245328686", "ReadWriteOnce"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.gce_persistent_disk.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.persistent_volume_source.0.gce_persistent_disk.0.pd_name", diskName),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.storage_class_name", defaultStorageClassName),
 				),
 			},
 			{


### PR DESCRIPTION
Set 'storage_class_name' to be computed for the persistent volume
resource. The persistent volume claim resource does the same thing, so
this should mimic the behaviour in persistent volume claim.

Having one of the storage_class_name's be computed and the other not
causes issues when trying to create a persistent volume and persistent
volume claim, because if there is a StorageClass already created in
Kubernetes, that will be used for the persistent volume claim
storage_class_name, but the persistent volume will be created with an
empty storage_class_name and this fails because Kubernetes validates
that both storage_class_name is the same for both the persistent volume
and persistent volume claim.