### PR TITLE
Bump Go version to 1.10 on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 - docker
 language: go
 go:
-- 1.9
+- 1.10
 
 install:
 # This script is used by the Travis build to install a cookie for

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 - docker
 language: go
 go:
-- 1.10.4
+- "1.10.x"
 
 install:
 # This script is used by the Travis build to install a cookie for

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 - docker
 language: go
 go:
-- 1.10
+- 1.10.4
 
 install:
 # This script is used by the Travis build to install a cookie for


### PR DESCRIPTION
Go version was lagging behind in Travis. This aligns it with internal CI.

@terraform-providers/ecosystem 