### PR TITLE
Add  pod metadata to replication controller spec template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 
 * `resource/kubernetes_deployment`, `resource/kubernetes_pod`, `resource/kubernetes_replication_controller`, `resource/kubernetes_stateful_set`: Add `allow_privilege_escalation` to container security contexts attributes ([#249](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/249))
+* Add pod metadata to replication controller spec template ([#193](https://github.com/terraform-providers/terraform-provider-kubernetes/issues/193))
 
 BUG FIXES:
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ test: fmtcheck
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 300s
 
 vet:
 	@echo "go vet ."

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ test: fmtcheck
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 300s
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
 
 vet:
 	@echo "go vet ."

--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -172,7 +172,7 @@ func resourceKubernetesDeployment() *schema.Resource {
 										Required:    true,
 										MaxItems:    1,
 										Elem: &schema.Resource{
-											Schema: podSpecFields(true),
+											Schema: podSpecFields(true, false, false),
 										},
 									},
 								},

--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -38,7 +38,7 @@ func resourceKubernetesPod() *schema.Resource {
 				Required:    true,
 				MaxItems:    1,
 				Elem: &schema.Resource{
-					Schema: podSpecFields(false),
+					Schema: podSpecFields(false, false, false),
 				},
 			},
 		},

--- a/kubernetes/resource_kubernetes_replication_controller.go
+++ b/kubernetes/resource_kubernetes_replication_controller.go
@@ -63,7 +63,7 @@ func resourceKubernetesReplicationController() *schema.Resource {
 							Required:    true,
 							MaxItems:    1,
 							Elem: &schema.Resource{
-								Schema: podSpecFields(true),
+								Schema: replicationControllerTemplateFieldSpec(),
 							},
 						},
 					},
@@ -71,6 +71,33 @@ func resourceKubernetesReplicationController() *schema.Resource {
 			},
 		},
 	}
+}
+
+func replicationControllerTemplateFieldSpec() map[string]*schema.Schema {
+	metadata := namespacedMetadataSchema("replication controller's template", true)
+	// TODO: make this required once the legacy fields are removed
+	metadata.Required = false
+	metadata.Optional = true
+
+	templateFields := map[string]*schema.Schema{
+		"metadata": metadata,
+		"spec": {
+			Type:        schema.TypeList,
+			Description: "Spec of the pods managed by the replication controller",
+			Optional:    true, // TODO: make this required once the legacy fields are removed
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: podSpecFields(false, false, true),
+			},
+		},
+	}
+
+	// Merge deprecated fields
+	for k, v := range podSpecFields(true, true, true) {
+		templateFields[k] = v
+	}
+
+	return templateFields
 }
 
 func resourceKubernetesReplicationControllerCreate(d *schema.ResourceData, meta interface{}) error {

--- a/kubernetes/resource_kubernetes_replication_controller.go
+++ b/kubernetes/resource_kubernetes_replication_controller.go
@@ -105,7 +105,7 @@ func replicationControllerTemplateFieldSpec() map[string]*schema.Schema {
 
 func useDeprecatedSpecFields(d *schema.ResourceData) (deprecatedSpecFieldsExist bool) {
 	// Check which replication controller template spec fields are used
-	_, deprecatedSpecFieldsExist = d.GetOk("spec.0.template.0.container.0.name")
+	_, deprecatedSpecFieldsExist = d.GetOkExists("spec.0.template.0.container.0.name")
 	return
 }
 

--- a/kubernetes/resource_kubernetes_replication_controller.go
+++ b/kubernetes/resource_kubernetes_replication_controller.go
@@ -76,6 +76,7 @@ func resourceKubernetesReplicationController() *schema.Resource {
 func replicationControllerTemplateFieldSpec() map[string]*schema.Schema {
 	metadata := namespacedMetadataSchema("replication controller's template", true)
 	// TODO: make this required once the legacy fields are removed
+	metadata.Computed = true
 	metadata.Required = false
 	metadata.Optional = true
 
@@ -85,6 +86,7 @@ func replicationControllerTemplateFieldSpec() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Description: "Spec of the pods managed by the replication controller",
 			Optional:    true, // TODO: make this required once the legacy fields are removed
+			Computed:    true,
 			MaxItems:    1,
 			Elem: &schema.Resource{
 				Schema: podSpecFields(false, false, true),

--- a/kubernetes/resource_kubernetes_replication_controller.go
+++ b/kubernetes/resource_kubernetes_replication_controller.go
@@ -107,7 +107,11 @@ func resourceKubernetesReplicationControllerCreate(d *schema.ResourceData, meta 
 	conn := meta.(*kubernetes.Clientset)
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
-	spec, err := expandReplicationControllerSpec(d.Get("spec").([]interface{}))
+
+	// Check which replication controller template spec fields are used
+	_, deprecatedSpecFieldsExist := d.GetOkExists("spec.0.template.0.container.0.name")
+
+	spec, err := expandReplicationControllerSpec(d.Get("spec").([]interface{}), deprecatedSpecFieldsExist)
 	if err != nil {
 		return err
 	}
@@ -165,7 +169,10 @@ func resourceKubernetesReplicationControllerRead(d *schema.ResourceData, meta in
 		return err
 	}
 
-	spec, err := flattenReplicationControllerSpec(rc.Spec)
+	// Check which replication controller template spec fields are used
+	_, deprecatedSpecFieldsExist := d.GetOkExists("spec.0.template.0.container.0.name")
+
+	spec, err := flattenReplicationControllerSpec(rc.Spec, deprecatedSpecFieldsExist)
 	if err != nil {
 		return err
 	}
@@ -189,7 +196,10 @@ func resourceKubernetesReplicationControllerUpdate(d *schema.ResourceData, meta 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 
 	if d.HasChange("spec") {
-		spec, err := expandReplicationControllerSpec(d.Get("spec").([]interface{}))
+		// Check which replication controller template spec fields are used
+		_, deprecatedSpecFieldsExist := d.GetOkExists("spec.0.template.0.container.0.name")
+
+		spec, err := expandReplicationControllerSpec(d.Get("spec").([]interface{}), deprecatedSpecFieldsExist)
 		if err != nil {
 			return err
 		}

--- a/kubernetes/resource_kubernetes_replication_controller.go
+++ b/kubernetes/resource_kubernetes_replication_controller.go
@@ -94,8 +94,9 @@ func replicationControllerTemplateFieldSpec() map[string]*schema.Schema {
 		},
 	}
 
-	// Merge deprecated fields
+	// Merge deprecated fields and mark them conflicting with the ones to avoid complex mixed use-cases
 	for k, v := range podSpecFields(true, true, true) {
+		v.ConflictsWith = []string{"spec.0.template.0.spec"}
 		templateFields[k] = v
 	}
 

--- a/kubernetes/resource_kubernetes_replication_controller_deprecated_test.go
+++ b/kubernetes/resource_kubernetes_replication_controller_deprecated_test.go
@@ -108,10 +108,9 @@ func TestAccKubernetesReplicationController_deprecated_importBasic(t *testing.T)
 				Config: testAccKubernetesReplicationControllerConfig_deprecated_basic(name),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
 			},
 		},
 	})
@@ -160,10 +159,9 @@ func TestAccKubernetesReplicationController_deprecated_importGeneratedName(t *te
 				Config: testAccKubernetesReplicationControllerConfig_deprecated_generatedName(prefix),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
 			},
 		},
 	})

--- a/kubernetes/resource_kubernetes_replication_controller_deprecated_test.go
+++ b/kubernetes/resource_kubernetes_replication_controller_deprecated_test.go
@@ -157,7 +157,7 @@ func TestAccKubernetesReplicationController_deprecated_importGeneratedName(t *te
 		CheckDestroy: testAccCheckKubernetesReplicationControllerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesReplicationControllerConfig_generatedName(prefix),
+				Config: testAccKubernetesReplicationControllerConfig_deprecated_generatedName(prefix),
 			},
 			{
 				ResourceName:            resourceName,

--- a/kubernetes/resource_kubernetes_replication_controller_deprecated_test.go
+++ b/kubernetes/resource_kubernetes_replication_controller_deprecated_test.go
@@ -420,20 +420,25 @@ resource "kubernetes_replication_controller" "test" {
       TestAnnotationOne = "one"
       TestAnnotationTwo = "two"
     }
+
     labels {
-      TestLabelOne = "one"
-      TestLabelTwo = "two"
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
       TestLabelThree = "three"
     }
+
     name = "%s"
   }
