### PR TITLE
Fix configuration for ServiceAccount token automount test.

### DIFF
--- a/kubernetes/resource_kubernetes_service_account_test.go
+++ b/kubernetes/resource_kubernetes_service_account_test.go
@@ -469,9 +469,53 @@ func testAccKubernetesServiceAccountConfig_automount(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_service_account" "test" {
 	metadata {
+		annotations {
+			TestAnnotationOne = "one"
+			TestAnnotationTwo = "two"
+		}
+		labels {
+			TestLabelOne = "one"
+			TestLabelTwo = "two"
+			TestLabelThree = "three"
+		}
 		name = "%s"
 	}
-
+	secret {
+		name = "${kubernetes_secret.one.metadata.0.name}"
+	}
+	secret {
+		name = "${kubernetes_secret.two.metadata.0.name}"
+	}
+	image_pull_secret {
+		name = "${kubernetes_secret.three.metadata.0.name}"
+	}
+	image_pull_secret {
+		name = "${kubernetes_secret.four.metadata.0.name}"
+	}
 	automount_service_account_token = true
-}`, name)
+}
+
+resource "kubernetes_secret" "one" {
+	metadata {
+		name = "%s-one"
+	}
+}
+
+resource "kubernetes_secret" "two" {
+	metadata {
+		name = "%s-two"
+	}
+}
+
+resource "kubernetes_secret" "three" {
+	metadata {
+		name = "%s-three"
+	}
+}
+
+resource "kubernetes_secret" "four" {
+	metadata {
+		name = "%s-four"
+	}
+}`, name, name, name, name, name)
 }


### PR DESCRIPTION
This fixes a broken test that was never passing because it was using the wrong resource configuration.

Before this change:
```
------- Stdout: -------
=== RUN   TestAccKubernetesServiceAccount_automount
--- FAIL: TestAccKubernetesServiceAccount_automount (0.60s)
	testing.go:518: Step 0 error: Check failed: 12 error(s) occurred:
		
		* Check 2/20 error: kubernetes_service_account.test: Attribute 'metadata.0.annotations.%' expected "2", got "0"
		* Check 3/20 error: kubernetes_service_account.test: Attribute 'metadata.0.annotations.TestAnnotationOne' not found
		* Check 4/20 error: kubernetes_service_account.test: Attribute 'metadata.0.annotations.TestAnnotationTwo' not found
		* Check 5/20 error: tf-acc-test-kvjlli0oxs annotations don't match.
		Expected: map["TestAnnotationTwo":"two" "TestAnnotationOne":"one"]
		Given: map[]
		* Check 6/20 error: kubernetes_service_account.test: Attribute 'metadata.0.labels.%' expected "3", got "0"
		* Check 7/20 error: kubernetes_service_account.test: Attribute 'metadata.0.labels.TestLabelOne' not found
		* Check 8/20 error: kubernetes_service_account.test: Attribute 'metadata.0.labels.TestLabelTwo' not found
		* Check 9/20 error: kubernetes_service_account.test: Attribute 'metadata.0.labels.TestLabelThree' not found
		* Check 10/20 error: tf-acc-test-kvjlli0oxs labels don't match.
		Expected: map["TestLabelOne":"one" "TestLabelTwo":"two" "TestLabelThree":"three"]
		Given: map[]
		* Check 16/20 error: kubernetes_service_account.test: Attribute 'secret.#' expected "2", got "0"
		* Check 17/20 error: kubernetes_service_account.test: Attribute 'image_pull_secret.#' expected "2", got "0"
		* Check 19/20 error: tf-acc-test-kvjlli0oxs image pull secrets don't match.
		Expected: ["^tf-acc-test-kvjlli0oxs-three$" "^tf-acc-test-kvjlli0oxs-four$"]
		Given: []
FAIL
```

After this change
```
TESTARGS='-run ^TestAccKubernetesServiceAccount' make testacc                              alex@alexs-macbook
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run ^TestAccKubernetesServiceAccount -timeout 120m
?   	github.com/terraform-providers/terraform-provider-kubernetes	[no test files]
=== RUN   TestAccKubernetesServiceAccount_basic
--- PASS: TestAccKubernetesServiceAccount_basic (0.73s)
=== RUN   TestAccKubernetesServiceAccount_automount
--- PASS: TestAccKubernetesServiceAccount_automount (0.72s)
=== RUN   TestAccKubernetesServiceAccount_update
--- PASS: TestAccKubernetesServiceAccount_update (0.85s)
=== RUN   TestAccKubernetesServiceAccount_generatedName
--- PASS: TestAccKubernetesServiceAccount_generatedName (0.60s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	3.513s
------------------------------------------------------------
```

@terraform-providers/ecosystem 