### PR TITLE
Revert "meta: Treat internal k8s annotations as invalid"

### DIFF
--- a/kubernetes/validators.go
+++ b/kubernetes/validators.go
@@ -21,10 +21,6 @@ func validateAnnotations(value interface{}, key string) (ws []string, es []error
 				es = append(es, fmt.Errorf("%s (%q) %s", key, k, e))
 			}
 		}
-
-		if isInternalKey(k) {
-			es = append(es, fmt.Errorf("%s: %q is internal Kubernetes annotation", key, k))
-		}
 	}
 	return
 }


### PR DESCRIPTION
This reverts #50 and closes #60 by allowing "internal" annotations that have "kubernetes.io" in the domain name.

Examples abound for which this "feature" breaks basic usage, such as with:

https://kubernetes.io/docs/concepts/services-networking/service/#ssl-support-on-aws
https://docs.microsoft.com/en-us/azure/aks/internal-lb
https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/
https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/ingress-resources.md#annotations

For 3rd party Kubernetes plugins, Kubernetes has no control over what annotation names they use, and many others have created custom annotations for their tools that end with kubernetes.io in the part before the slash, and for which the annotation is absolutely essential to get it working.

There was an argument made that this plugin is not meant to support alpha or beta features. The problem is these "alpha" or "beta" feature are heavily relied on in production by many users because of the long beta cycles and the the usefulness of those "beta" but in practice stable features. This provider should not be in the business of saying "this annotation should not be supported because it's beta"; let the developer/ops person decide.

With this over-protectiveness, people will start using direct calls to kubectl via null_resource local-execs; that's even more of a nightmare that lets people shoot themselves in the foot more than having the potential for a few broken annotations here and there (for which a good developer will notice the false changes in the plan, and eventually realize how to fix it).

Let the engineers make their mistakes and trust them to figure it out; don't be so over-protective as to cripple core functionality. If necessary, put a big warning up saying "you better know what you're doing", but don't stop the innovation.