### PR TITLE
Wait for deployment rollout status

### DIFF
--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -256,7 +256,7 @@ func resourceKubernetesDeploymentUpdate(d *schema.ResourceData, meta interface{}
 	log.Printf("[INFO] Submitted updated deployment: %#v", out)
 
 	err = resource.Retry(d.Timeout(schema.TimeoutUpdate),
-		waitForDesiredReplicasFunc(conn, namespace, name))
+		waitForDeploymentReplicasFunc(conn, namespace, name))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
replicationcontrollers are not created for a deployment. So we need to
wait for the deployment itself to finish.