### PR TITLE
Kops on AWS test env - create state S3 bucket via Terraform

### DIFF
--- a/kubernetes/test-infra/kops-on-aws/kops-create.sh
+++ b/kubernetes/test-infra/kops-on-aws/kops-create.sh
@@ -3,7 +3,6 @@ export NODE_SIZE=t2.small
 export MASTER_SIZE=t2.medium
 export KOPS_STATE_STORE="s3://${BUCKET_NAME}"
 
-aws s3api create-bucket --acl=private --bucket $BUCKET_NAME && \
 kops create cluster --cloud=aws \
   --name=$CLUSTER_NAME \
   --state=$KOPS_STATE_STORE \

--- a/kubernetes/test-infra/kops-on-aws/kops-delete.sh
+++ b/kubernetes/test-infra/kops-on-aws/kops-delete.sh
@@ -2,6 +2,4 @@
 kops delete cluster \
   --name=${CLUSTER_NAME} \
   --state=s3://${BUCKET_NAME} \
-  --yes && \
-aws s3 rm s3://${BUCKET_NAME} --recursive && \
-aws s3api delete-bucket --bucket $BUCKET_NAME
+  --yes

--- a/kubernetes/test-infra/kops-on-aws/main.tf
+++ b/kubernetes/test-infra/kops-on-aws/main.tf
@@ -39,8 +39,9 @@ resource "tls_private_key" "ssh" {
 }
 
 resource "aws_s3_bucket" "kops_state_store" {
-  bucket = "${local.bucket_name}"
-  acl    = "private"
+  bucket        = "${local.bucket_name}"
+  acl           = "private"
+  force_destroy = true
 
   tags {
     Usage     = "kops_state_store"

--- a/kubernetes/test-infra/kops-on-aws/main.tf
+++ b/kubernetes/test-infra/kops-on-aws/main.tf
@@ -1,4 +1,4 @@
-provider "aws" { }
+provider "aws" {}
 
 variable "route53_zone" {
   type = "string"
@@ -9,12 +9,12 @@ variable "kubernetes_version" {
 }
 
 variable "s3_bucket_prefix" {
-  type = "string"
+  type    = "string"
   default = "kops-tfacc"
 }
 
 variable "private_ssh_key_filename" {
-  type = "string"
+  type    = "string"
   default = "id_rsa"
 }
 
@@ -23,8 +23,8 @@ resource "random_id" "name" {
 }
 
 locals {
-  cluster_name = "${random_id.name.hex}.kops.${var.route53_zone}"
-  bucket_name = "${var.s3_bucket_prefix}-${random_id.name.hex}"
+  cluster_name            = "${random_id.name.hex}.kops.${var.route53_zone}"
+  bucket_name             = "${var.s3_bucket_prefix}-${random_id.name.hex}"
   public_ssh_key_location = "${path.module}/${var.private_ssh_key_filename}.pub"
 }
 
@@ -35,15 +35,27 @@ data "http" "ipinfo" {
 }
 
 resource "tls_private_key" "ssh" {
-  algorithm   = "RSA"
+  algorithm = "RSA"
+}
+
+resource "aws_s3_bucket" "kops_state_store" {
+  bucket = "${local.bucket_name}"
+  acl    = "private"
+
+  tags {
+    Usage     = "kops_state_store"
+    BelongsTo = "${local.cluster_name}"
+  }
 }
 
 resource "null_resource" "kops" {
+  depends_on = ["aws_s3_bucket.kops_state_store"]
+
   provisioner "local-exec" {
     command = <<EOF
 ssh-keygen -P "" -t rsa -f ./${var.private_ssh_key_filename}
 export CLUSTER_NAME=${local.cluster_name}
-export BUCKET_NAME=${local.bucket_name}
+export BUCKET_NAME=${aws_s3_bucket.kops_state_store.bucket}
 export KUBERNETES_VERSION=${var.kubernetes_version}
 export IP_ADDRESS=${chomp(data.http.ipinfo.body)}
 export ZONES=${data.aws_availability_zones.available.names[0]}
@@ -54,6 +66,7 @@ EOF
 
   provisioner "local-exec" {
     when = "destroy"
+
     command = <<EOF
 export CLUSTER_NAME=${local.cluster_name}
 export BUCKET_NAME=${local.bucket_name}


### PR DESCRIPTION
We run acceptance tests on clusters constructed with Kops on AWS. 
Kops requires a pre-existing S3 bucket to store its state in.

With this change, we create the bucket using Terraform itself, as a resource, instead of the AWS CLI.
Aside from being more explicit, this enables spinning up this environment in other regions.
To do this, the AWS CLI would otherwise require some additional JSON arguments (--create-bucket-configuration).

@terraform-providers/ecosystem 
@radeksimko 