### PR TITLE
Add NodeAffinity config to persistence volume

### DIFF
--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -104,6 +104,32 @@ func resourceKubernetesPersistentVolume() *schema.Resource {
 							Description: "A description of the persistent volume's class. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class",
 							Optional:    true,
 						},
+						"node_affinity": {
+							Type:        schema.TypeList,
+							Description: "A description of the persistent volume's node affinity. More info: https://kubernetes.io/docs/concepts/storage/volumes/#local",
+							Optional:    true,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"required": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"node_selector_term": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: nodeSelectorTermFields(),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/kubernetes/schema_node_selector_term.go
+++ b/kubernetes/schema_node_selector_term.go
@@ -1,0 +1,53 @@
+package kubernetes
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func nodeSelectorRequirementFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"key": {
+			Type:        schema.TypeString,
+			Description: "The label key that the selector applies to.",
+			Optional:    true,
+			ForceNew:    true,
+		},
+		"operator": {
+			Type:        schema.TypeString,
+			Description: "A key's relationship to a set of values. Valid operators ard `In`, `NotIn`, `Exists` and `DoesNotExist`.",
+			Optional:    true,
+			ForceNew:    true,
+		},
+		"values": {
+			Type:        schema.TypeSet,
+			Description: "An array of string values. If the operator is `In` or `NotIn`, the values array must be non-empty. If the operator is `Exists` or `DoesNotExist`, the values array must be empty. This array is replaced during a strategic merge patch.",
+			Optional:    true,
+			ForceNew:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Set:         schema.HashString,
+		},
+	}
+}
+
+func nodeSelectorTermFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"match_expressions": {
+			Type:        schema.TypeList,
+			Description: "A list of node selector requirements by node's labels. The requirements are ANDed.",
+			Optional:    true,
+			ForceNew:    true,
+			Elem: &schema.Resource{
+				Schema: nodeSelectorRequirementFields(),
+			},
+		},
+		"match_fields": {
+			Type:        schema.TypeList,
+			Description: "A list of node selector requirements by node's fields. The requirements are ANDed.",
+			Optional:    true,
+			ForceNew:    true,
+			Elem: &schema.Resource{
+				Schema: nodeSelectorRequirementFields(),
+			},
+		},
+	}
+}

--- a/kubernetes/structure_persistent_volume_spec.go
+++ b/kubernetes/structure_persistent_volume_spec.go
@@ -342,6 +342,9 @@ func flattenPersistentVolumeSpec(in v1.PersistentVolumeSpec) []interface{} {
 	if in.StorageClassName != "" {
 		att["storage_class_name"] = in.StorageClassName
 	}
+	if in.NodeAffinity != nil {
+		att["node_affinity"] = flattenVolumeNodeAffinity(in.NodeAffinity)
+	}
 	return []interface{}{att}
 }
 
@@ -864,6 +867,9 @@ func expandPersistentVolumeSpec(l []interface{}) (v1.PersistentVolumeSpec, error
 	if v, ok := in["storage_class_name"].(string); ok {
 		obj.StorageClassName = v
 	}
+	if v, ok := in["node_affinity"].([]interface{}); ok && len(v) > 0 {
+		obj.NodeAffinity = expandVolumeNodeAffinity(v)
+	}
 	return obj, nil
 }
 
@@ -1027,6 +1033,14 @@ func patchPersistentVolumeSpec(pathPrefix, prefix string, d *schema.ResourceData
 				Value: n.(string),
 			})
 		}
+	}
+	if d.HasChange(prefix + "node_affinity") {
+		v := d.Get(prefix + "node_affinity").([]interface{})
+		nodeAffinity := expandVolumeNodeAffinity(v)
+		ops = append(ops, &ReplaceOperation{
+			Path:  pathPrefix + "/nodeAffinity",
+			Value: nodeAffinity,
+		})
 	}
 
 	return ops, nil
@@ -1410,4 +1424,36 @@ func patchPersistentVolumeSource(pathPrefix, prefix string, d *schema.ResourceDa
 	}
 
 	return ops
+}
+
+func flattenVolumeNodeAffinity(in *v1.VolumeNodeAffinity) []interface{} {
+	att := make(map[string]interface{})
+	nodeSelector := map[string]interface{}{
+		"node_selector_term": flattenNodeSelectorTerm(in.Required.NodeSelectorTerms[0]),
+	}
+	att["required"] = []interface{}{nodeSelector}
+	return []interface{}{att}
+}
+
+func expandVolumeNodeAffinity(l []interface{}) *v1.VolumeNodeAffinity {
+	if len(l) == 0 || l[0] == nil {
+		return &v1.VolumeNodeAffinity{}
+	}
+	in := l[0].(map[string]interface{})
+	nodeSelectorList := in["required"].([]interface{})
+
+	if len(nodeSelectorList) == 0 || nodeSelectorList[0] == nil {
+		return &v1.VolumeNodeAffinity{}
+	}
+	nodeSelector := nodeSelectorList[0].(map[string]interface{})
+
+	if len(nodeSelector) == 0 || nodeSelectorList[0] == nil {
+		return &v1.VolumeNodeAffinity{}
+	}
+	obj := &v1.VolumeNodeAffinity{
+		Required: &v1.NodeSelector{
+			NodeSelectorTerms: []v1.NodeSelectorTerm{expandNodeSelectorTerm(nodeSelector["node_selector_term"].([]interface{}))},
+		},
+	}
+	return obj
 }


### PR DESCRIPTION
Support node affinity setting of persistence volume, which is needed when using local volume:
https://kubernetes.io/docs/concepts/storage/volumes/#local

example:
```
resource "kubernetes_persistent_volume" "test" {
  metadata {
    name = "%s"
  }
  spec {
    capacity {
      storage = "2Gi"
    }
    access_modes = ["ReadWriteOnce"]
    persistent_volume_source {
      host_path {
        path = "/mnt/local-volume"
      }
    }
    node_affinity {
      required {
        node_selector_term {
          match_expressions = [{
            key = "%s"
            operator = "In"
            values = ["%s"]
          }]
        }
      }
    }
  }
}
```

The config is following Kubernetes one, it allows smooth transition if they add option at the "required" level in the future.