+
   spec {
     replicas = 1000 # This is intentionally high to exercise the waiter
+
     selector {
-      TestLabelOne = "one"
-      TestLabelTwo = "two"
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
       TestLabelThree = "three"
     }
+
     template {
       container {
         image = "nginx:1.7.8"

--- a/kubernetes/resource_kubernetes_replication_controller_deprecated_test.go
+++ b/kubernetes/resource_kubernetes_replication_controller_deprecated_test.go
@@ -1,0 +1,884 @@
+package kubernetes
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	api "k8s.io/api/core/v1"
+)
+
+func TestAccKubernetesReplicationController_deprecated_basic(t *testing.T) {
+	var conf api.ReplicationController
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "kubernetes_replication_controller.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesReplicationControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesReplicationControllerConfig_deprecated_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "metadata.0.annotations.%", "2"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "metadata.0.annotations.TestAnnotationOne", "one"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "metadata.0.annotations.TestAnnotationTwo", "two"),
+					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{"TestAnnotationOne": "one", "TestAnnotationTwo": "two"}),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "metadata.0.labels.%", "3"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "metadata.0.labels.TestLabelOne", "one"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "metadata.0.labels.TestLabelTwo", "two"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "metadata.0.labels.TestLabelThree", "three"),
+					testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{"TestLabelOne": "one", "TestLabelTwo": "two", "TestLabelThree": "three"}),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.image", "nginx:1.7.8"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.name", "tf-acc-test"),
+				),
+			},
+			{
+				Config: testAccKubernetesReplicationControllerConfig_deprecated_modified(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "metadata.0.annotations.%", "2"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "metadata.0.annotations.TestAnnotationOne", "one"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "metadata.0.annotations.Different", "1234"),
+					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{"TestAnnotationOne": "one", "Different": "1234"}),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "metadata.0.labels.%", "2"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "metadata.0.labels.TestLabelOne", "one"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "metadata.0.labels.TestLabelThree", "three"),
+					testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{"TestLabelOne": "one", "TestLabelThree": "three"}),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.image", "nginx:1.7.9"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.name", "tf-acc-test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesReplicationController_deprecated_initContainer(t *testing.T) {
+	var conf api.ReplicationController
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "kubernetes_replication_controller.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesReplicationControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesReplicationControllerConfig_deprecated_initContainer(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.init_container.0.image", "busybox"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.init_container.0.name", "install"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.init_container.0.command.0", "wget"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.init_container.0.command.1", "-O"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.init_container.0.command.2", "/work-dir/index.html"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.init_container.0.command.3", "http://kubernetes.io"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.init_container.0.volume_mount.0.name", "workdir"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.init_container.0.volume_mount.0.mount_path", "/work-dir"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesReplicationController_deprecated_importBasic(t *testing.T) {
+	resourceName := "kubernetes_replication_controller.test"
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesReplicationControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesReplicationControllerConfig_deprecated_basic(name),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+			},
+		},
+	})
+}
+
+func TestAccKubernetesReplicationController_deprecated_generatedName(t *testing.T) {
+	var conf api.ReplicationController
+	prefix := "tf-acc-test-gen-"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "kubernetes_replication_controller.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesReplicationControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesReplicationControllerConfig_deprecated_generatedName(prefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "metadata.0.annotations.%", "0"),
+					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{}),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "metadata.0.labels.%", "3"),
+					testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{"TestLabelOne": "one", "TestLabelTwo": "two", "TestLabelThree": "three"}),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "metadata.0.generate_name", prefix),
+					resource.TestMatchResourceAttr("kubernetes_replication_controller.test", "metadata.0.name", regexp.MustCompile("^"+prefix)),
+					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.uid"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesReplicationController_deprecated_importGeneratedName(t *testing.T) {
+	resourceName := "kubernetes_replication_controller.test"
+	prefix := "tf-acc-test-gen-import-"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesReplicationControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesReplicationControllerConfig_generatedName(prefix),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version"},
+			},
+		},
+	})
+}
+
+func TestAccKubernetesReplicationController_deprecated_with_security_context(t *testing.T) {
+	var conf api.ReplicationController
+
+	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := "nginx:1.7.9"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesReplicationControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesReplicationControllerConfig_deprecated_WithSecurityContext(rcName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.security_context.0.fs_group", "100"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.security_context.0.run_as_non_root", "true"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.security_context.0.run_as_user", "101"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.security_context.0.supplemental_groups.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.security_context.0.supplemental_groups.988695518", "101"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesReplicationController_deprecated_with_container_liveness_probe_using_exec(t *testing.T) {
+	var conf api.ReplicationController
+
+	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := "gcr.io/google_containers/busybox"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesReplicationControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesReplicationControllerConfig_deprecated_WithLivenessProbeUsingExec(rcName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.args.#", "3"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.exec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.exec.0.command.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.exec.0.command.0", "cat"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.exec.0.command.1", "/tmp/healthy"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.failure_threshold", "3"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.initial_delay_seconds", "5"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesReplicationController_deprecated_with_container_liveness_probe_using_http_get(t *testing.T) {
+	var conf api.ReplicationController
+
+	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := "gcr.io/google_containers/liveness"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesReplicationControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesReplicationControllerConfig_deprecated_WithLivenessProbeUsingHTTPGet(rcName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.args.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.http_get.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.http_get.0.path", "/healthz"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.http_get.0.port", "8080"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.http_get.0.http_header.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.http_get.0.http_header.0.name", "X-Custom-Header"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.http_get.0.http_header.0.value", "Awesome"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.initial_delay_seconds", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesReplicationController_deprecated_with_container_liveness_probe_using_tcp(t *testing.T) {
+	var conf api.ReplicationController
+
+	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := "gcr.io/google_containers/liveness"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesReplicationControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesReplicationControllerConfig_deprecated_WithLivenessProbeUsingTCP(rcName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.args.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.tcp_socket.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.tcp_socket.0.port", "8080"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesReplicationController_deprecated_with_container_lifecycle(t *testing.T) {
+	var conf api.ReplicationController
+
+	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := "gcr.io/google_containers/liveness"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesReplicationControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesReplicationControllerConfig_deprecated_WithLifeCycle(rcName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.0.post_start.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.0.post_start.0.exec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.0.post_start.0.exec.0.command.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.0.post_start.0.exec.0.command.0", "ls"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.0.post_start.0.exec.0.command.1", "-al"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.0.pre_stop.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.0.pre_stop.0.exec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.0.pre_stop.0.exec.0.command.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.0.pre_stop.0.exec.0.command.0", "date"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesReplicationController_deprecated_with_container_security_context(t *testing.T) {
+	var conf api.ReplicationController
+
+	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := "nginx:1.7.9"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesReplicationControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesReplicationControllerConfig_deprecated_WithContainerSecurityContext(rcName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.security_context.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesReplicationController_deprecated_with_volume_mount(t *testing.T) {
+	var conf api.ReplicationController
+
+	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	secretName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	imageName := "nginx:1.7.9"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesReplicationControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesReplicationControllerConfig_deprecated_WithVolumeMounts(secretName, rcName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.image", imageName),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.volume_mount.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.volume_mount.0.mount_path", "/tmp/my_path"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.volume_mount.0.name", "db"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.volume_mount.0.read_only", "false"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.volume_mount.0.sub_path", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesReplicationController_deprecated_with_resource_requirements(t *testing.T) {
+	var conf api.ReplicationController
+
+	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	imageName := "nginx:1.7.9"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesReplicationControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesReplicationControllerConfig_deprecated_WithResourceRequirements(rcName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.image", imageName),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.resources.0.requests.0.memory", "50Mi"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.resources.0.requests.0.cpu", "250m"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.resources.0.limits.0.memory", "512Mi"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.resources.0.limits.0.cpu", "500m"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesReplicationController_deprecated_with_empty_dir_volume(t *testing.T) {
+	var conf api.ReplicationController
+
+	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := "nginx:1.7.9"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesReplicationControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesReplicationControllerConfig_deprecated_WithEmptyDirVolumes(rcName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.image", imageName),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.volume_mount.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.volume_mount.0.mount_path", "/cache"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.volume_mount.0.name", "cache-volume"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.volume.0.empty_dir.0.medium", "Memory"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKubernetesReplicationControllerConfig_deprecated_basic(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_replication_controller" "test" {
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+    labels {
+      TestLabelOne = "one"
+      TestLabelTwo = "two"
+      TestLabelThree = "three"
+    }
+    name = "%s"
+  }
+  spec {
+    replicas = 1000 # This is intentionally high to exercise the waiter
+    selector {
+      TestLabelOne = "one"
+      TestLabelTwo = "two"
+      TestLabelThree = "three"
+    }
+    template {
+      container {
+        image = "nginx:1.7.8"
+        name  = "tf-acc-test"
+      }
+    }
+  }
+}
+`, name)
+}
+
+func testAccKubernetesReplicationControllerConfig_deprecated_initContainer(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_replication_controller" "test" {
+	metadata {
+		annotations {
+			TestAnnotationOne = "one"
+			TestAnnotationTwo = "two"
+		}
+		labels {
+			TestLabelOne = "one"
+			TestLabelTwo = "two"
+			TestLabelThree = "three"
+		}
+		name = "%s"
+	}
+	spec {
+		replicas = 1000 # This is intentionally high to exercise the waiter
+		selector {
+			TestLabelOne = "one"
+			TestLabelTwo = "two"
+			TestLabelThree = "three"
+		}
+		template {
+			container {
+				name = "nginx"
+				image = "nginx"
+				port {
+					container_port = 80
+				}
+				volume_mount {
+					name = "workdir"
+					mount_path = "/usr/share/nginx/html"
+				}
+			}
+			init_container {
+				name = "install"
+				image = "busybox"
+				command = ["wget", "-O", "/work-dir/index.html", "http://kubernetes.io"]
+				volume_mount {
+					name = "workdir"
+					mount_path = "/work-dir"
+				}
+			}
+			dns_policy = "Default"
+			volume {
+				name = "workdir"
+				empty_dir {}
+			}
+		}
+	}
+}`, name)
+}
+
+func testAccKubernetesReplicationControllerConfig_deprecated_modified(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_replication_controller" "test" {
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      Different = "1234"
+    }
+    labels {
+      TestLabelOne = "one"
+      TestLabelThree = "three"
+    }
+    name = "%s"
+  }
+  spec {
+    selector {
+      TestLabelOne = "one"
+      TestLabelTwo = "two"
+      TestLabelThree = "three"
+    }
+    template {
+      container {
+        image = "nginx:1.7.9"
+        name  = "tf-acc-test"
+      }
+    }
+  }
+}`, name)
+}
+
+func testAccKubernetesReplicationControllerConfig_deprecated_generatedName(prefix string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_replication_controller" "test" {
+  metadata {
+    labels {
+      TestLabelOne = "one"
+      TestLabelTwo = "two"
+      TestLabelThree = "three"
+    }
+    generate_name = "%s"
+  }
+  spec {
+    selector {
+      TestLabelOne = "one"
+      TestLabelTwo = "two"
+      TestLabelThree = "three"
+    }
+    template {
+      container {
+        image = "nginx:1.7.9"
+        name  = "tf-acc-test"
+      }
+    }
+  }
+}`, prefix)
+}
+
+func testAccKubernetesReplicationControllerConfig_deprecated_WithSecurityContext(rcName, imageName string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_replication_controller" "test" {
+  metadata {
+    name = "%s"
+    labels {
+      Test = "TfAcceptanceTest"
+    }
+  }
+  spec {
+    selector {
+      Test = "TfAcceptanceTest"
+    }
+    template {
+      security_context {
+        fs_group            = 100
+        run_as_non_root     = true
+        run_as_user         = 101
+        supplemental_groups = [101]
+      }
+      container {
+        image = "%s"
+        name  = "containername"
+      }
+    }
+  }
+}
+	`, rcName, imageName)
+}
+
+func testAccKubernetesReplicationControllerConfig_deprecated_WithLivenessProbeUsingExec(rcName, imageName string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_replication_controller" "test" {
+  metadata {
+    name = "%s"
+    labels {
+      Test = "TfAcceptanceTest"
+    }
+  }
+  spec {
+    selector {
+      Test = "TfAcceptanceTest"
+    }
+    template {
+      container {
+        image = "%s"
+        name  = "containername"
+        args  = ["/bin/sh", "-c", "touch /tmp/healthy; sleep 300; rm -rf /tmp/healthy; sleep 600"]
+
+        liveness_probe {
+          exec {
+            command = ["cat", "/tmp/healthy"]
+          }
+
+          initial_delay_seconds = 5
+          period_seconds        = 5
+        }
+      }
+    }
+  }
+}
+	`, rcName, imageName)
+}
+
+func testAccKubernetesReplicationControllerConfig_deprecated_WithLivenessProbeUsingHTTPGet(rcName, imageName string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_replication_controller" "test" {
+  metadata {
+    name = "%s"
+    labels {
+      Test = "TfAcceptanceTest"
+    }
+  }
+  spec {
+    selector {
+      Test = "TfAcceptanceTest"
+    }
+    template {
+      container {
+        image = "%s"
+        name  = "containername"
+        args  = ["/server"]
+
+        liveness_probe {
+          http_get {
+            path = "/healthz"
+            port = 8080
+
+            http_header {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    }
+  }
+}
+	`, rcName, imageName)
+}
+
+func testAccKubernetesReplicationControllerConfig_deprecated_WithLivenessProbeUsingTCP(rcName, imageName string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_replication_controller" "test" {
+  metadata {
+    name = "%s"
+    labels {
+      Test = "TfAcceptanceTest"
+    }
+  }
+  spec {
+    selector {
+      Test = "TfAcceptanceTest"
+    }
+    template {
+      container {
+        image = "%s"
+        name  = "containername"
+        args  = ["/server"]
+
+        liveness_probe {
+          tcp_socket {
+            port = 8080
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    }
+  }
+}
+	`, rcName, imageName)
+}
+
+func testAccKubernetesReplicationControllerConfig_deprecated_WithLifeCycle(rcName, imageName string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_replication_controller" "test" {
+  metadata {
+    name = "%s"
+    labels {
+      Test = "TfAcceptanceTest"
+    }
+  }
+  spec {
+    selector {
+      Test = "TfAcceptanceTest"
+    }
+    template {
+      container {
+        image = "%s"
+        name  = "containername"
+        args  = ["/server"]
+
+        lifecycle {
+          post_start {
+            exec {
+              command = ["ls", "-al"]
+            }
+          }
+          pre_stop {
+            exec {
+              command = ["date"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+	`, rcName, imageName)
+}
+
+func testAccKubernetesReplicationControllerConfig_deprecated_WithContainerSecurityContext(rcName, imageName string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_replication_controller" "test" {
+  metadata {
+    name = "%s"
+    labels {
+      Test = "TfAcceptanceTest"
+    }
+  }
+  spec {
+    selector {
+      Test = "TfAcceptanceTest"
+    }
+    template {
+      container {
+        image = "%s"
+        name  = "containername"
+  
+        security_context {
+          privileged  = true
+          run_as_user = 1
+          se_linux_options {
+            level = "s0:c123,c456"
+          }
+        }
+      }
+    }
+  }
+}
+
+
+	`, rcName, imageName)
+}
+
+func testAccKubernetesReplicationControllerConfig_deprecated_WithVolumeMounts(secretName, rcName, imageName string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_secret" "test" {
+  metadata {
+    name = "%s"
+  }
+
+  data {
+    one = "first"
+  }
+}
+
+resource "kubernetes_replication_controller" "test" {
+  metadata {
+    name = "%s"
+    labels {
+      Test = "TfAcceptanceTest"
+    }
+  }
+
+  spec {
+    selector {
+      Test = "TfAcceptanceTest"
+    }
+  	template {
+      container {
+        image = "%s"
+        name  = "containername"
+        volume_mount {
+          mount_path = "/tmp/my_path"
+          name  = "db"
+        }
+      }
+      volume {
+        name = "db"
+        secret = {
+          secret_name = "${kubernetes_secret.test.metadata.0.name}"
+        }
+      }
+    }
+  }
+}
+	`, secretName, rcName, imageName)
+}
+
+func testAccKubernetesReplicationControllerConfig_deprecated_WithResourceRequirements(rcName, imageName string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_replication_controller" "test" {
+  metadata {
+    name = "%s"
+    labels {
+      Test = "TfAcceptanceTest"
+    }
+  }
+
+  spec {
+    selector {
+      Test = "TfAcceptanceTest"
+    }
+  	template {
+      container {
+        image = "%s"
+        name  = "containername"
+
+        resources{
+          limits{
+            cpu = "0.5"
+            memory = "512Mi"
+          }
+          requests{
+            cpu = "250m"
+            memory = "50Mi"
+          }
+        }
+      }
+    }
+  }
+}
+	`, rcName, imageName)
+}
+
+func testAccKubernetesReplicationControllerConfig_deprecated_WithEmptyDirVolumes(rcName, imageName string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_replication_controller" "test" {
+  metadata {
+    name = "%s"
+    labels {
+      Test = "TfAcceptanceTest"
+    }
+  }
+
+  spec {
+    selector {
+      Test = "TfAcceptanceTest"
+    }
+    template {
+      container {
+        image = "%s"
+        name  = "containername"
+        volume_mount {
+          mount_path =  "/cache"
+          name = "cache-volume"
+        }
+      }
+      volume {
+        name = "cache-volume"
+        empty_dir = {
+          medium = "Memory"
+        }
+      }
+    }
+  }
+}
+`, rcName, imageName)
+}

--- a/kubernetes/resource_kubernetes_replication_controller_test.go
+++ b/kubernetes/resource_kubernetes_replication_controller_test.go
@@ -43,6 +43,8 @@ func TestAccKubernetesReplicationController_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.image", "nginx:1.7.8"),
 					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.name", "tf-acc-test"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.metadata.0.annotations.%", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.metadata.0.annotations.TestAnnotationFive", "five"),
 				),
 			},
 			{
@@ -64,6 +66,8 @@ func TestAccKubernetesReplicationController_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.image", "nginx:1.7.9"),
 					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.name", "tf-acc-test"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.metadata.0.annotations.%", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.metadata.0.annotations.TestAnnotationSix", "six"),
 				),
 			},
 		},
@@ -493,6 +497,17 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
+      metadata {
+        labels {
+          TestLabelOne   = "one"
+          TestLabelTwo   = "two"
+          TestLabelThree = "three"
+        }
+
+        annotations {
+          TestAnnotationFive = "five"
+        }
+      }
       spec {
         container {
           image = "nginx:1.7.8"
@@ -533,6 +548,13 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
+      metadata {
+        labels {
+          TestLabelOne   = "one"
+          TestLabelTwo   = "two"
+          TestLabelThree = "three"
+        }
+      }
       spec {
         container {
           name  = "nginx"
@@ -597,6 +619,17 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
+      metadata {
+        labels {
+          TestLabelOne   = "one"
+          TestLabelTwo   = "two"
+          TestLabelThree = "three"
+        }
+
+        annotations {
+          TestAnnotationSix = "six"
+        }
+      }
       spec {
         container {
           image = "nginx:1.7.9"
@@ -630,6 +663,14 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
+      metadata {
+        labels {
+          TestLabelOne   = "one"
+          TestLabelTwo   = "two"
+          TestLabelThree = "three"
+        }
+      }
+
       spec {
         container {
           image = "nginx:1.7.9"
@@ -659,6 +700,12 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
+      metadata {
+        labels {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
       spec {
         security_context {
           fs_group            = 100
@@ -695,6 +742,12 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
+      metadata {
+        labels {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
       spec {
         container {
           image = "%s"
@@ -734,6 +787,12 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
+      metadata {
+        labels {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
       spec {
         container {
           image = "%s"
@@ -779,6 +838,12 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
+      metadata {
+        labels {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
       spec {
         container {
           image = "%s"
@@ -818,6 +883,12 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
+      metadata {
+        labels {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
       spec {
         container {
           image = "%s"
@@ -862,6 +933,12 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
+      metadata {
+        labels {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
       spec {
         container {
           image = "%s"
@@ -910,6 +987,12 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
+      metadata {
+        labels {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
       spec {
         container {
           image = "%s"
@@ -952,6 +1035,12 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
+      metadata {
+        labels {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
       spec {
         container {
           image = "%s"
@@ -993,6 +1082,12 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
+      metadata {
+        labels {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
       spec {
         container {
           image = "%s"

--- a/kubernetes/resource_kubernetes_replication_controller_test.go
+++ b/kubernetes/resource_kubernetes_replication_controller_test.go
@@ -41,8 +41,8 @@ func TestAccKubernetesReplicationController_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.uid"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.image", "nginx:1.7.8"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.name", "tf-acc-test"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.image", "nginx:1.7.8"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.name", "tf-acc-test"),
 				),
 			},
 			{
@@ -62,8 +62,8 @@ func TestAccKubernetesReplicationController_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_replication_controller.test", "metadata.0.uid"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.image", "nginx:1.7.9"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.name", "tf-acc-test"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.image", "nginx:1.7.9"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.name", "tf-acc-test"),
 				),
 			},
 		},
@@ -84,14 +84,14 @@ func TestAccKubernetesReplicationController_initContainer(t *testing.T) {
 				Config: testAccKubernetesReplicationControllerConfig_initContainer(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.init_container.0.image", "busybox"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.init_container.0.name", "install"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.init_container.0.command.0", "wget"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.init_container.0.command.1", "-O"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.init_container.0.command.2", "/work-dir/index.html"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.init_container.0.command.3", "http://kubernetes.io"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.init_container.0.volume_mount.0.name", "workdir"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.init_container.0.volume_mount.0.mount_path", "/work-dir"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.init_container.0.image", "busybox"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.init_container.0.name", "install"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.init_container.0.command.0", "wget"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.init_container.0.command.1", "-O"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.init_container.0.command.2", "/work-dir/index.html"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.init_container.0.command.3", "http://kubernetes.io"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.init_container.0.volume_mount.0.name", "workdir"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.init_container.0.volume_mount.0.mount_path", "/work-dir"),
 				),
 			},
 		},
@@ -187,11 +187,11 @@ func TestAccKubernetesReplicationController_with_security_context(t *testing.T) 
 				Config: testAccKubernetesReplicationControllerConfigWithSecurityContext(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.security_context.0.fs_group", "100"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.security_context.0.run_as_non_root", "true"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.security_context.0.run_as_user", "101"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.security_context.0.supplemental_groups.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.security_context.0.supplemental_groups.988695518", "101"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.security_context.0.fs_group", "100"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.security_context.0.run_as_non_root", "true"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.security_context.0.run_as_user", "101"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.security_context.0.supplemental_groups.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.security_context.0.supplemental_groups.988695518", "101"),
 				),
 			},
 		},
@@ -213,14 +213,14 @@ func TestAccKubernetesReplicationController_with_container_liveness_probe_using_
 				Config: testAccKubernetesReplicationControllerConfigWithLivenessProbeUsingExec(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.args.#", "3"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.exec.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.exec.0.command.#", "2"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.exec.0.command.0", "cat"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.exec.0.command.1", "/tmp/healthy"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.failure_threshold", "3"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.initial_delay_seconds", "5"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.args.#", "3"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.liveness_probe.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.exec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.exec.0.command.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.exec.0.command.0", "cat"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.exec.0.command.1", "/tmp/healthy"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.failure_threshold", "3"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.initial_delay_seconds", "5"),
 				),
 			},
 		},
@@ -242,15 +242,15 @@ func TestAccKubernetesReplicationController_with_container_liveness_probe_using_
 				Config: testAccKubernetesReplicationControllerConfigWithLivenessProbeUsingHTTPGet(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.args.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.http_get.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.http_get.0.path", "/healthz"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.http_get.0.port", "8080"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.http_get.0.http_header.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.http_get.0.http_header.0.name", "X-Custom-Header"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.http_get.0.http_header.0.value", "Awesome"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.initial_delay_seconds", "3"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.args.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.liveness_probe.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.http_get.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.http_get.0.path", "/healthz"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.http_get.0.port", "8080"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.http_get.0.http_header.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.http_get.0.http_header.0.name", "X-Custom-Header"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.http_get.0.http_header.0.value", "Awesome"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.initial_delay_seconds", "3"),
 				),
 			},
 		},
@@ -272,10 +272,10 @@ func TestAccKubernetesReplicationController_with_container_liveness_probe_using_
 				Config: testAccKubernetesReplicationControllerConfigWithLivenessProbeUsingTCP(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.args.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.tcp_socket.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.liveness_probe.0.tcp_socket.0.port", "8080"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.args.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.liveness_probe.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.tcp_socket.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.tcp_socket.0.port", "8080"),
 				),
 			},
 		},
@@ -297,16 +297,16 @@ func TestAccKubernetesReplicationController_with_container_lifecycle(t *testing.
 				Config: testAccKubernetesReplicationControllerConfigWithLifeCycle(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.0.post_start.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.0.post_start.0.exec.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.0.post_start.0.exec.0.command.#", "2"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.0.post_start.0.exec.0.command.0", "ls"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.0.post_start.0.exec.0.command.1", "-al"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.0.pre_stop.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.0.pre_stop.0.exec.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.0.pre_stop.0.exec.0.command.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.lifecycle.0.pre_stop.0.exec.0.command.0", "date"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.lifecycle.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.lifecycle.0.post_start.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.lifecycle.0.post_start.0.exec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.lifecycle.0.post_start.0.exec.0.command.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.lifecycle.0.post_start.0.exec.0.command.0", "ls"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.lifecycle.0.post_start.0.exec.0.command.1", "-al"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.lifecycle.0.pre_stop.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.lifecycle.0.pre_stop.0.exec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.lifecycle.0.pre_stop.0.exec.0.command.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.lifecycle.0.pre_stop.0.exec.0.command.0", "date"),
 				),
 			},
 		},
@@ -328,7 +328,7 @@ func TestAccKubernetesReplicationController_with_container_security_context(t *t
 				Config: testAccKubernetesReplicationControllerConfigWithContainerSecurityContext(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.security_context.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.security_context.#", "1"),
 				),
 			},
 		},
@@ -352,12 +352,12 @@ func TestAccKubernetesReplicationController_with_volume_mount(t *testing.T) {
 				Config: testAccKubernetesReplicationControllerConfigWithVolumeMounts(secretName, rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.image", imageName),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.volume_mount.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.volume_mount.0.mount_path", "/tmp/my_path"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.volume_mount.0.name", "db"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.volume_mount.0.read_only", "false"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.volume_mount.0.sub_path", ""),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.image", imageName),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.volume_mount.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.volume_mount.0.mount_path", "/tmp/my_path"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.volume_mount.0.name", "db"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.volume_mount.0.read_only", "false"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.volume_mount.0.sub_path", ""),
 				),
 			},
 		},
@@ -380,11 +380,11 @@ func TestAccKubernetesReplicationController_with_resource_requirements(t *testin
 				Config: testAccKubernetesReplicationControllerConfigWithResourceRequirements(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.image", imageName),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.resources.0.requests.0.memory", "50Mi"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.resources.0.requests.0.cpu", "250m"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.resources.0.limits.0.memory", "512Mi"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.resources.0.limits.0.cpu", "500m"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.image", imageName),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.resources.0.requests.0.memory", "50Mi"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.resources.0.requests.0.cpu", "250m"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.resources.0.limits.0.memory", "512Mi"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.resources.0.limits.0.cpu", "500m"),
 				),
 			},
 		},
@@ -406,11 +406,11 @@ func TestAccKubernetesReplicationController_with_empty_dir_volume(t *testing.T) 
 				Config: testAccKubernetesReplicationControllerConfigWithEmptyDirVolumes(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.image", imageName),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.volume_mount.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.volume_mount.0.mount_path", "/cache"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.volume_mount.0.name", "cache-volume"),
-					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.volume.0.empty_dir.0.medium", "Memory"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.image", imageName),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.volume_mount.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.volume_mount.0.mount_path", "/cache"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.container.0.volume_mount.0.name", "cache-volume"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.spec.0.volume.0.empty_dir.0.medium", "Memory"),
 				),
 			},
 		},
@@ -493,9 +493,11 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
-      container {
-        image = "nginx:1.7.8"
-        name  = "tf-acc-test"
+      spec {
+        container {
+          image = "nginx:1.7.8"
+          name  = "tf-acc-test"
+        }
       }
     }
   }
@@ -531,36 +533,38 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
-      container {
-        name  = "nginx"
-        image = "nginx"
+      spec {
+        container {
+          name  = "nginx"
+          image = "nginx"
 
-        port {
-          container_port = 80
+          port {
+            container_port = 80
+          }
+
+          volume_mount {
+            name       = "workdir"
+            mount_path = "/usr/share/nginx/html"
+          }
         }
 
-        volume_mount {
-          name       = "workdir"
-          mount_path = "/usr/share/nginx/html"
+        init_container {
+          name    = "install"
+          image   = "busybox"
+          command = ["wget", "-O", "/work-dir/index.html", "http://kubernetes.io"]
+
+          volume_mount {
+            name       = "workdir"
+            mount_path = "/work-dir"
+          }
         }
-      }
 
-      init_container {
-        name    = "install"
-        image   = "busybox"
-        command = ["wget", "-O", "/work-dir/index.html", "http://kubernetes.io"]
+        dns_policy = "Default"
 
-        volume_mount {
-          name       = "workdir"
-          mount_path = "/work-dir"
+        volume {
+          name      = "workdir"
+          empty_dir = {}
         }
-      }
-
-      dns_policy = "Default"
-
-      volume {
-        name      = "workdir"
-        empty_dir = {}
       }
     }
   }
@@ -593,9 +597,11 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
-      container {
-        image = "nginx:1.7.9"
-        name  = "tf-acc-test"
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "tf-acc-test"
+        }
       }
     }
   }
@@ -624,9 +630,11 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
-      container {
-        image = "nginx:1.7.9"
-        name  = "tf-acc-test"
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "tf-acc-test"
+        }
       }
     }
   }
@@ -651,16 +659,18 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
-      security_context {
-        fs_group            = 100
-        run_as_non_root     = true
-        run_as_user         = 101
-        supplemental_groups = [101]
-      }
+      spec {
+        security_context {
+          fs_group            = 100
+          run_as_non_root     = true
+          run_as_user         = 101
+          supplemental_groups = [101]
+        }
 
-      container {
-        image = "%s"
-        name  = "containername"
+        container {
+          image = "%s"
+          name  = "containername"
+        }
       }
     }
   }
@@ -685,18 +695,20 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
-      container {
-        image = "%s"
-        name  = "containername"
-        args  = ["/bin/sh", "-c", "touch /tmp/healthy; sleep 300; rm -rf /tmp/healthy; sleep 600"]
+      spec {
+        container {
+          image = "%s"
+          name  = "containername"
+          args  = ["/bin/sh", "-c", "touch /tmp/healthy; sleep 300; rm -rf /tmp/healthy; sleep 600"]
 
-        liveness_probe {
-          exec {
-            command = ["cat", "/tmp/healthy"]
+          liveness_probe {
+            exec {
+              command = ["cat", "/tmp/healthy"]
+            }
+
+            initial_delay_seconds = 5
+            period_seconds        = 5
           }
-
-          initial_delay_seconds = 5
-          period_seconds        = 5
         }
       }
     }
@@ -722,24 +734,26 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
-      container {
-        image = "%s"
-        name  = "containername"
-        args  = ["/server"]
+      spec {
+        container {
+          image = "%s"
+          name  = "containername"
+          args  = ["/server"]
 
-        liveness_probe {
-          http_get {
-            path = "/healthz"
-            port = 8080
+          liveness_probe {
+            http_get {
+              path = "/healthz"
+              port = 8080
 
-            http_header {
-              name  = "X-Custom-Header"
-              value = "Awesome"
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
             }
-          }
 
-          initial_delay_seconds = 3
-          period_seconds        = 3
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
         }
       }
     }
@@ -765,18 +779,20 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
-      container {
-        image = "%s"
-        name  = "containername"
-        args  = ["/server"]
+      spec {
+        container {
+          image = "%s"
+          name  = "containername"
+          args  = ["/server"]
 
-        liveness_probe {
-          tcp_socket {
-            port = 8080
+          liveness_probe {
+            tcp_socket {
+              port = 8080
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
           }
-
-          initial_delay_seconds = 3
-          period_seconds        = 3
         }
       }
     }
@@ -802,21 +818,23 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
-      container {
-        image = "%s"
-        name  = "containername"
-        args  = ["/server"]
+      spec {
+        container {
+          image = "%s"
+          name  = "containername"
+          args  = ["/server"]
 
-        lifecycle {
-          post_start {
-            exec {
-              command = ["ls", "-al"]
+          lifecycle {
+            post_start {
+              exec {
+                command = ["ls", "-al"]
+              }
             }
-          }
 
-          pre_stop {
-            exec {
-              command = ["date"]
+            pre_stop {
+              exec {
+                command = ["date"]
+              }
             }
           }
         }
@@ -844,16 +862,18 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
-      container {
-        image = "%s"
-        name  = "containername"
+      spec {
+        container {
+          image = "%s"
+          name  = "containername"
 
-        security_context {
-          privileged  = true
-          run_as_user = 1
+          security_context {
+            privileged  = true
+            run_as_user = 1
 
-          se_linux_options {
-            level = "s0:c123,c456"
+            se_linux_options {
+              level = "s0:c123,c456"
+            }
           }
         }
       }
@@ -890,21 +910,23 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
-      container {
-        image = "%s"
-        name  = "containername"
+      spec {
+        container {
+          image = "%s"
+          name  = "containername"
 
-        volume_mount {
-          mount_path = "/tmp/my_path"
-          name       = "db"
+          volume_mount {
+            mount_path = "/tmp/my_path"
+            name       = "db"
+          }
         }
-      }
 
-      volume {
-        name = "db"
+        volume {
+          name = "db"
 
-        secret = {
-          secret_name = "${kubernetes_secret.test.metadata.0.name}"
+          secret = {
+            secret_name = "${kubernetes_secret.test.metadata.0.name}"
+          }
         }
       }
     }
@@ -930,19 +952,21 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
-      container {
-        image = "%s"
-        name  = "containername"
+      spec {
+        container {
+          image = "%s"
+          name  = "containername"
 
-        resources {
-          limits {
-            cpu    = "0.5"
-            memory = "512Mi"
-          }
+          resources {
+            limits {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
 
-          requests {
-            cpu    = "250m"
-            memory = "50Mi"
+            requests {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
           }
         }
       }
@@ -969,21 +993,23 @@ resource "kubernetes_replication_controller" "test" {
     }
 
     template {
-      container {
-        image = "%s"
-        name  = "containername"
+      spec {
+        container {
+          image = "%s"
+          name  = "containername"
 
-        volume_mount {
-          mount_path = "/cache"
-          name       = "cache-volume"
+          volume_mount {
+            mount_path = "/cache"
+            name       = "cache-volume"
+          }
         }
-      }
 
-      volume {
-        name = "cache-volume"
+        volume {
+          name = "cache-volume"
 
-        empty_dir = {
-          medium = "Memory"
+          empty_dir = {
+            medium = "Memory"
+          }
         }
       }
     }

--- a/kubernetes/resource_kubernetes_replication_controller_test.go
+++ b/kubernetes/resource_kubernetes_replication_controller_test.go
@@ -508,6 +508,7 @@ resource "kubernetes_replication_controller" "test" {
           TestAnnotationFive = "five"
         }
       }
+
       spec {
         container {
           image = "nginx:1.7.8"
@@ -555,6 +556,7 @@ resource "kubernetes_replication_controller" "test" {
           TestLabelThree = "three"
         }
       }
+
       spec {
         container {
           name  = "nginx"
@@ -630,6 +632,7 @@ resource "kubernetes_replication_controller" "test" {
           TestAnnotationSix = "six"
         }
       }
+
       spec {
         container {
           image = "nginx:1.7.9"

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -4,18 +4,26 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-func podSpecFields(isUpdatable bool) map[string]*schema.Schema {
+func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schema.Schema {
+	var deprecatedMessage string
+	if isDeprecated {
+		deprecatedMessage = "This field is deprecated because template was incorrectly defined as a PodSpec preventing the definition of metadata. Please use the one under the spec field"
+	}
 	s := map[string]*schema.Schema{
 		"active_deadline_seconds": {
 			Type:         schema.TypeInt,
 			Optional:     true,
+			Computed:     isComputed,
 			ValidateFunc: validatePositiveInteger,
 			Description:  "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
+			Deprecated:   deprecatedMessage,
 		},
 		"container": {
 			Type:        schema.TypeList,
 			Optional:    true,
+			Computed:    isComputed,
 			Description: "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/containers",
+			Deprecated:  deprecatedMessage,
 			Elem: &schema.Resource{
 				Schema: containerFields(isUpdatable, false),
 			},
@@ -23,36 +31,46 @@ func podSpecFields(isUpdatable bool) map[string]*schema.Schema {
 		"init_container": {
 			Type:        schema.TypeList,
 			Optional:    true,
+			Computed:    isComputed,
 			ForceNew:    true,
 			Description: "List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
+			Deprecated:  deprecatedMessage,
 			Elem: &schema.Resource{
 				Schema: containerFields(isUpdatable, true),
 			},
 		},
 		"dns_policy": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     "ClusterFirst",
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: isComputed,
+			//Default:     "ClusterFirst"
 			Description: "Set DNS policy for containers within the pod. One of 'ClusterFirst' or 'Default'. Defaults to 'ClusterFirst'.",
+			Deprecated:  deprecatedMessage,
 		},
 		"host_ipc": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
+			Type:     schema.TypeBool,
+			Optional: true,
+			Computed: isComputed,
+			//Default:     false,
 			Description: "Use the host's ipc namespace. Optional: Default to false.",
+			Deprecated:  deprecatedMessage,
 		},
 		"host_network": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
+			Type:     schema.TypeBool,
+			Optional: true,
+			Computed: isComputed,
+			//Default:     false,
 			Description: "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified.",
+			Deprecated:  deprecatedMessage,
 		},
 
 		"host_pid": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
+			Type:     schema.TypeBool,
+			Optional: true,
+			Computed: isComputed,
+			//Default:     false,
 			Description: "Use the host's pid namespace.",
+			Deprecated:  deprecatedMessage,
 		},
 
 		"hostname": {
@@ -60,10 +78,12 @@ func podSpecFields(isUpdatable bool) map[string]*schema.Schema {
 			Optional:    true,
 			Computed:    true,
 			Description: "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.",
+			Deprecated:  deprecatedMessage,
 		},
 		"image_pull_secrets": {
 			Type:        schema.TypeList,
 			Description: "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod",
+			Deprecated:  deprecatedMessage,
 			Optional:    true,
 			Computed:    true,
 			Elem: &schema.Resource{
@@ -81,23 +101,30 @@ func podSpecFields(isUpdatable bool) map[string]*schema.Schema {
 			Optional:    true,
 			Computed:    true,
 			Description: "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.",
+			Deprecated:  deprecatedMessage,
 		},
 		"node_selector": {
 			Type:        schema.TypeMap,
 			Optional:    true,
+			Computed:    isComputed,
 			Description: "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: http://kubernetes.io/docs/user-guide/node-selection.",
+			Deprecated:  deprecatedMessage,
 		},
 		"restart_policy": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     "Always",
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: isComputed,
+			//Default:     "Always",
 			Description: "Restart policy for all containers within the pod. One of Always, OnFailure, Never. More info: http://kubernetes.io/docs/user-guide/pod-states#restartpolicy.",
+			Deprecated:  deprecatedMessage,
 		},
 		"security_context": {
 			Type:        schema.TypeList,
 			Optional:    true,
+			Computed:    isComputed,
 			MaxItems:    1,
 			Description: "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty",
+			Deprecated:  deprecatedMessage,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"fs_group": {
@@ -140,24 +167,31 @@ func podSpecFields(isUpdatable bool) map[string]*schema.Schema {
 			Optional:    true,
 			Computed:    true,
 			Description: "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: http://releases.k8s.io/HEAD/docs/design/service_accounts.md.",
+			Deprecated:  deprecatedMessage,
 		},
 		"subdomain": {
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    isComputed,
 			Description: `If specified, the fully qualified Pod hostname will be "...svc.". If not specified, the pod will not have a domainname at all..`,
+			Deprecated:  deprecatedMessage,
 		},
 		"termination_grace_period_seconds": {
-			Type:         schema.TypeInt,
-			Optional:     true,
-			Default:      30,
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: isComputed,
+			//Default:      30,
 			ValidateFunc: validateTerminationGracePeriodSeconds,
 			Description:  "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.",
+			Deprecated:   deprecatedMessage,
 		},
 
 		"volume": {
 			Type:        schema.TypeList,
 			Optional:    true,
+			Computed:    isComputed,
 			Description: "List of volumes that can be mounted by containers belonging to the pod. More info: http://kubernetes.io/docs/user-guide/volumes",
+			Deprecated:  deprecatedMessage,
 			Elem:        volumeSchema(),
 		},
 	}

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -40,35 +40,35 @@ func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schem
 			},
 		},
 		"dns_policy": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: isComputed,
-			//Default:     "ClusterFirst"
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    isComputed,
+			DefaultFunc: defaultIfNotComputed(isComputed, "ClusterFirst"),
 			Description: "Set DNS policy for containers within the pod. One of 'ClusterFirst' or 'Default'. Defaults to 'ClusterFirst'.",
 			Deprecated:  deprecatedMessage,
 		},
 		"host_ipc": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Computed: isComputed,
-			//Default:     false,
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    isComputed,
+			DefaultFunc: defaultIfNotComputed(isComputed, false),
 			Description: "Use the host's ipc namespace. Optional: Default to false.",
 			Deprecated:  deprecatedMessage,
 		},
 		"host_network": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Computed: isComputed,
-			//Default:     false,
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    isComputed,
+			DefaultFunc: defaultIfNotComputed(isComputed, false),
 			Description: "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified.",
 			Deprecated:  deprecatedMessage,
 		},
 
 		"host_pid": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Computed: isComputed,
-			//Default:     false,
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    isComputed,
+			DefaultFunc: defaultIfNotComputed(isComputed, false),
 			Description: "Use the host's pid namespace.",
 			Deprecated:  deprecatedMessage,
 		},
@@ -111,10 +111,10 @@ func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schem
 			Deprecated:  deprecatedMessage,
 		},
 		"restart_policy": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: isComputed,
-			//Default:     "Always",
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    isComputed,
+			DefaultFunc: defaultIfNotComputed(isComputed, "Always"),
 			Description: "Restart policy for all containers within the pod. One of Always, OnFailure, Never. More info: http://kubernetes.io/docs/user-guide/pod-states#restartpolicy.",
 			Deprecated:  deprecatedMessage,
 		},
@@ -177,10 +177,10 @@ func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schem
 			Deprecated:  deprecatedMessage,
 		},
 		"termination_grace_period_seconds": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: isComputed,
-			//Default:      30,
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Computed:     isComputed,
+			DefaultFunc:  defaultIfNotComputed(isComputed, 30),
 			ValidateFunc: validateTerminationGracePeriodSeconds,
 			Description:  "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.",
 			Deprecated:   deprecatedMessage,
@@ -211,6 +211,16 @@ func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schem
 	}
 
 	return s
+}
+
+func defaultIfNotComputed(isComputed bool, defaultValue interface{}) schema.SchemaDefaultFunc {
+	return func() (interface{}, error) {
+		if isComputed {
+			return nil, nil
+		}
+
+		return defaultValue, nil
+	}
 }
 
 func volumeSchema() *schema.Resource {

--- a/kubernetes/schema_pod_template.go
+++ b/kubernetes/schema_pod_template.go
@@ -13,7 +13,7 @@ func podTemplateFields(isUpdatable bool) map[string]*schema.Schema {
 			Optional:    true,
 			MaxItems:    1,
 			Elem: &schema.Resource{
-				Schema: podSpecFields(false),
+				Schema: podSpecFields(false, false, false),
 			},
 		},
 	}

--- a/kubernetes/structures_replication_controller.go
+++ b/kubernetes/structures_replication_controller.go
@@ -73,13 +73,9 @@ func expandReplicationControllerTemplate(rct []interface{}, selector map[string]
 	// Get user defined metadata
 	metadata := expandMetadata(in["metadata"].([]interface{}))
 
-	// Add or merge labels from selector to ensure proper selection of pods by the replication controller
+	// Add labels from selector to ensure proper selection of pods by the replication controller for deprecated use case
 	if metadata.Labels == nil {
 		metadata.Labels = selector
-	} else {
-		for k, v := range selector {
-			metadata.Labels[k] = v
-		}
 	}
 	obj.ObjectMeta = metadata
 

--- a/kubernetes/structures_replication_controller.go
+++ b/kubernetes/structures_replication_controller.go
@@ -34,6 +34,9 @@ func flattenReplicationControllerSpec(in v1.ReplicationControllerSpec, useDeprec
 			template["metadata"] = flattenMetadata(in.Template.ObjectMeta)
 		}
 
+		// TODO: Add conditional logic that returns an error if both the old and new attributes are not defined to preserve the Required property of the spec fields.
+		// cf. https://www.terraform.io/docs/extend/best-practices/deprecations.html#renaming-a-required-attribute
+
 		att["template"] = []interface{}{template}
 	}
 

--- a/kubernetes/structures_replication_controller.go
+++ b/kubernetes/structures_replication_controller.go
@@ -65,10 +65,6 @@ func expandReplicationControllerSpec(rc []interface{}, useDeprecatedSpecFields b
 
 func expandReplicationControllerTemplate(rct []interface{}, selector map[string]string, useDeprecatedSpecFields bool) (*v1.PodTemplateSpec, error) {
 	obj := &v1.PodTemplateSpec{}
-	in := rct[0].(map[string]interface{})
-
-	// Get user defined metadata
-	obj.ObjectMeta = expandMetadata(in["metadata"].([]interface{}))
 
 	if useDeprecatedSpecFields {
 		// Add labels from selector to ensure proper selection of pods by the replication controller for deprecated use case
@@ -81,6 +77,11 @@ func expandReplicationControllerTemplate(rct []interface{}, selector map[string]
 		}
 		obj.Spec = *podSpecDeprecated
 	} else {
+		in := rct[0].(map[string]interface{})
+
+		// Get user defined metadata
+		obj.ObjectMeta = expandMetadata(in["metadata"].([]interface{}))
+
 		// Get pod spec from new fields
 		podSpec, err := expandPodSpec(in["spec"].([]interface{}))
 		if err != nil {

--- a/kubernetes/structures_replication_controller.go
+++ b/kubernetes/structures_replication_controller.go
@@ -65,15 +65,12 @@ func expandReplicationControllerTemplate(rct []interface{}, selector map[string]
 	in := rct[0].(map[string]interface{})
 
 	// Get user defined metadata
-	metadata := expandMetadata(in["metadata"].([]interface{}))
-
-	// Add labels from selector to ensure proper selection of pods by the replication controller for deprecated use case
-	if metadata.Labels == nil {
-		metadata.Labels = selector
-	}
-	obj.ObjectMeta = metadata
+	obj.ObjectMeta = expandMetadata(in["metadata"].([]interface{}))
 
 	if useDeprecatedSpecFields {
+		// Add labels from selector to ensure proper selection of pods by the replication controller for deprecated use case
+		obj.ObjectMeta.Labels = selector
+
 		// Get pod spec from deprecated fields
 		podSpecDeprecated, err := expandPodSpec(rct)
 		if err != nil {

--- a/website/docs/r/replication_controller.html.markdown
+++ b/website/docs/r/replication_controller.html.markdown
@@ -10,6 +10,7 @@ description: |-
 
 A Replication Controller ensures that a specified number of pod “replicas” are running at any one time. In other words, a Replication Controller makes sure that a pod or homogeneous set of pods are always up and available. If there are too many pods, it will kill some. If there are too few, the Replication Controller will start more.
 
+~> **WARNING:** In many cases it is recommended to create a Deployment instead of a Replication Controller.
 
 ## Example Usage
 
@@ -27,18 +28,28 @@ resource "kubernetes_replication_controller" "example" {
       test = "MyExampleApp"
     }
     template {
-      container {
-        image = "nginx:1.7.8"
-        name  = "example"
-
-        resources{
-          limits{
-            cpu    = "0.5"
-            memory = "512Mi"
+      spec {
+        metadata {
+          labels {
+            test = "MyExampleApp"
           }
-          requests{
-            cpu    = "250m"
-            memory = "50Mi"
+          annotations {
+            "key1" = "value1"
+          }
+        }
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources{
+            limits{
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests{
+              cpu    = "250m"
+              memory = "50Mi"
+            }
           }
         }
       }
@@ -62,7 +73,7 @@ The following arguments are supported:
 
 * `annotations` - (Optional) An unstructured key value map stored with the replication controller that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the replication controller. **Must match `selector`**. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the replication controller. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the replication controller, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the replication controller must be unique.
 
@@ -79,535 +90,42 @@ The following arguments are supported:
 
 * `min_ready_seconds` - (Optional) Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
 * `replicas` - (Optional) The number of desired replicas. Defaults to 1. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/replication-controller#what-is-a-replication-controller)
-* `selector` - (Required) A label query over pods that should match the Replicas count. Label keys and values that must match in order to be controlled by this replication controller. **Must match labels (`metadata.0.labels`)**. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels#label-selectors)
-* `template` - (Required) Describes the pod that will be created if insufficient replicas are detected. This takes precedence over a TemplateRef. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/replication-controller#pod-template)
+* `selector` - (Required) A label query over pods that should match the Replicas count. Label keys and values that must match in order to be controlled by this replication controller. **Should match labels (`metadata.0.labels`)**. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#label-selector-and-annotation-conventions)
+* `template` - (Required) Template is the object that describes the pod that will be created if insufficient replicas are detected. This takes precedence over a TemplateRef. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/replication-controller#pod-template)
 
-### `template`
+## Nested Blocks
 
-#### Arguments
-
-* `active_deadline_seconds` - (Optional) Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
-* `container` - (Optional) List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/containers)
-* `init_container` - (Optional) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers)/
-* `dns_policy` - (Optional) Set DNS policy for containers within the pod. One of 'ClusterFirst' or 'Default'. Defaults to 'ClusterFirst'.
-* `host_ipc` - (Optional) Use the host's ipc namespace. Optional: Default to false.
-* `host_network` - (Optional) Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified.
-* `host_pid` - (Optional) Use the host's pid namespace.
-* `hostname` - (Optional) Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
-* `image_pull_secrets` - (Optional) ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod)
-* `node_name` - (Optional) NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
-* `node_selector` - (Optional) NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/node-selection).
-* `restart_policy` - (Optional) Restart policy for all containers within the pod. One of Always, OnFailure, Never. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/pod-states#restartpolicy).
-* `security_context` - (Optional) SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty
-* `service_account_name` - (Optional) ServiceAccountName is the name of the ServiceAccount to use to run this pod. For more info see http://releases.k8s.io/HEAD/docs/design/service_accounts.md.
-* `subdomain` - (Optional) If specified, the fully qualified Pod hostname will be "...svc.". If not specified, the pod will not have a domainname at all..
-* `termination_grace_period_seconds` - (Optional) Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.
-* `volume` - (Optional) List of volumes that can be mounted by containers belonging to the pod. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes)
-
-### `container`
+### `spec.template`
 
 #### Arguments
 
-* `args` - (Optional) Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/containers#containers-and-commands)
-* `command` - (Optional) Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/containers#containers-and-commands)
-* `env` - (Optional) List of environment variables to set in the container. Cannot be updated.
-* `env_from` - (Optional) List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
-* `image` - (Optional) Docker image name. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/images)
-* `image_pull_policy` - (Optional) Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/images#updating-images)
-* `lifecycle` - (Optional) Actions that the management system should take in response to container lifecycle events
-* `liveness_probe` - (Optional) Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/pod-states#container-probes)
-* `name` - (Required) Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
-* `port` - (Optional) List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
-* `readiness_probe` - (Optional) Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/pod-states#container-probes)
-* `resources` - (Optional) Compute Resources required by this container. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/persistent-volumes#resources)
-* `security_context` - (Optional) Security options the pod should run with. For more info see http://releases.k8s.io/HEAD/docs/design/security_context.md
-* `stdin` - (Optional) Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF.
-* `stdin_once` - (Optional) Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF.
-* `termination_message_path` - (Optional) Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.
-* `tty` - (Optional) Whether this container should allocate a TTY for itself
-* `volume_mount` - (Optional) Pod volumes to mount into the container's filesystem. Cannot be updated.
-* `working_dir` - (Optional) Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+* `metadata` - (Optional) Standard object's metadata. More info: [Kubernetes reference](https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata).  While required by the kubernetes API, this field is marked as optional to allow the usage of the deprecated pod spec fields that were mistakenly placed directly under the `template` block.
 
-### `aws_elastic_block_store`
+* `spec` - (Optional) Specification of the desired behavior of the pod. More info: [Kubernetes reference](https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status)
+
+~> **NOTE:** all the fields from the `spec.template.spec` block are also accepted at the `spec.template` level but that usage is deprecated. All existing configurations should be updated to only use the new fields under `spec.template.spec`. Mixing the usage of deprecated fields with new fields is not supported.
+
+## Nested Blocks
+
+### `spec.template.metadata`
 
 #### Arguments
 
-* `fs_type` - (Optional) Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#awselasticblockstore)
-* `partition` - (Optional) The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-* `read_only` - (Optional) Whether to set the read-only property in VolumeMounts to "true". If omitted, the default is "false". For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#awselasticblockstore)
-* `volume_id` - (Required) Unique ID of the persistent disk resource in AWS (Amazon EBS volume). For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#awselasticblockstore)
+* `annotations` - (Optional) An unstructured key value map stored with the replication controller that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the pods managed by this replication controller . **Should match `selector`**. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#label-selector-and-annotation-conventions)
+* `name` - (Optional) Name of the replication controller, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+* `namespace` - (Optional) Namespace defines the space within which name of the replication controller must be unique.
 
-### `azure_disk`
+## Nested Blocks
 
-#### Arguments
-
-* `caching_mode` - (Required) Host Caching mode: None, Read Only, Read Write.
-* `data_disk_uri` - (Required) The URI the data disk in the blob storage
-* `disk_name` - (Required) The Name of the data disk in the blob storage
-* `fs_type` - (Optional) Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-* `read_only` - (Optional) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
-
-### `azure_file`
+### `spec.template.spec`
 
 #### Arguments
 
-* `read_only` - (Optional) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
-* `secret_name` - (Required) The name of secret that contains Azure Storage Account Name and Key
-* `share_name` - (Required) Share Name
+These arguments are the same as the for the `spec` block of a Pod.
 
-### `capabilities`
-
-#### Arguments
-
-* `add` - (Optional) Added capabilities
-* `drop` - (Optional) Removed capabilities
-
-### `ceph_fs`
-
-#### Arguments
-
-* `monitors` - (Required) Monitors is a collection of Ceph monitors For more info see http://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it
-* `path` - (Optional) Used as the mounted root, rather than the full Ceph tree, default is /
-* `read_only` - (Optional) Whether to force the read-only setting in VolumeMounts. Defaults to `false` (read/write). For more info see http://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it
-* `secret_file` - (Optional) The path to key ring for User, default is /etc/ceph/user.secret For more info see http://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it
-* `secret_ref` - (Optional) Reference to the authentication secret for User, default is empty. For more info see http://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it
-* `user` - (Optional) User is the rados user name, default is admin. For more info see http://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it
-
-### `cinder`
-
-#### Arguments
-
-* `fs_type` - (Optional) Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. For more info see http://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md
-* `read_only` - (Optional) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write). For more info see http://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md
-* `volume_id` - (Required) Volume ID used to identify the volume in Cinder. For more info see http://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md
-
-### `config_map`
-
-#### Arguments
-
-* `default_mode` - (Optional) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-* `items` - (Optional) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'.
-* `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
-
-### `config_map_ref`
-
-#### Arguments
-
-* `name` - (Required) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
-* `optional` - (Optional) Specify whether the ConfigMap must be defined
-
-### `config_map_key_ref`
-
-#### Arguments
-
-* `key` - (Optional) The key to select.
-* `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
-
-### `downward_api`
-
-#### Arguments
-
-* `default_mode` - (Optional) Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-* `items` - (Optional) If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'.
-
-### `empty_dir`
-
-#### Arguments
-
-* `medium` - (Optional) What type of storage medium should back this directory. The default is "" which means to use the node's default medium. Must be an empty string (default) or Memory. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#emptydir)
-
-### `env`
-
-#### Arguments
-
-* `name` - (Required) Name of the environment variable. Must be a C_IDENTIFIER
-* `value` - (Optional) Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
-* `value_from` - (Optional) Source for the environment variable's value
-
-### `env_from`
-
-#### Arguments
-
-* `config_map_ref` - (Optional) The ConfigMap to select from
-* `prefix` - (Optional) An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER..
-* `secret_ref` - (Optional) The Secret to select from
-
-### `exec`
-
-#### Arguments
-
-* `command` - (Optional) Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
-
-### `fc`
-
-#### Arguments
-
-* `fs_type` - (Optional) Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-* `lun` - (Required) FC target lun number
-* `read_only` - (Optional) Whether to force the read-only setting in VolumeMounts. Defaults to false (read/write).
-* `target_ww_ns` - (Required) FC target worldwide names (WWNs)
-
-### `field_ref`
-
-#### Arguments
-
-* `api_version` - (Optional) Version of the schema the FieldPath is written in terms of, defaults to "v1".
-* `field_path` - (Optional) Path of the field to select in the specified API version
-
-### `flex_volume`
-
-#### Arguments
-
-* `driver` - (Required) Driver is the name of the driver to use for this volume.
-* `fs_type` - (Optional) Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
-* `options` - (Optional) Extra command options if any.
-* `read_only` - (Optional) Whether to force the ReadOnly setting in VolumeMounts. Defaults to false (read/write).
-* `secret_ref` - (Optional) Reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.
-
-### `flocker`
-
-#### Arguments
-
-* `dataset_name` - (Optional) Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
-* `dataset_uuid` - (Optional) UUID of the dataset. This is unique identifier of a Flocker dataset
-
-### `gce_persistent_disk`
-
-#### Arguments
-
-* `fs_type` - (Optional) Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#gcepersistentdisk)
-* `partition` - (Optional) The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#gcepersistentdisk)
-* `pd_name` - (Required) Unique name of the PD resource in GCE. Used to identify the disk in GCE. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#gcepersistentdisk)
-* `read_only` - (Optional) Whether to force the ReadOnly setting in VolumeMounts. Defaults to false. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#gcepersistentdisk)
-
-### `git_repo`
-
-#### Arguments
-
-* `directory` - (Optional) Target directory name. Must not contain or start with '..'. If '.' is supplied, the volume directory will be the git repository. Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
-* `repository` - (Optional) Repository URL
-* `revision` - (Optional) Commit hash for the specified revision.
-
-### `glusterfs`
-
-#### Arguments
-
-* `endpoints_name` - (Required) The endpoint name that details Glusterfs topology. For more info see http://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod
-* `path` - (Required) The Glusterfs volume path. For more info see http://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod
-* `read_only` - (Optional) Whether to force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. For more info see http://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod
-
-### `host_path`
-
-#### Arguments
-
-* `path` - (Optional) Path of the directory on the host. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#hostpath)
-
-### `http_get`
-
-#### Arguments
-
-* `host` - (Optional) Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
-* `http_header` - (Optional) Scheme to use for connecting to the host.
-* `path` - (Optional) Path to access on the HTTP server.
-* `port` - (Optional) Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
-* `scheme` - (Optional) Scheme to use for connecting to the host.
-
-### `http_header`
-
-#### Arguments
-
-* `name` - (Optional) The header field name
-* `value` - (Optional) The header field value
-
-### `image_pull_secrets`
-
-#### Arguments
-
-* `name` - (Required) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
-
-### `iscsi`
-
-#### Arguments
-
-* `fs_type` - (Optional) Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#iscsi)
-* `iqn` - (Required) Target iSCSI Qualified Name.
-* `iscsi_interface` - (Optional) iSCSI interface name that uses an iSCSI transport. Defaults to 'default' (tcp).
-* `lun` - (Optional) iSCSI target lun number.
-* `read_only` - (Optional) Whether to force the read-only setting in VolumeMounts. Defaults to false.
-* `target_portal` - (Required) iSCSI target portal. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
-
-### `items`
-
-#### Arguments
-
-* `key` - (Optional) The key to project.
-* `mode` - (Optional) Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-* `path` - (Optional) The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
-
-### `lifecycle`
-
-#### Arguments
-
-* `post_start` - (Optional) post_start is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/container-environment#hook-details)
-* `pre_stop` - (Optional) pre_stop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/container-environment#hook-details)
-
-### `limits`
-
-#### Arguments
-
-* `cpu` - (Optional) CPU
-* `memory` - (Optional) Memory
-
-### `liveness_probe`
-
-#### Arguments
-
-* `exec` - (Optional) exec specifies the action to take.
-* `failure_threshold` - (Optional) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-* `http_get` - (Optional) Specifies the http request to perform.
-* `initial_delay_seconds` - (Optional) Number of seconds after the container has started before liveness probes are initiated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/pod-states#container-probes)
-* `period_seconds` - (Optional) How often (in seconds) to perform the probe
-* `success_threshold` - (Optional) Minimum consecutive successes for the probe to be considered successful after having failed.
-* `tcp_socket` - (Optional) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
-* `timeout_seconds` - (Optional) Number of seconds after which the probe times out. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/pod-states#container-probes)
-
-### `nfs`
-
-#### Arguments
-
-* `path` - (Required) Path that is exported by the NFS server. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#nfs)
-* `read_only` - (Optional) Whether to force the NFS export to be mounted with read-only permissions. Defaults to false. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#nfs)
-* `server` - (Required) Server is the hostname or IP address of the NFS server. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#nfs)
-
-### `persistent_volume_claim`
-
-#### Arguments
-
-* `claim_name` - (Optional) ClaimName is the name of a PersistentVolumeClaim in the same
-* `read_only` - (Optional) Will force the ReadOnly setting in VolumeMounts.
-
-### `photon_persistent_disk`
-
-#### Arguments
-
-* `fs_type` - (Optional) Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-* `pd_id` - (Required) ID that identifies Photon Controller persistent disk
-
-### `port`
-
-#### Arguments
-
-* `container_port` - (Required) Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
-* `host_ip` - (Optional) What host IP to bind the external port to.
-* `host_port` - (Optional) Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
-* `name` - (Optional) If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services
-* `protocol` - (Optional) Protocol for port. Must be UDP or TCP. Defaults to "TCP".
-
-### `post_start`
-
-#### Arguments
-
-* `exec` - (Optional) exec specifies the action to take.
-* `http_get` - (Optional) Specifies the http request to perform.
-* `tcp_socket` - (Optional) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
-
-### `pre_stop`
-
-#### Arguments
-
-* `exec` - (Optional) exec specifies the action to take.
-* `http_get` - (Optional) Specifies the http request to perform.
-* `tcp_socket` - (Optional) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
-
-### `quobyte`
-
-#### Arguments
-
-* `group` - (Optional) Group to map volume access to Default is no group
-* `read_only` - (Optional) Whether to force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
-* `registry` - (Required) Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
-* `user` - (Optional) User to map volume access to Defaults to serivceaccount user
-* `volume` - (Required) Volume is a string that references an already created Quobyte volume by name.
-
-### `rbd`
-
-#### Arguments
-
-* `ceph_monitors` - (Required) A collection of Ceph monitors. For more info see http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it
-* `fs_type` - (Optional) Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#rbd)
-* `keyring` - (Optional) Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. For more info see http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it
-* `rados_user` - (Optional) The rados user name. Default is admin. For more info see http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it
-* `rbd_image` - (Required) The rados image name. For more info see http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it
-* `rbd_pool` - (Optional) The rados pool name. Default is rbd. For more info see http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it.
-* `read_only` - (Optional) Whether to force the read-only setting in VolumeMounts. Defaults to false. For more info see http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it
-* `secret_ref` - (Optional) Name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. For more info see http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it
-
-### `readiness_probe`
-
-#### Arguments
-
-* `exec` - (Optional) exec specifies the action to take.
-* `failure_threshold` - (Optional) Minimum consecutive failures for the probe to be considered failed after having succeeded.
-* `http_get` - (Optional) Specifies the http request to perform.
-* `initial_delay_seconds` - (Optional) Number of seconds after the container has started before liveness probes are initiated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/pod-states#container-probes)
-* `period_seconds` - (Optional) How often (in seconds) to perform the probe
-* `success_threshold` - (Optional) Minimum consecutive successes for the probe to be considered successful after having failed.
-* `tcp_socket` - (Optional) TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
-* `timeout_seconds` - (Optional) Number of seconds after which the probe times out. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/pod-states#container-probes)
-
-### `resources`
-
-#### Arguments
-
-* `limits` - (Optional) Describes the maximum amount of compute resources allowed. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/compute-resources)/
-* `requests` - (Optional) Describes the minimum amount of compute resources required.
-
-### `requests`
-
-#### Arguments
-
-* `cpu` - (Optional) CPU
-* `memory` - (Optional) Memory
-
-### `resource_field_ref`
-
-#### Arguments
-
-* `container_name` - (Optional) The name of the container
-* `resource` - (Required) Resource to select
-
-### `se_linux_options`
-
-#### Arguments
-
-* `level` - (Optional) Level is SELinux level label that applies to the container.
-* `role` - (Optional) Role is a SELinux role label that applies to the container.
-* `type` - (Optional) Type is a SELinux type label that applies to the container.
-* `user` - (Optional) User is a SELinux user label that applies to the container.
-
-### `secret`
-
-#### Arguments
-
-* `default_mode` - (Optional) Mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-* `items` - (Optional) List of Secret Items to project into the volume. See `items` block definition below. If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked `optional`. Paths must be relative and may not contain the '..' path or start with '..'.
-* `optional` - (Optional) Specify whether the Secret or it's keys must be defined.
-* `secret_name` - (Optional) Name of the secret in the pod's namespace to use. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#secrets)
-
-The `items` block supports:
-
-* `key` - (Required) The key to project.
-* `mode` - (Optional) Mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used.
-* `path` - (Required) The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
-
-### `secret_ref`
-
-#### Arguments
-
-* `name` - (Required) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
-* `optional` - (Optional) Specify whether the Secret must be defined
-
-### `secret_key_ref`
-
-#### Arguments
-
-* `key` - (Optional) The key of the secret to select from. Must be a valid secret key.
-* `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
-
-### `secret_ref`
-
-#### Arguments
-
-* `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
-
-### container `security_context`
-
-#### Arguments
-
-* `allow_privilege_escalation` - (Optional) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-* `capabilities` - (Optional) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
-* `privileged` - (Optional) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
-* `read_only_root_filesystem` - (Optional) Whether this container has a read-only root filesystem. Default is false.
-* `run_as_non_root` - (Optional) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-* `run_as_user` - (Optional) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-* `se_linux_options` - (Optional) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-
-### `capabilities`
-
-#### Arguments
-
-* `add` - (Optional) A list of added capabilities.
-* `drop` - (Optional) A list of removed capabilities.
-
-### pod `security_context`
-
-#### Arguments
-
-* `fs_group` - (Optional) A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- If unset, the Kubelet will not modify the ownership and permissions of any volume.
-* `run_as_non_root` - (Optional) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-* `run_as_user` - (Optional) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
-* `se_linux_options` - (Optional) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
-* `supplemental_groups` - (Optional) A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.
-
-### `tcp_socket`
-
-#### Arguments
-
-* `port` - (Required) Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
-
-### `value_from`
-
-#### Arguments
-
-* `config_map_key_ref` - (Optional) Selects a key of a ConfigMap.
-* `field_ref` - (Optional) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP..
-* `resource_field_ref` - (Optional) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP..
-* `secret_key_ref` - (Optional) Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP..
-
-### `volume`
-
-#### Arguments
-
-* `aws_elastic_block_store` - (Optional) Represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#awselasticblockstore)
-* `azure_disk` - (Optional) Represents an Azure Data Disk mount on the host and bind mount to the pod.
-* `azure_file` - (Optional) Represents an Azure File Service mount on the host and bind mount to the pod.
-* `ceph_fs` - (Optional) Represents a Ceph FS mount on the host that shares a pod's lifetime
-* `cinder` - (Optional) Represents a cinder volume attached and mounted on kubelets host machine. For more info see http://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md
-* `config_map` - (Optional) ConfigMap represents a configMap that should populate this volume
-* `downward_api` - (Optional) DownwardAPI represents downward API about the pod that should populate this volume
-* `empty_dir` - (Optional) EmptyDir represents a temporary directory that shares a pod's lifetime. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#emptydir)
-* `fc` - (Optional) Represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
-* `flex_volume` - (Optional) Represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future.
-* `flocker` - (Optional) Represents a Flocker volume attached to a kubelet's host machine and exposed to the pod for its usage. This depends on the Flocker control service being running
-* `gce_persistent_disk` - (Optional) Represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#gcepersistentdisk)
-* `git_repo` - (Optional) GitRepo represents a git repository at a particular revision.
-* `glusterfs` - (Optional) Represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. For more info see http://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md
-* `host_path` - (Optional) Represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#hostpath)
-* `iscsi` - (Optional) Represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin.
-* `name` - (Optional) Volume's name. Must be a DNS_LABEL and unique within the pod. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
-* `nfs` - (Optional) Represents an NFS mount on the host. Provisioned by an admin. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#nfs)
-* `persistent_volume_claim` - (Optional) The specification of a persistent volume.
-* `photon_persistent_disk` - (Optional) Represents a PhotonController persistent disk attached and mounted on kubelets host machine
-* `quobyte` - (Optional) Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
-* `rbd` - (Optional) Represents a Rados Block Device mount on the host that shares a pod's lifetime. For more info see http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md
-* `secret` - (Optional) Secret represents a secret that should populate this volume. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes#secrets)
-* `vsphere_volume` - (Optional) Represents a vSphere volume attached and mounted on kubelets host machine
-
-### `volume_mount`
-
-#### Arguments
-
-* `mount_path` - (Required) Path within the container at which the volume should be mounted. Must not contain ':'.
-* `name` - (Required) This must match the Name of a Volume.
-* `read_only` - (Optional) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
-* `sub_path` - (Optional) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
-
-### `vsphere_volume`
-
-#### Arguments
-
-* `fs_type` - (Optional) Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-* `volume_path` - (Required) Path that identifies vSphere volume vmdk
+Please see the [Pod resource](pod.html#spec-1) for reference.
 
 ## Timeouts
 
@@ -624,3 +142,5 @@ Replication Controller can be imported using the namespace and name, e.g.
 ```
 $ terraform import kubernetes_replication_controller.example default/terraform-example
 ```
+
+~> **NOTE:** Imported `kubernetes_replication_controller` resource will only have their fields from the `spec.template.spec` block in the state. Deprecated fields at the `spec.template` level are not updated during import. Configurations using the deprecated fields should be updated to only use the new fields under `spec.template.spec`.


### PR DESCRIPTION
Tries to resolve #106 

TODO:
- [x] add acceptance tests
- [x] add conditional logic that returns an error if both the old and new attributes are not defined to preserve the Required property of the spec fields
- [x] update documentation