### PR TITLE
Fix deployment acc tests

### DIFF
--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -133,7 +133,7 @@ func unsetEnv(t *testing.T) func() {
 
 func getEnv() *currentEnv {
 	e := &currentEnv{
-		Ctx:               os.Getenv("KUBE_CTX_CLUSTER"),
+		Ctx:               os.Getenv("KUBE_CTX"),
 		CtxAuthInfo:       os.Getenv("KUBE_CTX_AUTH_INFO"),
 		CtxCluster:        os.Getenv("KUBE_CTX_CLUSTER"),
 		Host:              os.Getenv("KUBE_HOST"),
@@ -153,7 +153,9 @@ func getEnv() *currentEnv {
 }
 
 func testAccPreCheck(t *testing.T) {
-	hasFileCfg := (os.Getenv("KUBE_CTX_AUTH_INFO") != "" && os.Getenv("KUBE_CTX_CLUSTER") != "")
+	hasFileCfg := (os.Getenv("KUBE_CTX_AUTH_INFO") != "" &&
+		os.Getenv("KUBE_CTX_CLUSTER") != "") ||
+		os.Getenv("KUBECONFIG") != ""
 	hasStaticCfg := (os.Getenv("KUBE_HOST") != "" &&
 		os.Getenv("KUBE_USER") != "" &&
 		os.Getenv("KUBE_PASSWORD") != "" &&

--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -489,113 +489,133 @@ func testAccCheckKubernetesDeploymentExists(n string, obj *api.Deployment) resou
 
 func testAccKubernetesDeploymentConfig_basic(name string) string {
 	return fmt.Sprintf(`
-	resource "kubernetes_deployment" "test" {
-		metadata {
-			annotations {
-				TestAnnotationOne = "one"
-				TestAnnotationTwo = "two"
-			}
-			labels {
+resource "kubernetes_deployment" "test" {
+	metadata {
+		annotations {
+			TestAnnotationOne = "one"
+			TestAnnotationTwo = "two"
+		}
+		labels {
+			TestLabelOne   = "one"
+			TestLabelTwo   = "two"
+			TestLabelThree = "three"
+		}
+		name = "%s"
+	}
+	spec {
+		replicas = 300 # This is intentionally high to exercise the waiter
+		selector {
+			match_labels {
 				TestLabelOne   = "one"
 				TestLabelTwo   = "two"
 				TestLabelThree = "three"
 			}
-			name = "%s"
 		}
-		spec {
-			replicas = 1000 # This is intentionally high to exercise the waiter
-			selector {
-				match_labels {
+		template {
+			metadata {
+				labels {
 					TestLabelOne   = "one"
 					TestLabelTwo   = "two"
 					TestLabelThree = "three"
 				}
 			}
-			template {
-				metadata {
-					labels {
-						TestLabelOne   = "one"
-						TestLabelTwo   = "two"
-						TestLabelThree = "three"
-					}
-				}
-				spec {
-					container {
-						image = "nginx:1.7.8"
-						name  = "tf-acc-test"
+			spec {
+				container {
+					image = "nginx:1.7.8"
+					name  = "tf-acc-test"
+					resources {
+						requests {
+							memory = "64Mi"
+							cpu = "50m"
+						}
 					}
 				}
 			}
 		}
 	}
+}
 `, name)
 }
 
 func testAccKubernetesDeploymentConfig_initContainer(name string) string {
 	return fmt.Sprintf(`
-	resource "kubernetes_deployment" "test" {
-		metadata {
-			annotations {
-				TestAnnotationOne = "one"
-				TestAnnotationTwo = "two"
-			}
-			labels {
+resource "kubernetes_deployment" "test" {
+	metadata {
+		annotations {
+			TestAnnotationOne = "one"
+			TestAnnotationTwo = "two"
+		}
+		labels {
+			TestLabelOne   = "one"
+			TestLabelTwo   = "two"
+			TestLabelThree = "three"
+		}
+		name = "%s"
+	}
+	spec {
+		replicas = 300 # This is intentionally high to exercise the waiter
+		selector {
+			match_labels {
 				TestLabelOne   = "one"
 				TestLabelTwo   = "two"
 				TestLabelThree = "three"
 			}
-			name = "%s"
 		}
-		spec {
-			replicas = 1000 # This is intentionally high to exercise the waiter
-			selector {
-				match_labels {
+		template {
+			metadata {
+				labels {
 					TestLabelOne   = "one"
 					TestLabelTwo   = "two"
 					TestLabelThree = "three"
 				}
 			}
-			template {
-				metadata {
-					labels {
-						TestLabelOne   = "one"
-						TestLabelTwo   = "two"
-						TestLabelThree = "three"
+			spec {
+				container {
+					name  = "nginx"
+					image = "nginx"
+
+					port {
+						container_port = 80
+					}
+
+					resources {
+						requests {
+							memory = "64Mi"
+							cpu = "50m"
+						}
+					}
+
+					volume_mount {
+						name       = "workdir"
+						mount_path = "/usr/share/nginx/html"
 					}
 				}
-				spec {
-					container {
-						name  = "nginx"
-						image = "nginx"
+				init_container {
+					name    = "install"
+					image   = "busybox"
+					command = ["wget", "-O", "/work-dir/index.html", "http://kubernetes.io"]
 
-						port {
-							container_port = 80
-						}
-
-						volume_mount {
-							name       = "workdir"
-							mount_path = "/usr/share/nginx/html"
+					resources {
+						requests {
+							memory = "64Mi"
+							cpu = "50m"
 						}
 					}
-					init_container {
-						name    = "install"
-						image   = "busybox"
-						command = ["wget", "-O", "/work-dir/index.html", "http://kubernetes.io"]
 
-						volume_mount {
-							name       = "workdir"
-							mount_path = "/work-dir"
-						}
+					volume_mount {
+						name       = "workdir"
+						mount_path = "/work-dir"
 					}
-					dns_policy = "Default"
-					volume {
-						name      = "workdir"
-						empty_dir = {}
-					}
+				}
+				dns_policy = "Default"
+				volume {
+					name      = "workdir"
+					empty_dir = {}
 				}
 			}
 		}
-	}`, name)
+	}
+}`, name)
 }
 
 func testAccKubernetesDeploymentConfig_modified(name string) string {
@@ -641,420 +661,420 @@ func testAccKubernetesDeploymentConfig_modified(name string) string {
 
 func testAccKubernetesDeploymentConfig_generatedName(prefix string) string {
 	return fmt.Sprintf(`
-	resource "kubernetes_deployment" "test" {
-		metadata {
-			labels {
+resource "kubernetes_deployment" "test" {
+	metadata {
+		labels {
+			TestLabelOne   = "one"
+			TestLabelTwo   = "two"
+			TestLabelThree = "three"
+		}
+		generate_name = "%s"
+	}
+	spec {
+		selector {
+			match_labels {
 				TestLabelOne   = "one"
 				TestLabelTwo   = "two"
 				TestLabelThree = "three"
 			}
-			generate_name = "%s"
 		}
-		spec {
-			selector {
-				match_labels {
+		template {
+			metadata {
+				labels {
 					TestLabelOne   = "one"
 					TestLabelTwo   = "two"
 					TestLabelThree = "three"
 				}
 			}
-			template {
-				metadata {
-					labels {
-						TestLabelOne   = "one"
-						TestLabelTwo   = "two"
-						TestLabelThree = "three"
-					}
-				}
-				spec {
-					container {
-						image = "nginx:1.7.9"
-						name  = "tf-acc-test"
-					}
+			spec {
+				container {
+					image = "nginx:1.7.9"
+					name  = "tf-acc-test"
 				}
 			}
 		}
-	}`, prefix)
+	}
+}`, prefix)
 }
 
 func testAccKubernetesDeploymentConfigWithSecurityContext(rcName, imageName string) string {
 	return fmt.Sprintf(`
-	resource "kubernetes_deployment" "test" {
-		metadata {
-			name = "%s"
-			labels {
+resource "kubernetes_deployment" "test" {
+	metadata {
+		name = "%s"
+		labels {
+			Test = "TfAcceptanceTest"
+		}
+	}
+	spec {
+		selector {
+			match_labels {
 				Test = "TfAcceptanceTest"
 			}
 		}
-		spec {
-			selector {
-				match_labels {
+		template {
+			metadata {
+				labels {
 					Test = "TfAcceptanceTest"
 				}
 			}
-			template {
-				metadata {
-					labels {
-						Test = "TfAcceptanceTest"
-					}
+			spec {
+				security_context {
+					run_as_non_root     = true
+					run_as_user         = 101
+					supplemental_groups = [101]
 				}
-				spec {
-					security_context {
-						run_as_non_root     = true
-						run_as_user         = 101
-						supplemental_groups = [101]
-					}
-					container {
-						image = "%s"
-						name  = "containername"
-					}
+				container {
+					image = "%s"
+					name  = "containername"
 				}
 			}
 		}
-	}`, rcName, imageName)
+	}
+}`, rcName, imageName)
 }
 
 func testAccKubernetesDeploymentConfigWithLivenessProbeUsingExec(rcName, imageName string) string {
 	return fmt.Sprintf(`
-	resource "kubernetes_deployment" "test" {
-		metadata {
-			name = "%s"
-			labels {
+resource "kubernetes_deployment" "test" {
+	metadata {
+		name = "%s"
+		labels {
+			Test = "TfAcceptanceTest"
+		}
+	}
+	spec {
+		selector {
+			match_labels {
 				Test = "TfAcceptanceTest"
 			}
 		}
-		spec {
-			selector {
-				match_labels {
+		template {
+			metadata {
+				labels {
 					Test = "TfAcceptanceTest"
 				}
 			}
-			template {
-				metadata {
-					labels {
-						Test = "TfAcceptanceTest"
-					}
-				}
-				spec {
-					container {
-						image = "%s"
-						name  = "containername"
-						args  = ["/bin/sh", "-c", "touch /tmp/healthy; sleep 300; rm -rf /tmp/healthy; sleep 600"]
-						liveness_probe {
-							exec {
-								command = ["cat", "/tmp/healthy"]
-							}
-							initial_delay_seconds = 5
-							period_seconds        = 5
+			spec {
+				container {
+					image = "%s"
+					name  = "containername"
+					args  = ["/bin/sh", "-c", "touch /tmp/healthy; sleep 300; rm -rf /tmp/healthy; sleep 600"]
+					liveness_probe {
+						exec {
+							command = ["cat", "/tmp/healthy"]
 						}
+						initial_delay_seconds = 5
+						period_seconds        = 5
 					}
 				}
 			}
 		}
-	}`, rcName, imageName)
+	}
+}`, rcName, imageName)
 }
 
 func testAccKubernetesDeploymentConfigWithLivenessProbeUsingHTTPGet(rcName, imageName string) string {
 	return fmt.Sprintf(`
-	resource "kubernetes_deployment" "test" {
-		metadata {
-			name = "%s"
+resource "kubernetes_deployment" "test" {
+	metadata {
+		name = "%s"
 
-			labels {
+		labels {
+			Test = "TfAcceptanceTest"
+		}
+	}
+	spec {
+		selector {
+			match_labels {
 				Test = "TfAcceptanceTest"
 			}
 		}
-		spec {
-			selector {
-				match_labels {
+		template {
+			metadata {
+				labels {
 					Test = "TfAcceptanceTest"
 				}
 			}
-			template {
-				metadata {
-					labels {
-						Test = "TfAcceptanceTest"
-					}
-				}
-				spec {
-					container {
-						image = "%s"
-						name  = "containername"
-						args  = ["/server"]
-						liveness_probe {
-							http_get {
-								path = "/healthz"
-								port = 8080
-								http_header {
-									name  = "X-Custom-Header"
-									value = "Awesome"
-								}
+			spec {
+				container {
+					image = "%s"
+					name  = "containername"
+					args  = ["/server"]
+					liveness_probe {
+						http_get {
+							path = "/healthz"
+							port = 8080
+							http_header {
+								name  = "X-Custom-Header"
+								value = "Awesome"
 							}
-							initial_delay_seconds = 3
-							period_seconds        = 3
 						}
+						initial_delay_seconds = 3
+						period_seconds        = 3
 					}
 				}
 			}
 		}
-	}`, rcName, imageName)
+	}
+}`, rcName, imageName)
 }
 
 func testAccKubernetesDeploymentConfigWithLivenessProbeUsingTCP(rcName, imageName string) string {
 	return fmt.Sprintf(`
-	resource "kubernetes_deployment" "test" {
-		metadata {
-			name = "%s"
-			labels {
+resource "kubernetes_deployment" "test" {
+	metadata {
+		name = "%s"
+		labels {
+			Test = "TfAcceptanceTest"
+		}
+	}
+	spec {
+		selector {
+			match_labels {
 				Test = "TfAcceptanceTest"
 			}
 		}
-		spec {
-			selector {
-				match_labels {
+		template {
+			metadata {
+				labels {
 					Test = "TfAcceptanceTest"
 				}
 			}
-			template {
-				metadata {
-					labels {
-						Test = "TfAcceptanceTest"
-					}
-				}
-				spec {
-					container {
-						image = "%s"
-						name  = "containername"
-						args  = ["/server"]
-						liveness_probe {
-							tcp_socket {
-								port = 8080
-							}
-							initial_delay_seconds = 3
-							period_seconds        = 3
+			spec {
+				container {
+					image = "%s"
+					name  = "containername"
+					args  = ["/server"]
+					liveness_probe {
+						tcp_socket {
+							port = 8080
 						}
+						initial_delay_seconds = 3
+						period_seconds        = 3
 					}
 				}
 			}
 		}
-	}`, rcName, imageName)
+	}
+}`, rcName, imageName)
 }
 
 func testAccKubernetesDeploymentConfigWithLifeCycle(rcName, imageName string) string {
 	return fmt.Sprintf(`
-	resource "kubernetes_deployment" "test" {
-		metadata {
-			name = "%s"
-			labels {
+resource "kubernetes_deployment" "test" {
+	metadata {
+		name = "%s"
+		labels {
+			Test = "TfAcceptanceTest"
+		}
+	}
+	spec {
+		selector {
+			match_labels {
 				Test = "TfAcceptanceTest"
 			}
 		}
-		spec {
-			selector {
-				match_labels {
+		template {
+			metadata {
+				labels {
 					Test = "TfAcceptanceTest"
 				}
 			}
-			template {
-				metadata {
-					labels {
-						Test = "TfAcceptanceTest"
-					}
-				}
-				spec {
-					container {
-						image = "%s"
-						name  = "containername"
-						args  = ["/server"]
-						lifecycle {
-							post_start {
-								exec {
-									command = ["ls", "-al"]
-								}
+			spec {
+				container {
+					image = "%s"
+					name  = "containername"
+					args  = ["/server"]
+					lifecycle {
+						post_start {
+							exec {
+								command = ["ls", "-al"]
 							}
-							pre_stop {
-								exec {
-									command = ["date"]
-								}
+						}
+						pre_stop {
+							exec {
+								command = ["date"]
 							}
 						}
 					}
 				}
 			}
 		}
-	}`, rcName, imageName)
+	}
+}`, rcName, imageName)
 }
 
 func testAccKubernetesDeploymentConfigWithContainerSecurityContext(rcName, imageName string) string {
 	return fmt.Sprintf(`
-	resource "kubernetes_deployment" "test" {
-		metadata {
-			name = "%s"
-			labels {
+resource "kubernetes_deployment" "test" {
+	metadata {
+		name = "%s"
+		labels {
+			Test = "TfAcceptanceTest"
+		}
+	}
+	spec {
+		selector {
+			match_labels {
 				Test = "TfAcceptanceTest"
 			}
 		}
-		spec {
-			selector {
-				match_labels {
+		template {
+			metadata {
+				labels {
 					Test = "TfAcceptanceTest"
 				}
 			}
-			template {
-				metadata {
-					labels {
-						Test = "TfAcceptanceTest"
-					}
-				}
-				spec {
-					container {
-						image = "%s"
-						name  = "containername"
-						security_context {
-							privileged  = true
-							run_as_user = 1
-							se_linux_options {
-								level = "s0:c123,c456"
-							}
+			spec {
+				container {
+					image = "%s"
+					name  = "containername"
+					security_context {
+						privileged  = true
+						run_as_user = 1
+						se_linux_options {
+							level = "s0:c123,c456"
 						}
 					}
 				}
 			}
 		}
-	}`, rcName, imageName)
+	}
+}`, rcName, imageName)
 }
 
 func testAccKubernetesDeploymentConfigWithVolumeMounts(secretName, rcName, imageName string) string {
 	return fmt.Sprintf(`
-	resource "kubernetes_secret" "test" {
-		metadata {
-			name = "%s"
-		}
-		data {
-			one = "first"
+resource "kubernetes_secret" "test" {
+	metadata {
+		name = "%s"
+	}
+	data {
+		one = "first"
+	}
+}
+
+resource "kubernetes_deployment" "test" {
+	metadata {
+		name = "%s"
+		labels {
+			Test = "TfAcceptanceTest"
 		}
 	}
-
-	resource "kubernetes_deployment" "test" {
-		metadata {
-			name = "%s"
-			labels {
+	spec {
+		selector {
+			match_labels {
 				Test = "TfAcceptanceTest"
 			}
 		}
-		spec {
-			selector {
-				match_labels {
+		template {
+			metadata {
+				labels {
 					Test = "TfAcceptanceTest"
 				}
 			}
-			template {
-				metadata {
-					labels {
-						Test = "TfAcceptanceTest"
+			spec {
+				container {
+					image = "%s"
+					name  = "containername"
+					volume_mount {
+						mount_path = "/tmp/my_path"
+						name       = "db"
 					}
 				}
-				spec {
-					container {
-						image = "%s"
-						name  = "containername"
-						volume_mount {
-							mount_path = "/tmp/my_path"
-							name       = "db"
-						}
-					}
-					volume {
-						name = "db"
-						secret = {
-							secret_name = "${kubernetes_secret.test.metadata.0.name}"
-						}
+				volume {
+					name = "db"
+					secret = {
+						secret_name = "${kubernetes_secret.test.metadata.0.name}"
 					}
 				}
 			}
 		}
-	}`, secretName, rcName, imageName)
+	}
+}`, secretName, rcName, imageName)
 }
 
 func testAccKubernetesDeploymentConfigWithResourceRequirements(rcName, imageName string) string {
 	return fmt.Sprintf(`
-	resource "kubernetes_deployment" "test" {
-		metadata {
-			name = "%s"
-			labels {
+resource "kubernetes_deployment" "test" {
+	metadata {
+		name = "%s"
+		labels {
+			Test = "TfAcceptanceTest"
+		}
+	}
+	spec {
+		selector {
+			match_labels {
 				Test = "TfAcceptanceTest"
 			}
 		}
-		spec {
-			selector {
-				match_labels {
+		template {
+			metadata {
+				labels {
 					Test = "TfAcceptanceTest"
 				}
 			}
-			template {
-				metadata {
-					labels {
-						Test = "TfAcceptanceTest"
-					}
-				}
-				spec {
-					container {
-						image = "%s"
-						name  = "containername"
-						resources {
-							limits {
-								cpu    = "0.5"
-								memory = "512Mi"
-							}
-							requests {
-								cpu    = "250m"
-								memory = "50Mi"
-							}
+			spec {
+				container {
+					image = "%s"
+					name  = "containername"
+					resources {
+						limits {
+							cpu    = "0.5"
+							memory = "512Mi"
+						}
+						requests {
+							cpu    = "250m"
+							memory = "50Mi"
 						}
 					}
 				}
 			}
 		}
-	}`, rcName, imageName)
+	}
+}`, rcName, imageName)
 }
 
 func testAccKubernetesDeploymentConfigWithEmptyDirVolumes(rcName, imageName string) string {
 	return fmt.Sprintf(`
-	resource "kubernetes_deployment" "test" {
-		metadata {
-			name = "%s"
-			labels {
+resource "kubernetes_deployment" "test" {
+	metadata {
+		name = "%s"
+		labels {
+			Test = "TfAcceptanceTest"
+		}
+	}
+	spec {
+		selector {
+			match_labels {
 				Test = "TfAcceptanceTest"
 			}
 		}
-		spec {
-			selector {
-				match_labels {
+		template {
+			metadata {
+				labels {
 					Test = "TfAcceptanceTest"
 				}
 			}
-			template {
-				metadata {
-					labels {
-						Test = "TfAcceptanceTest"
+			spec {
+				container {
+					image = "%s"
+					name  = "containername"
+					volume_mount {
+						mount_path = "/cache"
+						name       = "cache-volume"
 					}
 				}
-				spec {
-					container {
-						image = "%s"
-						name  = "containername"
-						volume_mount {
-							mount_path = "/cache"
-							name       = "cache-volume"
-						}
-					}
-					volume {
-						name = "cache-volume"
-						empty_dir = {
-							medium = "Memory"
-						}
+				volume {
+					name = "cache-volume"
+					empty_dir = {
+						medium = "Memory"
 					}
 				}
 			}
 		}
-	}`, rcName, imageName)
+	}
+}`, rcName, imageName)
 }

--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -13,36 +13,38 @@ import (
 	kubernetes "k8s.io/client-go/kubernetes"
 )
 
+const deploymentTestResourceName = "kubernetes_deployment.test"
+
 func TestAccKubernetesDeployment_basic(t *testing.T) {
 	var conf api.Deployment
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "kubernetes_deployment.test",
+		IDRefreshName: deploymentTestResourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccKubernetesDeploymentConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesDeploymentExists("kubernetes_deployment.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "metadata.0.annotations.%", "2"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "metadata.0.annotations.TestAnnotationOne", "one"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "metadata.0.annotations.TestAnnotationTwo", "two"),
+					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.annotations.%", "2"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.annotations.TestAnnotationOne", "one"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.annotations.TestAnnotationTwo", "two"),
 					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{"TestAnnotationOne": "one", "TestAnnotationTwo": "two"}),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "metadata.0.labels.%", "3"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "metadata.0.labels.TestLabelOne", "one"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "metadata.0.labels.TestLabelTwo", "two"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "metadata.0.labels.TestLabelThree", "three"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.labels.%", "3"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.labels.TestLabelOne", "one"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.labels.TestLabelTwo", "two"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.labels.TestLabelThree", "three"),
 					testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{"TestLabelOne": "one", "TestLabelTwo": "two", "TestLabelThree": "three"}),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "metadata.0.name", name),
-					resource.TestCheckResourceAttrSet("kubernetes_deployment.test", "metadata.0.generation"),
-					resource.TestCheckResourceAttrSet("kubernetes_deployment.test", "metadata.0.resource_version"),
-					resource.TestCheckResourceAttrSet("kubernetes_deployment.test", "metadata.0.self_link"),
-					resource.TestCheckResourceAttrSet("kubernetes_deployment.test", "metadata.0.uid"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.image", "nginx:1.7.8"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.name", "tf-acc-test"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet(deploymentTestResourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(deploymentTestResourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(deploymentTestResourceName, "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet(deploymentTestResourceName, "metadata.0.uid"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.image", "nginx:1.7.8"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.name", "tf-acc-test"),
 				),
 			},
 		},
@@ -55,22 +57,22 @@ func TestAccKubernetesDeployment_initContainer(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "kubernetes_deployment.test",
+		IDRefreshName: deploymentTestResourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccKubernetesDeploymentConfig_initContainer(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesDeploymentExists("kubernetes_deployment.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.init_container.0.image", "busybox"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.init_container.0.name", "install"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.init_container.0.command.0", "wget"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.init_container.0.command.1", "-O"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.init_container.0.command.2", "/work-dir/index.html"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.init_container.0.command.3", "http://kubernetes.io"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.init_container.0.volume_mount.0.name", "workdir"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.init_container.0.volume_mount.0.mount_path", "/work-dir"),
+					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.init_container.0.image", "busybox"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.init_container.0.name", "install"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.init_container.0.command.0", "wget"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.init_container.0.command.1", "-O"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.init_container.0.command.2", "/work-dir/index.html"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.init_container.0.command.3", "http://kubernetes.io"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.init_container.0.volume_mount.0.name", "workdir"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.init_container.0.volume_mount.0.mount_path", "/work-dir"),
 				),
 			},
 		},
@@ -78,7 +80,7 @@ func TestAccKubernetesDeployment_initContainer(t *testing.T) {
 }
 
 func TestAccKubernetesDeployment_importBasic(t *testing.T) {
-	resourceName := "kubernetes_deployment.test"
+	resourceName := deploymentTestResourceName
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
@@ -105,24 +107,24 @@ func TestAccKubernetesDeployment_generatedName(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "kubernetes_deployment.test",
+		IDRefreshName: deploymentTestResourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckKubernetesDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccKubernetesDeploymentConfig_generatedName(prefix),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesDeploymentExists("kubernetes_deployment.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "metadata.0.annotations.%", "0"),
+					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.annotations.%", "0"),
 					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{}),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "metadata.0.labels.%", "3"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.labels.%", "3"),
 					testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{"TestLabelOne": "one", "TestLabelTwo": "two", "TestLabelThree": "three"}),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "metadata.0.generate_name", prefix),
-					resource.TestMatchResourceAttr("kubernetes_deployment.test", "metadata.0.name", regexp.MustCompile("^"+prefix)),
-					resource.TestCheckResourceAttrSet("kubernetes_deployment.test", "metadata.0.generation"),
-					resource.TestCheckResourceAttrSet("kubernetes_deployment.test", "metadata.0.resource_version"),
-					resource.TestCheckResourceAttrSet("kubernetes_deployment.test", "metadata.0.self_link"),
-					resource.TestCheckResourceAttrSet("kubernetes_deployment.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.generate_name", prefix),
+					resource.TestMatchResourceAttr(deploymentTestResourceName, "metadata.0.name", regexp.MustCompile("^"+prefix)),
+					resource.TestCheckResourceAttrSet(deploymentTestResourceName, "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet(deploymentTestResourceName, "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet(deploymentTestResourceName, "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet(deploymentTestResourceName, "metadata.0.uid"),
 				),
 			},
 		},
@@ -130,7 +132,7 @@ func TestAccKubernetesDeployment_generatedName(t *testing.T) {
 }
 
 func TestAccKubernetesDeployment_importGeneratedName(t *testing.T) {
-	resourceName := "kubernetes_deployment.test"
+	resourceName := deploymentTestResourceName
 	prefix := "tf-acc-test-gen-import-"
 
 	resource.Test(t, resource.TestCase{
@@ -165,11 +167,11 @@ func TestAccKubernetesDeployment_with_security_context(t *testing.T) {
 			{
 				Config: testAccKubernetesDeploymentConfigWithSecurityContext(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesDeploymentExists("kubernetes_deployment.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.security_context.0.run_as_non_root", "true"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.security_context.0.run_as_user", "101"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.security_context.0.supplemental_groups.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.security_context.0.supplemental_groups.988695518", "101"),
+					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.security_context.0.run_as_non_root", "true"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.security_context.0.run_as_user", "101"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.security_context.0.supplemental_groups.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.security_context.0.supplemental_groups.988695518", "101"),
 				),
 			},
 		},
@@ -190,15 +192,15 @@ func TestAccKubernetesDeployment_with_container_liveness_probe_using_exec(t *tes
 			{
 				Config: testAccKubernetesDeploymentConfigWithLivenessProbeUsingExec(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesDeploymentExists("kubernetes_deployment.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.args.#", "3"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.liveness_probe.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.exec.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.exec.0.command.#", "2"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.exec.0.command.0", "cat"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.exec.0.command.1", "/tmp/healthy"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.failure_threshold", "3"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.initial_delay_seconds", "5"),
+					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.args.#", "3"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.exec.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.exec.0.command.#", "2"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.exec.0.command.0", "cat"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.exec.0.command.1", "/tmp/healthy"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.failure_threshold", "3"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.initial_delay_seconds", "5"),
 				),
 			},
 		},
@@ -219,16 +221,16 @@ func TestAccKubernetesDeployment_with_container_liveness_probe_using_http_get(t 
 			{
 				Config: testAccKubernetesDeploymentConfigWithLivenessProbeUsingHTTPGet(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesDeploymentExists("kubernetes_deployment.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.args.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.liveness_probe.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.http_get.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.http_get.0.path", "/healthz"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.http_get.0.port", "8080"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.http_get.0.http_header.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.http_get.0.http_header.0.name", "X-Custom-Header"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.http_get.0.http_header.0.value", "Awesome"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.initial_delay_seconds", "3"),
+					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.args.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.http_get.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.http_get.0.path", "/healthz"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.http_get.0.port", "8080"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.http_get.0.http_header.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.http_get.0.http_header.0.name", "X-Custom-Header"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.http_get.0.http_header.0.value", "Awesome"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.initial_delay_seconds", "3"),
 				),
 			},
 		},
@@ -249,11 +251,11 @@ func TestAccKubernetesDeployment_with_container_liveness_probe_using_tcp(t *test
 			{
 				Config: testAccKubernetesDeploymentConfigWithLivenessProbeUsingTCP(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesDeploymentExists("kubernetes_deployment.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.args.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.liveness_probe.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.tcp_socket.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.liveness_probe.0.tcp_socket.0.port", "8080"),
+					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.args.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.tcp_socket.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.liveness_probe.0.tcp_socket.0.port", "8080"),
 				),
 			},
 		},
@@ -274,17 +276,17 @@ func TestAccKubernetesDeployment_with_container_lifecycle(t *testing.T) {
 			{
 				Config: testAccKubernetesDeploymentConfigWithLifeCycle(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesDeploymentExists("kubernetes_deployment.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.lifecycle.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.lifecycle.0.post_start.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.lifecycle.0.post_start.0.exec.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.lifecycle.0.post_start.0.exec.0.command.#", "2"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.lifecycle.0.post_start.0.exec.0.command.0", "ls"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.lifecycle.0.post_start.0.exec.0.command.1", "-al"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.lifecycle.0.pre_stop.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.lifecycle.0.pre_stop.0.exec.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.lifecycle.0.pre_stop.0.exec.0.command.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.lifecycle.0.pre_stop.0.exec.0.command.0", "date"),
+					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.lifecycle.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.lifecycle.0.post_start.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.lifecycle.0.post_start.0.exec.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.lifecycle.0.post_start.0.exec.0.command.#", "2"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.lifecycle.0.post_start.0.exec.0.command.0", "ls"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.lifecycle.0.post_start.0.exec.0.command.1", "-al"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.lifecycle.0.pre_stop.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.lifecycle.0.pre_stop.0.exec.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.lifecycle.0.pre_stop.0.exec.0.command.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.lifecycle.0.pre_stop.0.exec.0.command.0", "date"),
 				),
 			},
 		},
@@ -305,8 +307,8 @@ func TestAccKubernetesDeployment_with_container_security_context(t *testing.T) {
 			{
 				Config: testAccKubernetesDeploymentConfigWithContainerSecurityContext(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesDeploymentExists("kubernetes_deployment.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.security_context.#", "1"),
+					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.security_context.#", "1"),
 				),
 			},
 		},
@@ -329,13 +331,13 @@ func TestAccKubernetesDeployment_with_volume_mount(t *testing.T) {
 			{
 				Config: testAccKubernetesDeploymentConfigWithVolumeMounts(secretName, rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesDeploymentExists("kubernetes_deployment.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.image", imageName),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.volume_mount.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.volume_mount.0.mount_path", "/tmp/my_path"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.volume_mount.0.name", "db"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.volume_mount.0.read_only", "false"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.volume_mount.0.sub_path", ""),
+					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.image", imageName),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.volume_mount.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.volume_mount.0.mount_path", "/tmp/my_path"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.volume_mount.0.name", "db"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.volume_mount.0.read_only", "false"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.volume_mount.0.sub_path", ""),
 				),
 			},
 		},
@@ -357,12 +359,12 @@ func TestAccKubernetesDeployment_with_resource_requirements(t *testing.T) {
 			{
 				Config: testAccKubernetesDeploymentConfigWithResourceRequirements(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesDeploymentExists("kubernetes_deployment.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.image", imageName),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.resources.0.requests.0.memory", "50Mi"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.resources.0.requests.0.cpu", "250m"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.resources.0.limits.0.memory", "512Mi"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.resources.0.limits.0.cpu", "500m"),
+					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.image", imageName),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.resources.0.requests.0.memory", "50Mi"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.resources.0.requests.0.cpu", "250m"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.resources.0.limits.0.memory", "512Mi"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.resources.0.limits.0.cpu", "500m"),
 				),
 			},
 		},
@@ -383,12 +385,12 @@ func TestAccKubernetesDeployment_with_empty_dir_volume(t *testing.T) {
 			{
 				Config: testAccKubernetesDeploymentConfigWithEmptyDirVolumes(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesDeploymentExists("kubernetes_deployment.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.image", imageName),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.volume_mount.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.volume_mount.0.mount_path", "/cache"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.volume_mount.0.name", "cache-volume"),
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.volume.0.empty_dir.0.medium", "Memory"),
+					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.image", imageName),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.volume_mount.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.volume_mount.0.mount_path", "/cache"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.volume_mount.0.name", "cache-volume"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.volume.0.empty_dir.0.medium", "Memory"),
 				),
 			},
 		},
@@ -408,29 +410,29 @@ func TestAccKubernetesDeploymentUpdate_basic(t *testing.T) {
 			{
 				Config: testAccKubernetesDeploymentConfig_basic(rcName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesDeploymentExists("kubernetes_deployment.test", &conf),
+					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					// Not to be changed
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "metadata.0.annotations.TestAnnotationOne", "one"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.annotations.TestAnnotationOne", "one"),
 					// To be removed
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "metadata.0.annotations.TestAnnotationTwo", "two"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.annotations.TestAnnotationTwo", "two"),
 					// To be added
-					resource.TestCheckNoResourceAttr("kubernetes_deployment.test", "metadata.0.annotations.Different"),
+					resource.TestCheckNoResourceAttr(deploymentTestResourceName, "metadata.0.annotations.Different"),
 					// To be changed
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.image", "nginx:1.7.8"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.image", "nginx:1.7.8"),
 				),
 			},
 			{
 				Config: testAccKubernetesDeploymentConfig_modified(rcName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckKubernetesDeploymentExists("kubernetes_deployment.test", &conf),
+					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					// Unchanged
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "metadata.0.annotations.TestAnnotationOne", "one"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.annotations.TestAnnotationOne", "one"),
 					// Removed
-					resource.TestCheckNoResourceAttr("kubernetes_deployment.test", "metadata.0.annotations.TestAnnotationTwo"),
+					resource.TestCheckNoResourceAttr(deploymentTestResourceName, "metadata.0.annotations.TestAnnotationTwo"),
 					// Added
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "metadata.0.annotations.Different", "1234"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "metadata.0.annotations.Different", "1234"),
 					// Changed
-					resource.TestCheckResourceAttr("kubernetes_deployment.test", "spec.0.template.0.spec.0.container.0.image", "nginx:1.7.9"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.image", "nginx:1.7.9"),
 				),
 			},
 		},

--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -34,6 +34,7 @@ resource "google_container_cluster" "primary" {
   }
 
   node_config {
+    machine_type = "n1-standard-4"
     oauth_scopes = [
       "https://www.googleapis.com/auth/compute",
       "https://www.googleapis.com/auth/devstorage.read_only",


### PR DESCRIPTION
This change improves the reliability of the `Deployment` resource tests, particularly on GKE.

Specifically, it does:
* pin down the instance type for the test cluster nodes
* reduce the deployment replicas count to 300 because GKE has a per node limit of 110 pods
* add explicit resource claims to `Deployment` containers to make them fit the test cluster's resources
* fix an issue with extracting K8S configuration context from provider env vars
* make the provider configuration aware of `KUBECONFIG` env var
* `const` the test resource name

```
TESTARGS='-run ^TestAccKubernetesDeployment' make testacc                                   alex@alexs-macbook
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run ^TestAccKubernetesDeployment -timeout 120m
?   	github.com/terraform-providers/terraform-provider-kubernetes	[no test files]
=== RUN   TestAccKubernetesDeployment_basic
--- PASS: TestAccKubernetesDeployment_basic (37.77s)
=== RUN   TestAccKubernetesDeployment_initContainer
--- PASS: TestAccKubernetesDeployment_initContainer (0.70s)
=== RUN   TestAccKubernetesDeployment_importBasic
--- PASS: TestAccKubernetesDeployment_importBasic (0.54s)
=== RUN   TestAccKubernetesDeployment_generatedName
--- PASS: TestAccKubernetesDeployment_generatedName (0.61s)
=== RUN   TestAccKubernetesDeployment_importGeneratedName
--- PASS: TestAccKubernetesDeployment_importGeneratedName (0.83s)
=== RUN   TestAccKubernetesDeployment_with_security_context
--- PASS: TestAccKubernetesDeployment_with_security_context (0.48s)
=== RUN   TestAccKubernetesDeployment_with_container_liveness_probe_using_exec
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_exec (0.82s)
=== RUN   TestAccKubernetesDeployment_with_container_liveness_probe_using_http_get
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_http_get (0.89s)
=== RUN   TestAccKubernetesDeployment_with_container_liveness_probe_using_tcp
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_tcp (0.41s)
=== RUN   TestAccKubernetesDeployment_with_container_lifecycle
--- PASS: TestAccKubernetesDeployment_with_container_lifecycle (0.51s)
=== RUN   TestAccKubernetesDeployment_with_container_security_context
--- PASS: TestAccKubernetesDeployment_with_container_security_context (0.45s)
=== RUN   TestAccKubernetesDeployment_with_volume_mount
--- PASS: TestAccKubernetesDeployment_with_volume_mount (0.76s)
=== RUN   TestAccKubernetesDeployment_with_resource_requirements
--- PASS: TestAccKubernetesDeployment_with_resource_requirements (116.84s)
=== RUN   TestAccKubernetesDeployment_with_empty_dir_volume
--- PASS: TestAccKubernetesDeployment_with_empty_dir_volume (0.44s)
=== RUN   TestAccKubernetesDeploymentUpdate_basic
--- PASS: TestAccKubernetesDeploymentUpdate_basic (82.75s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	246.675s
------------------------------------------------------------
```

```
kubectl get nodes -owide                                          alex@alexs-macbook
NAME                                                  STATUS   ROLES    AGE   VERSION          INTERNAL-IP   EXTERNAL-IP     OS-IMAGE                             KERNEL-VERSION   CONTAINER-RUNTIME
gke-tf-acc-test-bfb7645f-default-pool-099906b1-mz88   Ready    <none>   21h   v1.11.2-gke.18   10.132.0.4    104.199.0.143   Container-Optimized OS from Google   4.14.65+         docker://17.3.2
gke-tf-acc-test-bfb7645f-default-pool-099906b1-qls6   Ready    <none>   21h   v1.11.2-gke.18   10.132.0.3    35.205.96.132   Container-Optimized OS from Google   4.14.65+         docker://17.3.2
gke-tf-acc-test-bfb7645f-default-pool-099906b1-vhgf   Ready    <none>   21h   v1.11.2-gke.18   10.132.0.2    35.205.145.59   Container-Optimized OS from Google   4.14.65+         docker://17.3.2
gke-tf-acc-test-bfb7645f-default-pool-db201615-fkc4   Ready    <none>   21h   v1.11.2-gke.18   10.132.0.5    35.241.175.8    Container-Optimized OS from Google   4.14.65+         docker://17.3.2
gke-tf-acc-test-bfb7645f-default-pool-db201615-pbp1   Ready    <none>   21h   v1.11.2-gke.18   10.132.0.7    35.187.50.188   Container-Optimized OS from Google   4.14.65+         docker://17.3.2
gke-tf-acc-test-bfb7645f-default-pool-db201615-vlwd   Ready    <none>   21h   v1.11.2-gke.18   10.132.0.6    35.189.252.99   Container-Optimized OS from Google   4.14.65+         docker://17.3.2
------------------------------------------------------------
```
@terraform-providers/ecosystem 