### PR TITLE
Format inline HCL in ACC tests

### DIFF
--- a/kubernetes/resource_kubernetes_cluster_role_binding_test.go
+++ b/kubernetes/resource_kubernetes_cluster_role_binding_test.go
@@ -134,48 +134,56 @@ func testAccCheckKubernetesClusterRoleBindingExists(n string, obj *api.ClusterRo
 func testAccKubernetesClusterRoleBindingConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_cluster_role_binding" "test" {
-	metadata {
-		name = "%s"
-	}
-	role_ref {
-		api_group = "rbac.authorization.k8s.io"
-		kind = "ClusterRole"
-		name = "cluster-admin"
-	}
-	subject {
-		kind = "User"
-		name = "notauser"
-		api_group = "rbac.authorization.k8s.io"
-	}
-}`, name)
+  metadata {
+    name = "%s"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "cluster-admin"
+  }
+
+  subject {
+    kind      = "User"
+    name      = "notauser"
+    api_group = "rbac.authorization.k8s.io"
+  }
+}
+`, name)
 }
 
 func testAccKubernetesClusterRoleBindingConfig_modified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_cluster_role_binding" "test" {
-	metadata {
-		name = "%s"
-	}
-	role_ref {
-		api_group = "rbac.authorization.k8s.io"
-		kind = "ClusterRole"
-		name = "cluster-admin"
-	}
-	subject {
-		kind = "User"
-		name = "notauser"
-		api_group = "rbac.authorization.k8s.io"
-	}
-	subject {
-		kind = "ServiceAccount"
-		name = "default"
-		api_group = ""
-		namespace = "kube-system"
-	}
-	subject {
-		kind = "Group"
-		name = "system:masters"
-		api_group = "rbac.authorization.k8s.io"
-	}
-}`, name)
+  metadata {
+    name = "%s"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "cluster-admin"
+  }
+
+  subject {
+    kind      = "User"
+    name      = "notauser"
+    api_group = "rbac.authorization.k8s.io"
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = "default"
+    api_group = ""
+    namespace = "kube-system"
+  }
+
+  subject {
+    kind      = "Group"
+    name      = "system:masters"
+    api_group = "rbac.authorization.k8s.io"
+  }
+}
+`, name)
 }

--- a/kubernetes/resource_kubernetes_config_map_test.go
+++ b/kubernetes/resource_kubernetes_config_map_test.go
@@ -249,84 +249,99 @@ func testAccCheckKubernetesConfigMapExists(n string, obj *api.ConfigMap) resourc
 func testAccKubernetesConfigMapConfig_nodata(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_config_map" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	data {}
-}`, name)
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  data {}
+}
+`, name)
 }
 
 func testAccKubernetesConfigMapConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_config_map" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	data {
-		one = "first"
-		two = "second"
-	}
-}`, name)
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  data {
+    one = "first"
+    two = "second"
+  }
+}
+`, name)
 }
 
 func testAccKubernetesConfigMapConfig_modified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_config_map" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			Different = "1234"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	data {
-		one = "first"
-		two = "second"
-		nine = "ninth"
-	}
-}`, name)
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      Different         = "1234"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  data {
+    one  = "first"
+    two  = "second"
+    nine = "ninth"
+  }
+}
+`, name)
 }
 
 func testAccKubernetesConfigMapConfig_noData(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_config_map" "test" {
-	metadata {
-		name = "%s"
-	}
-}`, name)
+  metadata {
+    name = "%s"
+  }
+}
+`, name)
 }
 
 func testAccKubernetesConfigMapConfig_generatedName(prefix string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_config_map" "test" {
-	metadata {
-		generate_name = "%s"
-	}
-	data {
-		one = "first"
-		two = "second"
-	}
-}`, prefix)
+  metadata {
+    generate_name = "%s"
+  }
+
+  data {
+    one = "first"
+    two = "second"
+  }
+}
+`, prefix)
 }

--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -490,49 +490,56 @@ func testAccCheckKubernetesDeploymentExists(n string, obj *api.Deployment) resou
 func testAccKubernetesDeploymentConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne   = "one"
-			TestLabelTwo   = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	spec {
-		replicas = 300 # This is intentionally high to exercise the waiter
-		selector {
-			match_labels {
-				TestLabelOne   = "one"
-				TestLabelTwo   = "two"
-				TestLabelThree = "three"
-			}
-		}
-		template {
-			metadata {
-				labels {
-					TestLabelOne   = "one"
-					TestLabelTwo   = "two"
-					TestLabelThree = "three"
-				}
-			}
-			spec {
-				container {
-					image = "nginx:1.7.8"
-					name  = "tf-acc-test"
-					resources {
-						requests {
-							memory = "64Mi"
-							cpu = "50m"
-						}
-					}
-				}
-			}
-		}
-	}
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    replicas = 300 # This is intentionally high to exercise the waiter
+
+    selector {
+      match_labels {
+        TestLabelOne   = "one"
+        TestLabelTwo   = "two"
+        TestLabelThree = "three"
+      }
+    }
+
+    template {
+      metadata {
+        labels {
+          TestLabelOne   = "one"
+          TestLabelTwo   = "two"
+          TestLabelThree = "three"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.8"
+          name  = "tf-acc-test"
+
+          resources {
+            requests {
+              memory = "64Mi"
+              cpu    = "50m"
+            }
+          }
+        }
+      }
+    }
+  }
 }
 `, name)
 }
@@ -540,541 +547,627 @@ resource "kubernetes_deployment" "test" {
 func testAccKubernetesDeploymentConfig_initContainer(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne   = "one"
-			TestLabelTwo   = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	spec {
-		replicas = 300 # This is intentionally high to exercise the waiter
-		selector {
-			match_labels {
-				TestLabelOne   = "one"
-				TestLabelTwo   = "two"
-				TestLabelThree = "three"
-			}
-		}
-		template {
-			metadata {
-				labels {
-					TestLabelOne   = "one"
-					TestLabelTwo   = "two"
-					TestLabelThree = "three"
-				}
-			}
-			spec {
-				container {
-					name  = "nginx"
-					image = "nginx"
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
 
-					port {
-						container_port = 80
-					}
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
 
-					resources {
-						requests {
-							memory = "64Mi"
-							cpu = "50m"
-						}
-					}
+    name = "%s"
+  }
 
-					volume_mount {
-						name       = "workdir"
-						mount_path = "/usr/share/nginx/html"
-					}
-				}
-				init_container {
-					name    = "install"
-					image   = "busybox"
-					command = ["wget", "-O", "/work-dir/index.html", "http://kubernetes.io"]
+  spec {
+    replicas = 300 # This is intentionally high to exercise the waiter
 
-					resources {
-						requests {
-							memory = "64Mi"
-							cpu = "50m"
-						}
-					}
+    selector {
+      match_labels {
+        TestLabelOne   = "one"
+        TestLabelTwo   = "two"
+        TestLabelThree = "three"
+      }
+    }
 
-					volume_mount {
-						name       = "workdir"
-						mount_path = "/work-dir"
-					}
-				}
-				dns_policy = "Default"
-				volume {
-					name      = "workdir"
-					empty_dir = {}
-				}
-			}
-		}
-	}
-}`, name)
+    template {
+      metadata {
+        labels {
+          TestLabelOne   = "one"
+          TestLabelTwo   = "two"
+          TestLabelThree = "three"
+        }
+      }
+
+      spec {
+        container {
+          name  = "nginx"
+          image = "nginx"
+
+          port {
+            container_port = 80
+          }
+
+          resources {
+            requests {
+              memory = "64Mi"
+              cpu    = "50m"
+            }
+          }
+
+          volume_mount {
+            name       = "workdir"
+            mount_path = "/usr/share/nginx/html"
+          }
+        }
+
+        init_container {
+          name    = "install"
+          image   = "busybox"
+          command = ["wget", "-O", "/work-dir/index.html", "http://kubernetes.io"]
+
+          resources {
+            requests {
+              memory = "64Mi"
+              cpu    = "50m"
+            }
+          }
+
+          volume_mount {
+            name       = "workdir"
+            mount_path = "/work-dir"
+          }
+        }
+
+        dns_policy = "Default"
+
+        volume {
+          name      = "workdir"
+          empty_dir = {}
+        }
+      }
+    }
+  }
+}
+`, name)
 }
 
 func testAccKubernetesDeploymentConfig_modified(name string) string {
 	return fmt.Sprintf(`
-	resource "kubernetes_deployment" "test" {
-		metadata {
-			annotations {
-				TestAnnotationOne = "one"
-				Different         = "1234"
-			}
-			labels {
-				TestLabelOne   = "one"
-				TestLabelThree = "three"
-			}
-			name = "%s"
-		}
-		spec {
-			selector {
-				match_labels {
-					TestLabelOne   = "one"
-					TestLabelTwo   = "two"
-					TestLabelThree = "three"
-				}
-			}
-			template {
-				metadata {
-					labels {
-						TestLabelOne   = "one"
-						TestLabelTwo   = "two"
-						TestLabelThree = "three"
-					}
-				}
-				spec {
-					container {
-						image = "nginx:1.7.9"
-						name  = "tf-acc-test"
-					}
-				}
-			}
-		}
-	}`, name)
+resource "kubernetes_deployment" "test" {
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      Different         = "1234"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    selector {
+      match_labels {
+        TestLabelOne   = "one"
+        TestLabelTwo   = "two"
+        TestLabelThree = "three"
+      }
+    }
+
+    template {
+      metadata {
+        labels {
+          TestLabelOne   = "one"
+          TestLabelTwo   = "two"
+          TestLabelThree = "three"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "tf-acc-test"
+        }
+      }
+    }
+  }
+}
+`, name)
 }
 
 func testAccKubernetesDeploymentConfig_generatedName(prefix string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
-	metadata {
-		labels {
-			TestLabelOne   = "one"
-			TestLabelTwo   = "two"
-			TestLabelThree = "three"
-		}
-		generate_name = "%s"
-	}
-	spec {
-		selector {
-			match_labels {
-				TestLabelOne   = "one"
-				TestLabelTwo   = "two"
-				TestLabelThree = "three"
-			}
-		}
-		template {
-			metadata {
-				labels {
-					TestLabelOne   = "one"
-					TestLabelTwo   = "two"
-					TestLabelThree = "three"
-				}
-			}
-			spec {
-				container {
-					image = "nginx:1.7.9"
-					name  = "tf-acc-test"
-				}
-			}
-		}
-	}
-}`, prefix)
+  metadata {
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    generate_name = "%s"
+  }
+
+  spec {
+    selector {
+      match_labels {
+        TestLabelOne   = "one"
+        TestLabelTwo   = "two"
+        TestLabelThree = "three"
+      }
+    }
+
+    template {
+      metadata {
+        labels {
+          TestLabelOne   = "one"
+          TestLabelTwo   = "two"
+          TestLabelThree = "three"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.9"
+          name  = "tf-acc-test"
+        }
+      }
+    }
+  }
+}
+`, prefix)
 }
 
 func testAccKubernetesDeploymentConfigWithSecurityContext(rcName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
-	metadata {
-		name = "%s"
-		labels {
-			Test = "TfAcceptanceTest"
-		}
-	}
-	spec {
-		selector {
-			match_labels {
-				Test = "TfAcceptanceTest"
-			}
-		}
-		template {
-			metadata {
-				labels {
-					Test = "TfAcceptanceTest"
-				}
-			}
-			spec {
-				security_context {
-					run_as_non_root     = true
-					run_as_user         = 101
-					supplemental_groups = [101]
-				}
-				container {
-					image = "%s"
-					name  = "containername"
-				}
-			}
-		}
-	}
-}`, rcName, imageName)
+  metadata {
+    name = "%s"
+
+    labels {
+      Test = "TfAcceptanceTest"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels {
+        Test = "TfAcceptanceTest"
+      }
+    }
+
+    template {
+      metadata {
+        labels {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
+      spec {
+        security_context {
+          run_as_non_root     = true
+          run_as_user         = 101
+          supplemental_groups = [101]
+        }
+
+        container {
+          image = "%s"
+          name  = "containername"
+        }
+      }
+    }
+  }
+}
+`, rcName, imageName)
 }
 
 func testAccKubernetesDeploymentConfigWithLivenessProbeUsingExec(rcName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
-	metadata {
-		name = "%s"
-		labels {
-			Test = "TfAcceptanceTest"
-		}
-	}
-	spec {
-		selector {
-			match_labels {
-				Test = "TfAcceptanceTest"
-			}
-		}
-		template {
-			metadata {
-				labels {
-					Test = "TfAcceptanceTest"
-				}
-			}
-			spec {
-				container {
-					image = "%s"
-					name  = "containername"
-					args  = ["/bin/sh", "-c", "touch /tmp/healthy; sleep 300; rm -rf /tmp/healthy; sleep 600"]
-					liveness_probe {
-						exec {
-							command = ["cat", "/tmp/healthy"]
-						}
-						initial_delay_seconds = 5
-						period_seconds        = 5
-					}
-				}
-			}
-		}
-	}
-}`, rcName, imageName)
+  metadata {
+    name = "%s"
+
+    labels {
+      Test = "TfAcceptanceTest"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels {
+        Test = "TfAcceptanceTest"
+      }
+    }
+
+    template {
+      metadata {
+        labels {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
+      spec {
+        container {
+          image = "%s"
+          name  = "containername"
+          args  = ["/bin/sh", "-c", "touch /tmp/healthy; sleep 300; rm -rf /tmp/healthy; sleep 600"]
+
+          liveness_probe {
+            exec {
+              command = ["cat", "/tmp/healthy"]
+            }
+
+            initial_delay_seconds = 5
+            period_seconds        = 5
+          }
+        }
+      }
+    }
+  }
+}
+`, rcName, imageName)
 }
 
 func testAccKubernetesDeploymentConfigWithLivenessProbeUsingHTTPGet(rcName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
-	metadata {
-		name = "%s"
+  metadata {
+    name = "%s"
 
-		labels {
-			Test = "TfAcceptanceTest"
-		}
-	}
-	spec {
-		selector {
-			match_labels {
-				Test = "TfAcceptanceTest"
-			}
-		}
-		template {
-			metadata {
-				labels {
-					Test = "TfAcceptanceTest"
-				}
-			}
-			spec {
-				container {
-					image = "%s"
-					name  = "containername"
-					args  = ["/server"]
-					liveness_probe {
-						http_get {
-							path = "/healthz"
-							port = 8080
-							http_header {
-								name  = "X-Custom-Header"
-								value = "Awesome"
-							}
-						}
-						initial_delay_seconds = 3
-						period_seconds        = 3
-					}
-				}
-			}
-		}
-	}
-}`, rcName, imageName)
+    labels {
+      Test = "TfAcceptanceTest"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels {
+        Test = "TfAcceptanceTest"
+      }
+    }
+
+    template {
+      metadata {
+        labels {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
+      spec {
+        container {
+          image = "%s"
+          name  = "containername"
+          args  = ["/server"]
+
+          liveness_probe {
+            http_get {
+              path = "/healthz"
+              port = 8080
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}
+`, rcName, imageName)
 }
 
 func testAccKubernetesDeploymentConfigWithLivenessProbeUsingTCP(rcName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
-	metadata {
-		name = "%s"
-		labels {
-			Test = "TfAcceptanceTest"
-		}
-	}
-	spec {
-		selector {
-			match_labels {
-				Test = "TfAcceptanceTest"
-			}
-		}
-		template {
-			metadata {
-				labels {
-					Test = "TfAcceptanceTest"
-				}
-			}
-			spec {
-				container {
-					image = "%s"
-					name  = "containername"
-					args  = ["/server"]
-					liveness_probe {
-						tcp_socket {
-							port = 8080
-						}
-						initial_delay_seconds = 3
-						period_seconds        = 3
-					}
-				}
-			}
-		}
-	}
-}`, rcName, imageName)
+  metadata {
+    name = "%s"
+
+    labels {
+      Test = "TfAcceptanceTest"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels {
+        Test = "TfAcceptanceTest"
+      }
+    }
+
+    template {
+      metadata {
+        labels {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
+      spec {
+        container {
+          image = "%s"
+          name  = "containername"
+          args  = ["/server"]
+
+          liveness_probe {
+            tcp_socket {
+              port = 8080
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}
+`, rcName, imageName)
 }
 
 func testAccKubernetesDeploymentConfigWithLifeCycle(rcName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
-	metadata {
-		name = "%s"
-		labels {
-			Test = "TfAcceptanceTest"
-		}
-	}
-	spec {
-		selector {
-			match_labels {
-				Test = "TfAcceptanceTest"
-			}
-		}
-		template {
-			metadata {
-				labels {
-					Test = "TfAcceptanceTest"
-				}
-			}
-			spec {
-				container {
-					image = "%s"
-					name  = "containername"
-					args  = ["/server"]
-					lifecycle {
-						post_start {
-							exec {
-								command = ["ls", "-al"]
-							}
-						}
-						pre_stop {
-							exec {
-								command = ["date"]
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-}`, rcName, imageName)
+  metadata {
+    name = "%s"
+
+    labels {
+      Test = "TfAcceptanceTest"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels {
+        Test = "TfAcceptanceTest"
+      }
+    }
+
+    template {
+      metadata {
+        labels {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
+      spec {
+        container {
+          image = "%s"
+          name  = "containername"
+          args  = ["/server"]
+
+          lifecycle {
+            post_start {
+              exec {
+                command = ["ls", "-al"]
+              }
+            }
+
+            pre_stop {
+              exec {
+                command = ["date"]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, rcName, imageName)
 }
 
 func testAccKubernetesDeploymentConfigWithContainerSecurityContext(rcName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
-	metadata {
-		name = "%s"
-		labels {
-			Test = "TfAcceptanceTest"
-		}
-	}
-	spec {
-		selector {
-			match_labels {
-				Test = "TfAcceptanceTest"
-			}
-		}
-		template {
-			metadata {
-				labels {
-					Test = "TfAcceptanceTest"
-				}
-			}
-			spec {
-				container {
-					image = "%s"
-					name  = "containername"
-					security_context {
-						privileged  = true
-						run_as_user = 1
-						se_linux_options {
-							level = "s0:c123,c456"
-						}
-					}
-				}
-			}
-		}
-	}
-}`, rcName, imageName)
+  metadata {
+    name = "%s"
+
+    labels {
+      Test = "TfAcceptanceTest"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels {
+        Test = "TfAcceptanceTest"
+      }
+    }
+
+    template {
+      metadata {
+        labels {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
+      spec {
+        container {
+          image = "%s"
+          name  = "containername"
+
+          security_context {
+            privileged  = true
+            run_as_user = 1
+
+            se_linux_options {
+              level = "s0:c123,c456"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, rcName, imageName)
 }
 
 func testAccKubernetesDeploymentConfigWithVolumeMounts(secretName, rcName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_secret" "test" {
-	metadata {
-		name = "%s"
-	}
-	data {
-		one = "first"
-	}
+  metadata {
+    name = "%s"
+  }
+
+  data {
+    one = "first"
+  }
 }
 
 resource "kubernetes_deployment" "test" {
-	metadata {
-		name = "%s"
-		labels {
-			Test = "TfAcceptanceTest"
-		}
-	}
-	spec {
-		selector {
-			match_labels {
-				Test = "TfAcceptanceTest"
-			}
-		}
-		template {
-			metadata {
-				labels {
-					Test = "TfAcceptanceTest"
-				}
-			}
-			spec {
-				container {
-					image = "%s"
-					name  = "containername"
-					volume_mount {
-						mount_path = "/tmp/my_path"
-						name       = "db"
-					}
-				}
-				volume {
-					name = "db"
-					secret = {
-						secret_name = "${kubernetes_secret.test.metadata.0.name}"
-					}
-				}
-			}
-		}
-	}
-}`, secretName, rcName, imageName)
+  metadata {
+    name = "%s"
+
+    labels {
+      Test = "TfAcceptanceTest"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels {
+        Test = "TfAcceptanceTest"
+      }
+    }
+
+    template {
+      metadata {
+        labels {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
+      spec {
+        container {
+          image = "%s"
+          name  = "containername"
+
+          volume_mount {
+            mount_path = "/tmp/my_path"
+            name       = "db"
+          }
+        }
+
+        volume {
+          name = "db"
+
+          secret = {
+            secret_name = "${kubernetes_secret.test.metadata.0.name}"
+          }
+        }
+      }
+    }
+  }
+}
+`, secretName, rcName, imageName)
 }
 
 func testAccKubernetesDeploymentConfigWithResourceRequirements(rcName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
-	metadata {
-		name = "%s"
-		labels {
-			Test = "TfAcceptanceTest"
-		}
-	}
-	spec {
-		selector {
-			match_labels {
-				Test = "TfAcceptanceTest"
-			}
-		}
-		template {
-			metadata {
-				labels {
-					Test = "TfAcceptanceTest"
-				}
-			}
-			spec {
-				container {
-					image = "%s"
-					name  = "containername"
-					resources {
-						limits {
-							cpu    = "0.5"
-							memory = "512Mi"
-						}
-						requests {
-							cpu    = "250m"
-							memory = "50Mi"
-						}
-					}
-				}
-			}
-		}
-	}
-}`, rcName, imageName)
+  metadata {
+    name = "%s"
+
+    labels {
+      Test = "TfAcceptanceTest"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels {
+        Test = "TfAcceptanceTest"
+      }
+    }
+
+    template {
+      metadata {
+        labels {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
+      spec {
+        container {
+          image = "%s"
+          name  = "containername"
+
+          resources {
+            limits {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+
+            requests {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, rcName, imageName)
 }
 
 func testAccKubernetesDeploymentConfigWithEmptyDirVolumes(rcName, imageName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_deployment" "test" {
-	metadata {
-		name = "%s"
-		labels {
-			Test = "TfAcceptanceTest"
-		}
-	}
-	spec {
-		selector {
-			match_labels {
-				Test = "TfAcceptanceTest"
-			}
-		}
-		template {
-			metadata {
-				labels {
-					Test = "TfAcceptanceTest"
-				}
-			}
-			spec {
-				container {
-					image = "%s"
-					name  = "containername"
-					volume_mount {
-						mount_path = "/cache"
-						name       = "cache-volume"
-					}
-				}
-				volume {
-					name = "cache-volume"
-					empty_dir = {
-						medium = "Memory"
-					}
-				}
-			}
-		}
-	}
-}`, rcName, imageName)
+  metadata {
+    name = "%s"
+
+    labels {
+      Test = "TfAcceptanceTest"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels {
+        Test = "TfAcceptanceTest"
+      }
+    }
+
+    template {
+      metadata {
+        labels {
+          Test = "TfAcceptanceTest"
+        }
+      }
+
+      spec {
+        container {
+          image = "%s"
+          name  = "containername"
+
+          volume_mount {
+            mount_path = "/cache"
+            name       = "cache-volume"
+          }
+        }
+
+        volume {
+          name = "cache-volume"
+
+          empty_dir = {
+            medium = "Memory"
+          }
+        }
+      }
+    }
+  }
+}
+`, rcName, imageName)
 }

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_test.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_test.go
@@ -205,24 +205,28 @@ func testAccCheckKubernetesHorizontalPodAutoscalerExists(n string, obj *api.Hori
 func testAccKubernetesHorizontalPodAutoscalerConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_horizontal_pod_autoscaler" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelThree = "three"
-			TestLabelFour = "four"
-		}
-		name = "%s"
-	}
-	spec {
-		max_replicas = 10
-		scale_target_ref {
-			kind = "ReplicationController"
-			name = "TerraformAccTest"
-		}
-	}
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelThree = "three"
+      TestLabelFour  = "four"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    max_replicas = 10
+
+    scale_target_ref {
+      kind = "ReplicationController"
+      name = "TerraformAccTest"
+    }
+  }
 }
 `, name)
 }
@@ -230,25 +234,29 @@ resource "kubernetes_horizontal_pod_autoscaler" "test" {
 func testAccKubernetesHorizontalPodAutoscalerConfig_metaModified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_horizontal_pod_autoscaler" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	spec {
-		max_replicas = 10
-		scale_target_ref {
-			kind = "ReplicationController"
-			name = "TerraformAccTest"
-		}
-	}
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    max_replicas = 10
+
+    scale_target_ref {
+      kind = "ReplicationController"
+      name = "TerraformAccTest"
+    }
+  }
 }
 `, name)
 }
@@ -256,16 +264,18 @@ resource "kubernetes_horizontal_pod_autoscaler" "test" {
 func testAccKubernetesHorizontalPodAutoscalerConfig_specModified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_horizontal_pod_autoscaler" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		max_replicas = 8
-		scale_target_ref {
-			kind = "ReplicationController"
-			name = "TerraformAccTestModified"
-		}
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    max_replicas = 8
+
+    scale_target_ref {
+      kind = "ReplicationController"
+      name = "TerraformAccTestModified"
+    }
+  }
 }
 `, name)
 }
@@ -273,16 +283,18 @@ resource "kubernetes_horizontal_pod_autoscaler" "test" {
 func testAccKubernetesHorizontalPodAutoscalerConfig_generatedName(prefix string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_horizontal_pod_autoscaler" "test" {
-	metadata {
-		generate_name = "%s"
-	}
-	spec {
-		max_replicas = 1
-		scale_target_ref {
-			kind = "ReplicationController"
-			name = "TerraformAccTestGeneratedName"
-		}
-	}
+  metadata {
+    generate_name = "%s"
+  }
+
+  spec {
+    max_replicas = 1
+
+    scale_target_ref {
+      kind = "ReplicationController"
+      name = "TerraformAccTestGeneratedName"
+    }
+  }
 }
 `, prefix)
 }

--- a/kubernetes/resource_kubernetes_limit_range_test.go
+++ b/kubernetes/resource_kubernetes_limit_range_test.go
@@ -338,9 +338,9 @@ func testAccCheckKubernetesLimitRangeExists(n string, obj *api.LimitRange) resou
 func testAccKubernetesLimitRangeConfig_empty(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_limit_range" "test" {
-	metadata {
-		name = "%s"
-	}
+  metadata {
+    name = "%s"
+  }
 }
 `, name)
 }
@@ -348,32 +348,35 @@ resource "kubernetes_limit_range" "test" {
 func testAccKubernetesLimitRangeConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_limit_range" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelThree = "three"
-			TestLabelFour = "four"
-		}
-		name = "%s"
-	}
-	spec {
-		limit {
-			type = "Container"
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+    }
 
-			default {
-				cpu = "200m"
-				memory = "512M"
-			}
+    labels {
+      TestLabelOne   = "one"
+      TestLabelThree = "three"
+      TestLabelFour  = "four"
+    }
 
-			default_request {
-				cpu = "100m"
-				memory = "256M"
-			}
-		}
-	}
+    name = "%s"
+  }
+
+  spec {
+    limit {
+      type = "Container"
+
+      default {
+        cpu    = "200m"
+        memory = "512M"
+      }
+
+      default_request {
+        cpu    = "100m"
+        memory = "256M"
+      }
+    }
+  }
 }
 `, name)
 }
@@ -381,33 +384,36 @@ resource "kubernetes_limit_range" "test" {
 func testAccKubernetesLimitRangeConfig_metaModified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_limit_range" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	spec {
-		limit {
-			type = "Container"
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
 
-			default {
-				cpu = "200m"
-				memory = "512M"
-			}
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
 
-			default_request {
-				cpu = "100m"
-				memory = "256M"
-			}
-		}
-	}
+    name = "%s"
+  }
+
+  spec {
+    limit {
+      type = "Container"
+
+      default {
+        cpu    = "200m"
+        memory = "512M"
+      }
+
+      default_request {
+        cpu    = "100m"
+        memory = "256M"
+      }
+    }
+  }
 }
 `, name)
 }
@@ -415,28 +421,29 @@ resource "kubernetes_limit_range" "test" {
 func testAccKubernetesLimitRangeConfig_specModified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_limit_range" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		limit {
-			type = "Container"
+  metadata {
+    name = "%s"
+  }
 
-			default {
-				cpu = "200m"
-				memory = "1024M"
-			}
+  spec {
+    limit {
+      type = "Container"
 
-			max {
-				cpu = "500m"
-			}
+      default {
+        cpu    = "200m"
+        memory = "1024M"
+      }
 
-			min {
-				cpu = "10m"
-				memory = "10M"
-			}
-		}
-	}
+      max {
+        cpu = "500m"
+      }
+
+      min {
+        cpu    = "10m"
+        memory = "10M"
+      }
+    }
+  }
 }
 `, name)
 }
@@ -444,14 +451,15 @@ resource "kubernetes_limit_range" "test" {
 func testAccKubernetesLimitRangeConfig_generatedName(prefix string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_limit_range" "test" {
-	metadata {
-		generate_name = "%s"
-	}
-	spec {
-		limit {
-			type = "Pod"
-		}
-	}
+  metadata {
+    generate_name = "%s"
+  }
+
+  spec {
+    limit {
+      type = "Pod"
+    }
+  }
 }
 `, prefix)
 }
@@ -459,18 +467,20 @@ resource "kubernetes_limit_range" "test" {
 func testAccKubernetesLimitRangeConfig_typeChange(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_limit_range" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		limit {
-			type = "Container"
-			default {
-				cpu = "200m"
-				memory = "1024M"
-			}
-		}
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    limit {
+      type = "Container"
+
+      default {
+        cpu    = "200m"
+        memory = "1024M"
+      }
+    }
+  }
 }
 `, name)
 }
@@ -478,18 +488,20 @@ resource "kubernetes_limit_range" "test" {
 func testAccKubernetesLimitRangeConfig_typeChangeModified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_limit_range" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		limit {
-			type = "Pod"
-			min {
-				cpu = "200m"
-				memory = "1024M"
-			}
-		}
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    limit {
+      type = "Pod"
+
+      min {
+        cpu    = "200m"
+        memory = "1024M"
+      }
+    }
+  }
 }
 `, name)
 }
@@ -497,31 +509,37 @@ resource "kubernetes_limit_range" "test" {
 func testAccKubernetesLimitRangeConfig_multipleLimits(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_limit_range" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		limit {
-			type = "Pod"
-			max {
-				cpu = "200m"
-				memory = "1024M"
-			}
-		}
-		limit {
-			type = "PersistentVolumeClaim"
-			min {
-				storage = "24M"
-			}
-		}
-		limit {
-			type = "Container"
-			default {
-				cpu = "50m"
-				memory = "24M"
-			}
-		}
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    limit {
+      type = "Pod"
+
+      max {
+        cpu    = "200m"
+        memory = "1024M"
+      }
+    }
+
+    limit {
+      type = "PersistentVolumeClaim"
+
+      min {
+        storage = "24M"
+      }
+    }
+
+    limit {
+      type = "Container"
+
+      default {
+        cpu    = "50m"
+        memory = "24M"
+      }
+    }
+  }
 }
 `, name)
 }

--- a/kubernetes/resource_kubernetes_namespace_test.go
+++ b/kubernetes/resource_kubernetes_namespace_test.go
@@ -328,105 +328,120 @@ func testAccCheckKubernetesNamespaceExists(n string, obj *api.Namespace) resourc
 func testAccKubernetesNamespaceConfig_basic(nsName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_namespace" "test" {
-	metadata {
-		name = "%s"
-	}
-}`, nsName)
+  metadata {
+    name = "%s"
+  }
+}
+`, nsName)
 }
 
 func testAccKubernetesNamespaceConfig_addAnnotations(nsName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_namespace" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		name = "%s"
-	}
-}`, nsName)
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    name = "%s"
+  }
+}
+`, nsName)
 }
 func testAccKubernetesNamespaceConfig_addLabels(nsName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_namespace" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-}`, nsName)
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+}
+`, nsName)
 }
 
 func testAccKubernetesNamespaceConfig_smallerLists(nsName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_namespace" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			Different = "1234"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-}`, nsName)
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      Different         = "1234"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+}
+`, nsName)
 }
 
 func testAccKubernetesNamespaceConfig_noLists(nsName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_namespace" "test" {
-	metadata {
-		name = "%s"
-	}
-}`, nsName)
+  metadata {
+    name = "%s"
+  }
+}
+`, nsName)
 }
 
 func testAccKubernetesNamespaceConfig_generatedName(prefix string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_namespace" "test" {
-	metadata {
-		generate_name = "%s"
-	}
-}`, prefix)
+  metadata {
+    generate_name = "%s"
+  }
+}
+`, prefix)
 }
 
 func testAccKubernetesNamespaceConfig_specialCharacters(nsName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_namespace" "test" {
-	metadata {
-		annotations {
-			"myhost.co.uk/any-path" = "one"
-			"Different"             = "1234"
-		}
-		labels {
-			"myhost.co.uk/any-path" = "one"
-			"TestLabelThree"        = "three"
-		}
+  metadata {
+    annotations {
+      "myhost.co.uk/any-path" = "one"
+      "Different"             = "1234"
+    }
 
-		name = "%s"
-	}
-}`, nsName)
+    labels {
+      "myhost.co.uk/any-path" = "one"
+      "TestLabelThree"        = "three"
+    }
+
+    name = "%s"
+  }
+}
+`, nsName)
 }
 
 func testAccKubernetesNamespaceConfig_invalidLabelValueType(nsName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_namespace" "test" {
-	metadata {
-		labels {
-			"first"   = "one"
-			"integer" = 2
-			"bool"    = true
-		}
-		name = "%s"
-	}
-}`, nsName)
+  metadata {
+    labels {
+      "first"   = "one"
+      "integer" = 2
+      "bool"    = true
+    }
+
+    name = "%s"
+  }
+}
+`, nsName)
 }

--- a/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
@@ -517,33 +517,39 @@ type ObjectRefStatic struct {
 func testAccKubernetesPersistentVolumeClaimConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume_claim" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelThree = "three"
-			TestLabelFour = "four"
-		}
-		name = "%s"
-	}
-	spec {
-		access_modes = ["ReadWriteOnce"]
-		resources {
-			requests {
-				storage = "5Gi"
-			}
-		}
-		selector {
-			match_expressions {
-				key = "environment"
-				operator = "In"
-				values = ["non-exists-12345"]
-			}
-		}
-	}
-	wait_until_bound = false
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelThree = "three"
+      TestLabelFour  = "four"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    access_modes = ["ReadWriteOnce"]
+
+    resources {
+      requests {
+        storage = "5Gi"
+      }
+    }
+
+    selector {
+      match_expressions {
+        key      = "environment"
+        operator = "In"
+        values   = ["non-exists-12345"]
+      }
+    }
+  }
+
+  wait_until_bound = false
 }
 `, name)
 }
@@ -551,34 +557,40 @@ resource "kubernetes_persistent_volume_claim" "test" {
 func testAccKubernetesPersistentVolumeClaimConfig_metaModified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume_claim" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	spec {
-		access_modes = ["ReadWriteOnce"]
-		resources {
-			requests {
-				storage = "5Gi"
-			}
-		}
-		selector {
-			match_expressions {
-				key = "environment"
-				operator = "In"
-				values = ["non-exists-12345"]
-			}
-		}
-	}
-	wait_until_bound = false
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    access_modes = ["ReadWriteOnce"]
+
+    resources {
+      requests {
+        storage = "5Gi"
+      }
+    }
+
+    selector {
+      match_expressions {
+        key      = "environment"
+        operator = "In"
+        values   = ["non-exists-12345"]
+      }
+    }
+  }
+
+  wait_until_bound = false
 }
 `, name)
 }
@@ -586,21 +598,24 @@ resource "kubernetes_persistent_volume_claim" "test" {
 func testAccKubernetesPersistentVolumeClaimConfig_import(volumeName, claimName, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		capacity {
-			storage = "10Gi"
-		}
-		access_modes = ["ReadWriteOnce"]
-		storage_class_name = "standard"
-		persistent_volume_source {
-			gce_persistent_disk {
-				pd_name = "${google_compute_disk.test.name}"
-			}
-		}
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    capacity {
+      storage = "10Gi"
+    }
+
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = "standard"
+
+    persistent_volume_source {
+      gce_persistent_disk {
+        pd_name = "${google_compute_disk.test.name}"
+      }
+    }
+  }
 }
 
 resource "google_compute_disk" "test" {
@@ -608,23 +623,26 @@ resource "google_compute_disk" "test" {
   type  = "pd-ssd"
   zone  = "%s"
   image = "debian-8-jessie-v20170523"
-  size = 10
+  size  = 10
 }
 
 resource "kubernetes_persistent_volume_claim" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		access_modes = ["ReadWriteOnce"]
-		storage_class_name = "standard"
-		resources {
-			requests {
-				storage = "5Gi"
-			}
-		}
-		volume_name = "${kubernetes_persistent_volume.test.metadata.0.name}"
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = "standard"
+
+    resources {
+      requests {
+        storage = "5Gi"
+      }
+    }
+
+    volume_name = "${kubernetes_persistent_volume.test.metadata.0.name}"
+  }
 }
 `, volumeName, diskName, zone, claimName)
 }
@@ -632,21 +650,24 @@ resource "kubernetes_persistent_volume_claim" "test" {
 func testAccKubernetesPersistentVolumeClaimConfig_volumeMatch(volumeName, claimName, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		capacity {
-			storage = "10Gi"
-		}
-		access_modes = ["ReadWriteOnce"]
-		storage_class_name = "standard"
-		persistent_volume_source {
-			gce_persistent_disk {
-				pd_name = "${google_compute_disk.test.name}"
-			}
-		}
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    capacity {
+      storage = "10Gi"
+    }
+
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = "standard"
+
+    persistent_volume_source {
+      gce_persistent_disk {
+        pd_name = "${google_compute_disk.test.name}"
+      }
+    }
+  }
 }
 
 resource "google_compute_disk" "test" {
@@ -654,23 +675,26 @@ resource "google_compute_disk" "test" {
   type  = "pd-ssd"
   zone  = "%s"
   image = "debian-8-jessie-v20170523"
-  size = 10
+  size  = 10
 }
 
 resource "kubernetes_persistent_volume_claim" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		access_modes = ["ReadWriteOnce"]
-		storage_class_name = "standard"
-		resources {
-			requests {
-				storage = "5Gi"
-			}
-		}
-		volume_name = "${kubernetes_persistent_volume.test.metadata.0.name}"
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = "standard"
+
+    resources {
+      requests {
+        storage = "5Gi"
+      }
+    }
+
+    volume_name = "${kubernetes_persistent_volume.test.metadata.0.name}"
+  }
 }
 `, volumeName, diskName, zone, claimName)
 }
@@ -678,21 +702,24 @@ resource "kubernetes_persistent_volume_claim" "test" {
 func testAccKubernetesPersistentVolumeClaimConfig_volumeMatch_modified(volumeName, claimName, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test2" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		capacity {
-			storage = "10Gi"
-		}
-		access_modes = ["ReadWriteOnce"]
-		storage_class_name = "standard"
-		persistent_volume_source {
-			gce_persistent_disk {
-				pd_name = "${google_compute_disk.test.name}"
-			}
-		}
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    capacity {
+      storage = "10Gi"
+    }
+
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = "standard"
+
+    persistent_volume_source {
+      gce_persistent_disk {
+        pd_name = "${google_compute_disk.test.name}"
+      }
+    }
+  }
 }
 
 resource "google_compute_disk" "test" {
@@ -700,23 +727,26 @@ resource "google_compute_disk" "test" {
   type  = "pd-ssd"
   zone  = "%s"
   image = "debian-8-jessie-v20170523"
-  size = 10
+  size  = 10
 }
 
 resource "kubernetes_persistent_volume_claim" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		access_modes = ["ReadWriteOnce"]
-		storage_class_name = "standard"
-		resources {
-			requests {
-				storage = "5Gi"
-			}
-		}
-		volume_name = "${kubernetes_persistent_volume.test2.metadata.0.name}"
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = "standard"
+
+    resources {
+      requests {
+        storage = "5Gi"
+      }
+    }
+
+    volume_name = "${kubernetes_persistent_volume.test2.metadata.0.name}"
+  }
 }
 `, volumeName, diskName, zone, claimName)
 }
@@ -812,21 +842,24 @@ resource "kubernetes_persistent_volume_claim" "test" {
 func testAccKubernetesPersistentVolumeClaimConfig_volumeUpdate(volumeName, claimName, storage, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		capacity {
-			storage = "%s"
-		}
-		access_modes = ["ReadWriteOnce"]
-		storage_class_name = "standard"
-		persistent_volume_source {
-			gce_persistent_disk {
-				pd_name = "${google_compute_disk.test.name}"
-			}
-		}
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    capacity {
+      storage = "%s"
+    }
+
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = "standard"
+
+    persistent_volume_source {
+      gce_persistent_disk {
+        pd_name = "${google_compute_disk.test.name}"
+      }
+    }
+  }
 }
 
 resource "google_compute_disk" "test" {
@@ -834,23 +867,26 @@ resource "google_compute_disk" "test" {
   type  = "pd-ssd"
   zone  = "%s"
   image = "debian-8-jessie-v20170523"
-  size = 10
+  size  = 10
 }
 
 resource "kubernetes_persistent_volume_claim" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		access_modes = ["ReadWriteOnce"]
-		storage_class_name = "standard"
-		resources {
-			requests {
-				storage = "5Gi"
-			}
-		}
-		volume_name = "${kubernetes_persistent_volume.test.metadata.0.name}"
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = "standard"
+
+    resources {
+      requests {
+        storage = "5Gi"
+      }
+    }
+
+    volume_name = "${kubernetes_persistent_volume.test.metadata.0.name}"
+  }
 }
 `, volumeName, storage, diskName, zone, claimName)
 }
@@ -858,28 +894,33 @@ resource "kubernetes_persistent_volume_claim" "test" {
 func testAccKubernetesPersistentVolumeClaimConfig_storageClass(className, claimName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_storage_class" "test" {
-	metadata {
-		name = "%s"
-	}
-	storage_provisioner = "kubernetes.io/gce-pd"
-	parameters {
-		type = "pd-standard"
-	}
+  metadata {
+    name = "%s"
+  }
+
+  storage_provisioner = "kubernetes.io/gce-pd"
+
+  parameters {
+    type = "pd-standard"
+  }
 }
 
 resource "kubernetes_persistent_volume_claim" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		access_modes = ["ReadWriteOnce"]
-		resources {
-			requests {
-				storage = "5Gi"
-			}
-		}
-		storage_class_name = "${kubernetes_storage_class.test.metadata.0.name}"
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    access_modes = ["ReadWriteOnce"]
+
+    resources {
+      requests {
+        storage = "5Gi"
+      }
+    }
+
+    storage_class_name = "${kubernetes_storage_class.test.metadata.0.name}"
+  }
 }
 `, className, claimName)
 }
@@ -887,38 +928,45 @@ resource "kubernetes_persistent_volume_claim" "test" {
 func testAccKubernetesPersistentVolumeClaimConfig_storageClassUpdated(className, claimName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_storage_class" "test" {
-	metadata {
-		name = "%s"
-	}
-	storage_provisioner = "kubernetes.io/gce-pd"
-	parameters {
-		type = "pd-standard"
-	}
+  metadata {
+    name = "%s"
+  }
+
+  storage_provisioner = "kubernetes.io/gce-pd"
+
+  parameters {
+    type = "pd-standard"
+  }
 }
 
 resource "kubernetes_storage_class" "second" {
-	metadata {
-		name = "%s-second"
-	}
-	storage_provisioner = "kubernetes.io/gce-pd"
-	parameters {
-		type = "pd-ssd"
-	}
+  metadata {
+    name = "%s-second"
+  }
+
+  storage_provisioner = "kubernetes.io/gce-pd"
+
+  parameters {
+    type = "pd-ssd"
+  }
 }
 
 resource "kubernetes_persistent_volume_claim" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		access_modes = ["ReadWriteOnce"]
-		resources {
-			requests {
-				storage = "5Gi"
-			}
-		}
-		storage_class_name = "${kubernetes_storage_class.second.metadata.0.name}"
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    access_modes = ["ReadWriteOnce"]
+
+    resources {
+      requests {
+        storage = "5Gi"
+      }
+    }
+
+    storage_class_name = "${kubernetes_storage_class.second.metadata.0.name}"
+  }
 }
 `, className, className, claimName)
 }

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -468,29 +468,34 @@ func testAccCheckKubernetesPersistentVolumeExists(n string, obj *api.PersistentV
 func testAccKubernetesPersistentVolumeConfig_googleCloud_basic(name, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	spec {
-		capacity {
-			storage = "123Gi"
-		}
-		access_modes = ["ReadWriteOnce"]
-		persistent_volume_source {
-			gce_persistent_disk {
-				pd_name = "${google_compute_disk.test.name}"
-			}
-		}
-	}
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    capacity {
+      storage = "123Gi"
+    }
+
+    access_modes = ["ReadWriteOnce"]
+
+    persistent_volume_source {
+      gce_persistent_disk {
+        pd_name = "${google_compute_disk.test.name}"
+      }
+    }
+  }
 }
 
 resource "google_compute_disk" "test" {
@@ -498,7 +503,7 @@ resource "google_compute_disk" "test" {
   type  = "pd-ssd"
   zone  = "%s"
   image = "debian-8-jessie-v20170523"
-  size = 10
+  size  = 10
 }
 `, name, diskName, zone)
 }
@@ -506,31 +511,36 @@ resource "google_compute_disk" "test" {
 func testAccKubernetesPersistentVolumeConfig_googleCloud_modified(name, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	spec {
-		capacity {
-			storage = "42Mi"
-		}
-		access_modes = ["ReadWriteOnce", "ReadOnlyMany"]
-		persistent_volume_source {
-			gce_persistent_disk {
-				fs_type = "ntfs"
-				pd_name = "${google_compute_disk.test.name}"
-				read_only = true
-			}
-		}
-	}
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    capacity {
+      storage = "42Mi"
+    }
+
+    access_modes = ["ReadWriteOnce", "ReadOnlyMany"]
+
+    persistent_volume_source {
+      gce_persistent_disk {
+        fs_type   = "ntfs"
+        pd_name   = "${google_compute_disk.test.name}"
+        read_only = true
+      }
+    }
+  }
 }
 
 resource "google_compute_disk" "test" {
@@ -538,7 +548,7 @@ resource "google_compute_disk" "test" {
   type  = "pd-ssd"
   zone  = "%s"
   image = "debian-8-jessie-v20170523"
-  size = 10
+  size  = 10
 }
 `, name, diskName, zone)
 }
@@ -546,20 +556,23 @@ resource "google_compute_disk" "test" {
 func testAccKubernetesPersistentVolumeConfig_googleCloud_volumeSource(name, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		capacity {
-			storage = "123Gi"
-		}
-		access_modes = ["ReadWriteOnce"]
-		persistent_volume_source {
-			gce_persistent_disk {
-				pd_name = "${google_compute_disk.test.name}"
-			}
-		}
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    capacity {
+      storage = "123Gi"
+    }
+
+    access_modes = ["ReadWriteOnce"]
+
+    persistent_volume_source {
+      gce_persistent_disk {
+        pd_name = "${google_compute_disk.test.name}"
+      }
+    }
+  }
 }
 
 resource "google_compute_disk" "test" {
@@ -567,7 +580,7 @@ resource "google_compute_disk" "test" {
   type  = "pd-ssd"
   zone  = "%s"
   image = "debian-8-jessie-v20170523"
-  size = 12
+  size  = 12
 }
 `, name, diskName, zone)
 }
@@ -575,37 +588,43 @@ resource "google_compute_disk" "test" {
 func testAccKubernetesPersistentVolumeConfig_aws_basic(name, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	spec {
-		capacity {
-			storage = "123Gi"
-		}
-		access_modes = ["ReadWriteOnce"]
-		persistent_volume_source {
-			aws_elastic_block_store {
-				volume_id = "${aws_ebs_volume.test.id}"
-			}
-		}
-	}
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    capacity {
+      storage = "123Gi"
+    }
+
+    access_modes = ["ReadWriteOnce"]
+
+    persistent_volume_source {
+      aws_elastic_block_store {
+        volume_id = "${aws_ebs_volume.test.id}"
+      }
+    }
+  }
 }
 
 resource "aws_ebs_volume" "test" {
-	availability_zone = "%s"
-	size = 10
-	tags {
-		Name = "%s"
-	}
+  availability_zone = "%s"
+  size              = 10
+
+  tags {
+    Name = "%s"
+  }
 }
 `, name, zone, diskName)
 }
@@ -613,40 +632,46 @@ resource "aws_ebs_volume" "test" {
 func testAccKubernetesPersistentVolumeConfig_aws_modified(name, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	spec {
-		capacity {
-			storage = "42Mi"
-		}
-		access_modes = ["ReadWriteOnce"]
-		persistent_volume_source {
-			aws_elastic_block_store {
-				volume_id = "${aws_ebs_volume.test.id}"
-				fs_type = "io1"
-				partition = 1
-				read_only = true
-			}
-		}
-	}
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    capacity {
+      storage = "42Mi"
+    }
+
+    access_modes = ["ReadWriteOnce"]
+
+    persistent_volume_source {
+      aws_elastic_block_store {
+        volume_id = "${aws_ebs_volume.test.id}"
+        fs_type   = "io1"
+        partition = 1
+        read_only = true
+      }
+    }
+  }
 }
 
 resource "aws_ebs_volume" "test" {
-	availability_zone = "%s"
-	size = 10
-	tags {
-		Name = "%s"
-	}
+  availability_zone = "%s"
+  size              = 10
+
+  tags {
+    Name = "%s"
+  }
 }
 `, name, zone, diskName)
 }
@@ -654,64 +679,77 @@ resource "aws_ebs_volume" "test" {
 func testAccKubernetesPersistentVolumeConfig_hostPath_volumeSource(name, path string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		capacity {
-			storage = "123Gi"
-		}
-		access_modes = ["ReadWriteOnce"]
-		persistent_volume_source {
-			host_path {
-				path = "%s"
-			}
-		}
-	}
-}`, name, path)
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    capacity {
+      storage = "123Gi"
+    }
+
+    access_modes = ["ReadWriteOnce"]
+
+    persistent_volume_source {
+      host_path {
+        path = "%s"
+      }
+    }
+  }
+}
+`, name, path)
 }
 
 func testAccKubernetesPersistentVolumeConfig_cephFsSecretRef(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		capacity {
-			storage = "2Gi"
-		}
-		access_modes = ["ReadWriteMany"]
-		persistent_volume_source {
-			ceph_fs {
-				monitors = ["10.16.154.78:6789", "10.16.154.82:6789"]
-				secret_ref {
-					name = "ceph-secret"
-				}
-			}
-		}
-	}
-}`, name)
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    capacity {
+      storage = "2Gi"
+    }
+
+    access_modes = ["ReadWriteMany"]
+
+    persistent_volume_source {
+      ceph_fs {
+        monitors = ["10.16.154.78:6789", "10.16.154.82:6789"]
+
+        secret_ref {
+          name = "ceph-secret"
+        }
+      }
+    }
+  }
+}
+`, name)
 }
 
 func testAccKubernetesPersistentVolumeConfig_storageClass(name, diskName, storageClassName, storageClassName2, zone, refName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		capacity {
-			storage = "123Gi"
-		}
-		access_modes = ["ReadWriteMany"]
-		persistent_volume_source {
-			gce_persistent_disk {
-				pd_name = "${google_compute_disk.test.name}"
-			}
-		}
-		storage_class_name = "${kubernetes_storage_class.%s.metadata.0.name}"
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    capacity {
+      storage = "123Gi"
+    }
+
+    access_modes = ["ReadWriteMany"]
+
+    persistent_volume_source {
+      gce_persistent_disk {
+        pd_name = "${google_compute_disk.test.name}"
+      }
+    }
+
+    storage_class_name = "${kubernetes_storage_class.%s.metadata.0.name}"
+  }
 }
 
 resource "google_compute_disk" "test" {
@@ -719,27 +757,31 @@ resource "google_compute_disk" "test" {
   type  = "pd-ssd"
   zone  = "%s"
   image = "debian-8-jessie-v20170523"
-  size = 12
+  size  = 12
 }
 
 resource "kubernetes_storage_class" "test" {
-	metadata {
-		name = "%s"
-	}
-	storage_provisioner = "kubernetes.io/gce-pd"
-	parameters {
-		type = "pd-ssd"
-	}
+  metadata {
+    name = "%s"
+  }
+
+  storage_provisioner = "kubernetes.io/gce-pd"
+
+  parameters {
+    type = "pd-ssd"
+  }
 }
 
 resource "kubernetes_storage_class" "test2" {
-	metadata {
-		name = "%s"
-	}
-	storage_provisioner = "kubernetes.io/gce-pd"
-	parameters {
-		type = "pd-standard"
-	}
+  metadata {
+    name = "%s"
+  }
+
+  storage_provisioner = "kubernetes.io/gce-pd"
+
+  parameters {
+    type = "pd-standard"
+  }
 }
 `, name, refName, diskName, zone, storageClassName, storageClassName2)
 }

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -652,7 +652,6 @@ func testAccCheckKubernetesPodForceNew(old, new *api.Pod, wantNew bool) resource
 
 func testAccKubernetesPodConfigBasic(secretName, configMapName, podName, imageName string) string {
 	return fmt.Sprintf(`
-
 resource "kubernetes_secret" "test" {
   metadata {
     name = "%s"
@@ -669,7 +668,7 @@ resource "kubernetes_secret" "test_from" {
   }
 
   data {
-    one = "first_from"
+    one    = "first_from"
     second = "second_from"
   }
 }
@@ -691,7 +690,7 @@ resource "kubernetes_config_map" "test_from" {
 
   data {
     one = "ONE_FROM"
-	two = "TWO_FROM"
+    two = "TWO_FROM"
   }
 }
 
@@ -733,69 +732,81 @@ resource "kubernetes_pod" "test" {
 
       env_from = [{
         config_map_ref {
-          name = "${kubernetes_config_map.test_from.metadata.0.name}"
+          name     = "${kubernetes_config_map.test_from.metadata.0.name}"
           optional = true
         }
-		prefix = "FROM_CM_"
-	}, {
-        secret_ref {
-          name = "${kubernetes_secret.test_from.metadata.0.name}"
-          optional = false
-        }
-		prefix = "FROM_S_"
-      }]
 
+        prefix = "FROM_CM_"
+      },
+        {
+          secret_ref {
+            name     = "${kubernetes_secret.test_from.metadata.0.name}"
+            optional = false
+          }
+
+          prefix = "FROM_S_"
+        },
+      ]
     }
+
     volume {
       name = "db"
+
       secret = {
         secret_name = "${kubernetes_secret.test.metadata.0.name}"
       }
     }
   }
 }
-	`, secretName, secretName, configMapName, configMapName, podName, imageName)
+`, secretName, secretName, configMapName, configMapName, podName, imageName)
 }
 
 func testAccKubernetesPodConfigWithInitContainer(podName string, image string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_pod" "test" {
-	metadata {
-		labels {
-			app = "pod_label"
-		}
+  metadata {
+    labels {
+      app = "pod_label"
+    }
 
-		name = "%s"
-	}
-	spec {
-		container {
-			name = "nginx"
-			image = "nginx"
-			port {
-				container_port = 80
-			}
-			volume_mount {
-				name = "workdir"
-				mount_path = "/usr/share/nginx/html"
-			}
-		}
-		init_container {
-			name = "install"
-			image = "%s"
-			command = ["wget", "-O", "/work-dir/index.html", "http://kubernetes.io"]
-			volume_mount {
-				name = "workdir"
-				mount_path = "/work-dir"
-			}
-		}
-		dns_policy = "Default"
-		volume {
-			name = "workdir"
-			empty_dir {}
-		}
-	}
+    name = "%s"
+  }
+
+  spec {
+    container {
+      name  = "nginx"
+      image = "nginx"
+
+      port {
+        container_port = 80
+      }
+
+      volume_mount {
+        name       = "workdir"
+        mount_path = "/usr/share/nginx/html"
+      }
+    }
+
+    init_container {
+      name    = "install"
+      image   = "%s"
+      command = ["wget", "-O", "/work-dir/index.html", "http://kubernetes.io"]
+
+      volume_mount {
+        name       = "workdir"
+        mount_path = "/work-dir"
+      }
+    }
+
+    dns_policy = "Default"
+
+    volume {
+      name      = "workdir"
+      empty_dir = {}
+    }
+  }
 }
-	`, podName, image)
+`, podName, image)
 }
 
 func testAccKubernetesPodConfigWithSecurityContext(podName, imageName string) string {
@@ -808,19 +819,21 @@ resource "kubernetes_pod" "test" {
 
     name = "%s"
   }
+
   spec {
     security_context {
       run_as_non_root     = true
       run_as_user         = 101
       supplemental_groups = [101]
     }
+
     container {
       image = "%s"
       name  = "containername"
     }
   }
 }
-	`, podName, imageName)
+`, podName, imageName)
 }
 
 func testAccKubernetesPodConfigWithLivenessProbeUsingExec(podName, imageName string) string {
@@ -851,7 +864,7 @@ resource "kubernetes_pod" "test" {
     }
   }
 }
-	`, podName, imageName)
+`, podName, imageName)
 }
 
 func testAccKubernetesPodConfigWithLivenessProbeUsingHTTPGet(podName, imageName string) string {
@@ -881,13 +894,14 @@ resource "kubernetes_pod" "test" {
             value = "Awesome"
           }
         }
+
         initial_delay_seconds = 3
         period_seconds        = 3
       }
     }
   }
 }
-	`, podName, imageName)
+`, podName, imageName)
 }
 
 func testAccKubernetesPodConfigWithLivenessProbeUsingTCP(podName, imageName string) string {
@@ -900,6 +914,7 @@ resource "kubernetes_pod" "test" {
 
     name = "%s"
   }
+
   spec {
     container {
       image = "%s"
@@ -917,7 +932,7 @@ resource "kubernetes_pod" "test" {
     }
   }
 }
-	`, podName, imageName)
+`, podName, imageName)
 }
 
 func testAccKubernetesPodConfigWithLifeCycle(podName, imageName string) string {
@@ -930,6 +945,7 @@ resource "kubernetes_pod" "test" {
 
     name = "%s"
   }
+
   spec {
     container {
       image = "%s"
@@ -942,6 +958,7 @@ resource "kubernetes_pod" "test" {
             command = ["ls", "-al"]
           }
         }
+
         pre_stop {
           exec {
             command = ["date"]
@@ -951,8 +968,7 @@ resource "kubernetes_pod" "test" {
     }
   }
 }
-
-	`, podName, imageName)
+`, podName, imageName)
 }
 
 func testAccKubernetesPodConfigWithContainerSecurityContext(podName, imageName string) string {
@@ -965,6 +981,7 @@ resource "kubernetes_pod" "test" {
 
     name = "%s"
   }
+
   spec {
     container {
       image = "%s"
@@ -973,9 +990,11 @@ resource "kubernetes_pod" "test" {
       security_context {
         privileged  = true
         run_as_user = 1
+
         se_linux_options {
           level = "s0:c123,c456"
         }
+
         capabilities {
           add = ["NET_ADMIN", "SYS_TIME"]
         }
@@ -988,7 +1007,6 @@ resource "kubernetes_pod" "test" {
 
 func testAccKubernetesPodConfigWithVolumeMounts(secretName, podName, imageName string) string {
 	return fmt.Sprintf(`
-
 resource "kubernetes_secret" "test" {
   metadata {
     name = "%s"
@@ -1012,25 +1030,27 @@ resource "kubernetes_pod" "test" {
     container {
       image = "%s"
       name  = "containername"
+
       volume_mount {
         mount_path = "/tmp/my_path"
         name       = "db"
       }
     }
+
     volume {
       name = "db"
+
       secret {
         secret_name = "${kubernetes_secret.test.metadata.0.name}"
       }
     }
   }
 }
-	`, secretName, podName, imageName)
+`, secretName, podName, imageName)
 }
 
 func testAccKubernetesPodConfigWithSecretItemsVolume(secretName, podName, imageName string) string {
 	return fmt.Sprintf(`
-
 resource "kubernetes_secret" "test" {
   metadata {
     name = "%s"
@@ -1054,24 +1074,28 @@ resource "kubernetes_pod" "test" {
     container {
       image = "%s"
       name  = "containername"
+
       volume_mount {
         mount_path = "/tmp/my_path"
         name       = "db"
       }
     }
+
     volume {
       name = "db"
+
       secret {
         secret_name = "${kubernetes_secret.test.metadata.0.name}"
+
         items {
-          key = "one"
+          key  = "one"
           path = "path/to/one"
         }
       }
     }
   }
 }
-	`, secretName, podName, imageName)
+`, secretName, podName, imageName)
 }
 
 func testAccKubernetesPodConfigWithConfigMapVolume(secretName, podName, imageName string) string {
@@ -1099,21 +1123,25 @@ resource "kubernetes_pod" "test" {
     container {
       image = "%s"
       name  = "containername"
+
       volume_mount {
         mount_path = "/tmp/my_path"
         name       = "cfg"
       }
     }
+
     volume {
       name = "cfg"
+
       config_map {
-        name = "${kubernetes_config_map.test.metadata.0.name}"
+        name         = "${kubernetes_config_map.test.metadata.0.name}"
         default_mode = 0777
       }
     }
 
     volume {
       name = "cfg-item"
+
       config_map {
         name = "${kubernetes_config_map.test.metadata.0.name}"
 
@@ -1126,6 +1154,7 @@ resource "kubernetes_pod" "test" {
 
     volume {
       name = "cfg-item-with-mode"
+
       config_map {
         name = "${kubernetes_config_map.test.metadata.0.name}"
 
@@ -1138,12 +1167,11 @@ resource "kubernetes_pod" "test" {
     }
   }
 }
-	`, secretName, podName, imageName)
+`, secretName, podName, imageName)
 }
 
 func testAccKubernetesPodConfigWithResourceRequirements(podName, imageName string) string {
 	return fmt.Sprintf(`
-
 resource "kubernetes_pod" "test" {
   metadata {
     labels {
@@ -1157,22 +1185,22 @@ resource "kubernetes_pod" "test" {
     container {
       image = "%s"
       name  = "containername"
-		
-			resources{
-				limits{
-					cpu = "0.5"
-					memory = "512Mi"
-				}
-				requests{
-					cpu = "250m"
-				  memory = "50Mi"
-				}
-			}
-			
+
+      resources {
+        limits {
+          cpu    = "0.5"
+          memory = "512Mi"
+        }
+
+        requests {
+          cpu    = "250m"
+          memory = "50Mi"
+        }
+      }
     }
   }
 }
-	`, podName, imageName)
+`, podName, imageName)
 }
 
 func testAccKubernetesPodConfigWithEmptyDirVolumes(podName, imageName string) string {
@@ -1190,13 +1218,16 @@ resource "kubernetes_pod" "test" {
     container {
       image = "%s"
       name  = "containername"
+
       volume_mount {
-        mount_path =  "/cache"
-        name =  "cache-volume"
+        mount_path = "/cache"
+        name       = "cache-volume"
       }
     }
+
     volume {
       name = "cache-volume"
+
       empty_dir = {
         medium = "Memory"
       }
@@ -1218,6 +1249,7 @@ resource "kubernetes_pod" "test" {
       image = "%s"
       name  = "containername"
     }
+
     node_selector {
       "failure-domain.beta.kubernetes.io/region" = "%s"
     }
@@ -1246,21 +1278,22 @@ resource "kubernetes_pod" "test" {
 
 func testAccKubernetesPodConfigEnvUpdate(podName, imageName, val string) string {
 	return fmt.Sprintf(`
-		resource "kubernetes_pod" "test" {
-			metadata {
-				name = "%s"
-			}
-		
-			spec {
-				container {
-					image = "%s"
-					name  = "containername"
-					env {
-						name = "foo"
-						value = "%s"
-					}
-				}
-			}
-		}
-		`, podName, imageName, val)
+resource "kubernetes_pod" "test" {
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    container {
+      image = "%s"
+      name  = "containername"
+
+      env {
+        name  = "foo"
+        value = "%s"
+      }
+    }
+  }
+}
+`, podName, imageName, val)
 }

--- a/kubernetes/resource_kubernetes_replication_controller_test.go
+++ b/kubernetes/resource_kubernetes_replication_controller_test.go
@@ -472,20 +472,25 @@ resource "kubernetes_replication_controller" "test" {
       TestAnnotationOne = "one"
       TestAnnotationTwo = "two"
     }
+
     labels {
-      TestLabelOne = "one"
-      TestLabelTwo = "two"
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
       TestLabelThree = "three"
     }
+
     name = "%s"
   }
+
   spec {
     replicas = 1000 # This is intentionally high to exercise the waiter
+
     selector {
-      TestLabelOne = "one"
-      TestLabelTwo = "two"
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
       TestLabelThree = "three"
     }
+
     template {
       container {
         image = "nginx:1.7.8"
@@ -500,54 +505,66 @@ resource "kubernetes_replication_controller" "test" {
 func testAccKubernetesReplicationControllerConfig_initContainer(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_replication_controller" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	spec {
-		replicas = 1000 # This is intentionally high to exercise the waiter
-		selector {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		template {
-			container {
-				name = "nginx"
-				image = "nginx"
-				port {
-					container_port = 80
-				}
-				volume_mount {
-					name = "workdir"
-					mount_path = "/usr/share/nginx/html"
-				}
-			}
-			init_container {
-				name = "install"
-				image = "busybox"
-				command = ["wget", "-O", "/work-dir/index.html", "http://kubernetes.io"]
-				volume_mount {
-					name = "workdir"
-					mount_path = "/work-dir"
-				}
-			}
-			dns_policy = "Default"
-			volume {
-				name = "workdir"
-				empty_dir {}
-			}
-		}
-	}
-}`, name)
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    replicas = 1000 # This is intentionally high to exercise the waiter
+
+    selector {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    template {
+      container {
+        name  = "nginx"
+        image = "nginx"
+
+        port {
+          container_port = 80
+        }
+
+        volume_mount {
+          name       = "workdir"
+          mount_path = "/usr/share/nginx/html"
+        }
+      }
+
+      init_container {
+        name    = "install"
+        image   = "busybox"
+        command = ["wget", "-O", "/work-dir/index.html", "http://kubernetes.io"]
+
+        volume_mount {
+          name       = "workdir"
+          mount_path = "/work-dir"
+        }
+      }
+
+      dns_policy = "Default"
+
+      volume {
+        name      = "workdir"
+        empty_dir = {}
+      }
+    }
+  }
+}
+`, name)
 }
 
 func testAccKubernetesReplicationControllerConfig_modified(name string) string {
@@ -556,20 +573,24 @@ resource "kubernetes_replication_controller" "test" {
   metadata {
     annotations {
       TestAnnotationOne = "one"
-      Different = "1234"
+      Different         = "1234"
     }
+
     labels {
-      TestLabelOne = "one"
+      TestLabelOne   = "one"
       TestLabelThree = "three"
     }
+
     name = "%s"
   }
+
   spec {
     selector {
-      TestLabelOne = "one"
-      TestLabelTwo = "two"
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
       TestLabelThree = "three"
     }
+
     template {
       container {
         image = "nginx:1.7.9"
@@ -577,7 +598,8 @@ resource "kubernetes_replication_controller" "test" {
       }
     }
   }
-}`, name)
+}
+`, name)
 }
 
 func testAccKubernetesReplicationControllerConfig_generatedName(prefix string) string {
@@ -585,18 +607,21 @@ func testAccKubernetesReplicationControllerConfig_generatedName(prefix string) s
 resource "kubernetes_replication_controller" "test" {
   metadata {
     labels {
-      TestLabelOne = "one"
-      TestLabelTwo = "two"
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
       TestLabelThree = "three"
     }
+
     generate_name = "%s"
   }
+
   spec {
     selector {
-      TestLabelOne = "one"
-      TestLabelTwo = "two"
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
       TestLabelThree = "three"
     }
+
     template {
       container {
         image = "nginx:1.7.9"
@@ -604,7 +629,8 @@ resource "kubernetes_replication_controller" "test" {
       }
     }
   }
-}`, prefix)
+}
+`, prefix)
 }
 
 func testAccKubernetesReplicationControllerConfigWithSecurityContext(rcName, imageName string) string {
@@ -612,20 +638,24 @@ func testAccKubernetesReplicationControllerConfigWithSecurityContext(rcName, ima
 resource "kubernetes_replication_controller" "test" {
   metadata {
     name = "%s"
+
     labels {
       Test = "TfAcceptanceTest"
     }
   }
+
   spec {
     selector {
       Test = "TfAcceptanceTest"
     }
+
     template {
       security_context {
         run_as_non_root     = true
         run_as_user         = 101
         supplemental_groups = [101]
       }
+
       container {
         image = "%s"
         name  = "containername"
@@ -633,7 +663,7 @@ resource "kubernetes_replication_controller" "test" {
     }
   }
 }
-	`, rcName, imageName)
+`, rcName, imageName)
 }
 
 func testAccKubernetesReplicationControllerConfigWithLivenessProbeUsingExec(rcName, imageName string) string {
@@ -641,14 +671,17 @@ func testAccKubernetesReplicationControllerConfigWithLivenessProbeUsingExec(rcNa
 resource "kubernetes_replication_controller" "test" {
   metadata {
     name = "%s"
+
     labels {
       Test = "TfAcceptanceTest"
     }
   }
+
   spec {
     selector {
       Test = "TfAcceptanceTest"
     }
+
     template {
       container {
         image = "%s"
@@ -667,7 +700,7 @@ resource "kubernetes_replication_controller" "test" {
     }
   }
 }
-	`, rcName, imageName)
+`, rcName, imageName)
 }
 
 func testAccKubernetesReplicationControllerConfigWithLivenessProbeUsingHTTPGet(rcName, imageName string) string {
@@ -675,14 +708,17 @@ func testAccKubernetesReplicationControllerConfigWithLivenessProbeUsingHTTPGet(r
 resource "kubernetes_replication_controller" "test" {
   metadata {
     name = "%s"
+
     labels {
       Test = "TfAcceptanceTest"
     }
   }
+
   spec {
     selector {
       Test = "TfAcceptanceTest"
     }
+
     template {
       container {
         image = "%s"
@@ -699,6 +735,7 @@ resource "kubernetes_replication_controller" "test" {
               value = "Awesome"
             }
           }
+
           initial_delay_seconds = 3
           period_seconds        = 3
         }
@@ -706,7 +743,7 @@ resource "kubernetes_replication_controller" "test" {
     }
   }
 }
-	`, rcName, imageName)
+`, rcName, imageName)
 }
 
 func testAccKubernetesReplicationControllerConfigWithLivenessProbeUsingTCP(rcName, imageName string) string {
@@ -714,14 +751,17 @@ func testAccKubernetesReplicationControllerConfigWithLivenessProbeUsingTCP(rcNam
 resource "kubernetes_replication_controller" "test" {
   metadata {
     name = "%s"
+
     labels {
       Test = "TfAcceptanceTest"
     }
   }
+
   spec {
     selector {
       Test = "TfAcceptanceTest"
     }
+
     template {
       container {
         image = "%s"
@@ -740,7 +780,7 @@ resource "kubernetes_replication_controller" "test" {
     }
   }
 }
-	`, rcName, imageName)
+`, rcName, imageName)
 }
 
 func testAccKubernetesReplicationControllerConfigWithLifeCycle(rcName, imageName string) string {
@@ -748,14 +788,17 @@ func testAccKubernetesReplicationControllerConfigWithLifeCycle(rcName, imageName
 resource "kubernetes_replication_controller" "test" {
   metadata {
     name = "%s"
+
     labels {
       Test = "TfAcceptanceTest"
     }
   }
+
   spec {
     selector {
       Test = "TfAcceptanceTest"
     }
+
     template {
       container {
         image = "%s"
@@ -768,6 +811,7 @@ resource "kubernetes_replication_controller" "test" {
               command = ["ls", "-al"]
             }
           }
+
           pre_stop {
             exec {
               command = ["date"]
@@ -778,8 +822,7 @@ resource "kubernetes_replication_controller" "test" {
     }
   }
 }
-
-	`, rcName, imageName)
+`, rcName, imageName)
 }
 
 func testAccKubernetesReplicationControllerConfigWithContainerSecurityContext(rcName, imageName string) string {
@@ -787,22 +830,26 @@ func testAccKubernetesReplicationControllerConfigWithContainerSecurityContext(rc
 resource "kubernetes_replication_controller" "test" {
   metadata {
     name = "%s"
+
     labels {
       Test = "TfAcceptanceTest"
     }
   }
+
   spec {
     selector {
       Test = "TfAcceptanceTest"
     }
+
     template {
       container {
         image = "%s"
         name  = "containername"
-  
+
         security_context {
           privileged  = true
           run_as_user = 1
+
           se_linux_options {
             level = "s0:c123,c456"
           }
@@ -811,9 +858,7 @@ resource "kubernetes_replication_controller" "test" {
     }
   }
 }
-
-
-	`, rcName, imageName)
+`, rcName, imageName)
 }
 
 func testAccKubernetesReplicationControllerConfigWithVolumeMounts(secretName, rcName, imageName string) string {
@@ -831,6 +876,7 @@ resource "kubernetes_secret" "test" {
 resource "kubernetes_replication_controller" "test" {
   metadata {
     name = "%s"
+
     labels {
       Test = "TfAcceptanceTest"
     }
@@ -840,17 +886,21 @@ resource "kubernetes_replication_controller" "test" {
     selector {
       Test = "TfAcceptanceTest"
     }
-  	template {
+
+    template {
       container {
         image = "%s"
         name  = "containername"
+
         volume_mount {
           mount_path = "/tmp/my_path"
-          name  = "db"
+          name       = "db"
         }
       }
+
       volume {
         name = "db"
+
         secret = {
           secret_name = "${kubernetes_secret.test.metadata.0.name}"
         }
@@ -858,7 +908,7 @@ resource "kubernetes_replication_controller" "test" {
     }
   }
 }
-	`, secretName, rcName, imageName)
+`, secretName, rcName, imageName)
 }
 
 func testAccKubernetesReplicationControllerConfigWithResourceRequirements(rcName, imageName string) string {
@@ -866,6 +916,7 @@ func testAccKubernetesReplicationControllerConfigWithResourceRequirements(rcName
 resource "kubernetes_replication_controller" "test" {
   metadata {
     name = "%s"
+
     labels {
       Test = "TfAcceptanceTest"
     }
@@ -875,18 +926,20 @@ resource "kubernetes_replication_controller" "test" {
     selector {
       Test = "TfAcceptanceTest"
     }
-  	template {
+
+    template {
       container {
         image = "%s"
         name  = "containername"
 
-        resources{
-          limits{
-            cpu = "0.5"
+        resources {
+          limits {
+            cpu    = "0.5"
             memory = "512Mi"
           }
-          requests{
-            cpu = "250m"
+
+          requests {
+            cpu    = "250m"
             memory = "50Mi"
           }
         }
@@ -894,7 +947,7 @@ resource "kubernetes_replication_controller" "test" {
     }
   }
 }
-	`, rcName, imageName)
+`, rcName, imageName)
 }
 
 func testAccKubernetesReplicationControllerConfigWithEmptyDirVolumes(rcName, imageName string) string {
@@ -902,6 +955,7 @@ func testAccKubernetesReplicationControllerConfigWithEmptyDirVolumes(rcName, ima
 resource "kubernetes_replication_controller" "test" {
   metadata {
     name = "%s"
+
     labels {
       Test = "TfAcceptanceTest"
     }
@@ -911,17 +965,21 @@ resource "kubernetes_replication_controller" "test" {
     selector {
       Test = "TfAcceptanceTest"
     }
+
     template {
       container {
         image = "%s"
         name  = "containername"
+
         volume_mount {
-          mount_path =  "/cache"
-          name = "cache-volume"
+          mount_path = "/cache"
+          name       = "cache-volume"
         }
       }
+
       volume {
         name = "cache-volume"
+
         empty_dir = {
           medium = "Memory"
         }

--- a/kubernetes/resource_kubernetes_resource_quota_test.go
+++ b/kubernetes/resource_kubernetes_resource_quota_test.go
@@ -250,24 +250,27 @@ func testAccCheckKubernetesResourceQuotaExists(n string, obj *api.ResourceQuota)
 func testAccKubernetesResourceQuotaConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_resource_quota" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelThree = "three"
-			TestLabelFour = "four"
-		}
-		name = "%s"
-	}
-	spec {
-		hard {
-			"limits.cpu" = 2
-			"limits.memory" = "2Gi"
-			pods = 4
-		}
-	}
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelThree = "three"
+      TestLabelFour  = "four"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    hard {
+      "limits.cpu"    = 2
+      "limits.memory" = "2Gi"
+      pods            = 4
+    }
+  }
 }
 `, name)
 }
@@ -275,25 +278,28 @@ resource "kubernetes_resource_quota" "test" {
 func testAccKubernetesResourceQuotaConfig_metaModified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_resource_quota" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	spec {
-		hard {
-			"limits.cpu" = 2
-			"limits.memory" = "2Gi"
-			pods = 4
-		}
-	}
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    hard {
+      "limits.cpu"    = 2
+      "limits.memory" = "2Gi"
+      pods            = 4
+    }
+  }
 }
 `, name)
 }
@@ -301,17 +307,18 @@ resource "kubernetes_resource_quota" "test" {
 func testAccKubernetesResourceQuotaConfig_specModified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_resource_quota" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		hard {
-			"limits.cpu" = 4
-			"requests.cpu" = 1
-			"limits.memory" = "4Gi"
-			pods = 10
-		}
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    hard {
+      "limits.cpu"    = 4
+      "requests.cpu"  = 1
+      "limits.memory" = "4Gi"
+      pods            = 10
+    }
+  }
 }
 `, name)
 }
@@ -319,14 +326,15 @@ resource "kubernetes_resource_quota" "test" {
 func testAccKubernetesResourceQuotaConfig_generatedName(prefix string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_resource_quota" "test" {
-	metadata {
-		generate_name = "%s"
-	}
-	spec {
-		hard {
-			pods = 10
-		}
-	}
+  metadata {
+    generate_name = "%s"
+  }
+
+  spec {
+    hard {
+      pods = 10
+    }
+  }
 }
 `, prefix)
 }
@@ -334,15 +342,17 @@ resource "kubernetes_resource_quota" "test" {
 func testAccKubernetesResourceQuotaConfig_withScopes(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_resource_quota" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		hard {
-			pods = 10
-		}
-		scopes = ["BestEffort"]
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    hard {
+      pods = 10
+    }
+
+    scopes = ["BestEffort"]
+  }
 }
 `, name)
 }
@@ -350,15 +360,17 @@ resource "kubernetes_resource_quota" "test" {
 func testAccKubernetesResourceQuotaConfig_withScopesModified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_resource_quota" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		hard {
-			pods = 10
-		}
-		scopes = ["NotBestEffort"]
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    hard {
+      pods = 10
+    }
+
+    scopes = ["NotBestEffort"]
+  }
 }
 `, name)
 }

--- a/kubernetes/resource_kubernetes_secret_test.go
+++ b/kubernetes/resource_kubernetes_secret_test.go
@@ -332,123 +332,145 @@ resource "kubernetes_secret" "test" {
 func testAccKubernetesSecretConfig_emptyData(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_secret" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	data {}
-}`, name)
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  data {}
+}
+`, name)
 }
 
 func testAccKubernetesSecretConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_secret" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	data {
-		one = "first"
-		two = "second"
-	}
-}`, name)
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  data {
+    one = "first"
+    two = "second"
+  }
+}
+`, name)
 }
 
 func testAccKubernetesSecretConfig_modified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_secret" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			Different = "1234"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	data {
-		one = "first"
-		two = "second"
-		nine = "ninth"
-	}
-}`, name)
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      Different         = "1234"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  data {
+    one  = "first"
+    two  = "second"
+    nine = "ninth"
+  }
+}
+`, name)
 }
 
 func testAccKubernetesSecretConfig_noData(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_secret" "test" {
-	metadata {
-		name = "%s"
-	}
-}`, name)
+  metadata {
+    name = "%s"
+  }
+}
+`, name)
 }
 
 func testAccKubernetesSecretConfig_typeSpecified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_secret" "test" {
-	metadata {
-		name = "%s"
-	}
-	data {
-		username = "admin"
-		password = "password"
-	}
-	type = "kubernetes.io/basic-auth"
-}`, name)
+  metadata {
+    name = "%s"
+  }
+
+  data {
+    username = "admin"
+    password = "password"
+  }
+
+  type = "kubernetes.io/basic-auth"
+}
+`, name)
 }
 
 func testAccKubernetesSecretConfig_generatedName(prefix string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_secret" "test" {
-	metadata {
-		generate_name = "%s"
-	}
-	data {
-		one = "first"
-		two = "second"
-	}
-}`, prefix)
+  metadata {
+    generate_name = "%s"
+  }
+
+  data {
+    one = "first"
+    two = "second"
+  }
+}
+`, prefix)
 }
 
 func testAccKubernetesSecretConfig_binaryData(prefix string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_secret" "test" {
-	metadata {
-		generate_name = "%s"
-	}
-	data {
-		one = "${file("./test-fixtures/binary.data")}"
-	}
-}`, prefix)
+  metadata {
+    generate_name = "%s"
+  }
+
+  data {
+    one = "${file("./test-fixtures/binary.data")}"
+  }
+}
+`, prefix)
 }
 
 func testAccKubernetesSecretConfig_binaryData2(prefix string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_secret" "test" {
-	metadata {
-		generate_name = "%s"
-	}
-	data {
-		one = "${file("./test-fixtures/binary2.data")}"
-		two = "${file("./test-fixtures/binary.data")}"
-	}
-}`, prefix)
+  metadata {
+    generate_name = "%s"
+  }
+
+  data {
+    one = "${file("./test-fixtures/binary2.data")}"
+    two = "${file("./test-fixtures/binary.data")}"
+  }
+}
+`, prefix)
 }

--- a/kubernetes/resource_kubernetes_service_account_test.go
+++ b/kubernetes/resource_kubernetes_service_account_test.go
@@ -341,54 +341,60 @@ func testAccCheckKubernetesServiceAccountExists(n string, obj *api.ServiceAccoun
 func testAccKubernetesServiceAccountConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_service_account" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	secret {
-		name = "${kubernetes_secret.one.metadata.0.name}"
-	}
-	secret {
-		name = "${kubernetes_secret.two.metadata.0.name}"
-	}
-	image_pull_secret {
-		name = "${kubernetes_secret.three.metadata.0.name}"
-	}
-	image_pull_secret {
-		name = "${kubernetes_secret.four.metadata.0.name}"
-	}
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  secret {
+    name = "${kubernetes_secret.one.metadata.0.name}"
+  }
+
+  secret {
+    name = "${kubernetes_secret.two.metadata.0.name}"
+  }
+
+  image_pull_secret {
+    name = "${kubernetes_secret.three.metadata.0.name}"
+  }
+
+  image_pull_secret {
+    name = "${kubernetes_secret.four.metadata.0.name}"
+  }
 }
 
 resource "kubernetes_secret" "one" {
-	metadata {
-		name = "%s-one"
-	}
+  metadata {
+    name = "%s-one"
+  }
 }
 
 resource "kubernetes_secret" "two" {
-	metadata {
-		name = "%s-two"
-	}
+  metadata {
+    name = "%s-two"
+  }
 }
 
 resource "kubernetes_secret" "three" {
-	metadata {
-		name = "%s-three"
-	}
+  metadata {
+    name = "%s-three"
+  }
 }
 
 resource "kubernetes_secret" "four" {
-	metadata {
-		name = "%s-four"
-	}
+  metadata {
+    name = "%s-four"
+  }
 }
 `, name, name, name, name, name)
 }
@@ -396,53 +402,59 @@ resource "kubernetes_secret" "four" {
 func testAccKubernetesServiceAccountConfig_modified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_service_account" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			Different = "1234"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	secret {
-		name = "${kubernetes_secret.one.metadata.0.name}"
-	}
-	image_pull_secret {
-		name = "${kubernetes_secret.two.metadata.0.name}"
-	}
-	image_pull_secret {
-		name = "${kubernetes_secret.three.metadata.0.name}"
-	}
-	image_pull_secret {
-		name = "${kubernetes_secret.four.metadata.0.name}"
-	}
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      Different         = "1234"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  secret {
+    name = "${kubernetes_secret.one.metadata.0.name}"
+  }
+
+  image_pull_secret {
+    name = "${kubernetes_secret.two.metadata.0.name}"
+  }
+
+  image_pull_secret {
+    name = "${kubernetes_secret.three.metadata.0.name}"
+  }
+
+  image_pull_secret {
+    name = "${kubernetes_secret.four.metadata.0.name}"
+  }
 }
 
 resource "kubernetes_secret" "one" {
-	metadata {
-		name = "%s-one"
-	}
+  metadata {
+    name = "%s-one"
+  }
 }
 
 resource "kubernetes_secret" "two" {
-	metadata {
-		name = "%s-two"
-	}
+  metadata {
+    name = "%s-two"
+  }
 }
 
 resource "kubernetes_secret" "three" {
-	metadata {
-		name = "%s-three"
-	}
+  metadata {
+    name = "%s-three"
+  }
 }
 
 resource "kubernetes_secret" "four" {
-	metadata {
-		name = "%s-four"
-	}
+  metadata {
+    name = "%s-four"
+  }
 }
 `, name, name, name, name, name)
 }
@@ -450,72 +462,82 @@ resource "kubernetes_secret" "four" {
 func testAccKubernetesServiceAccountConfig_noAttributes(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_service_account" "test" {
-	metadata {
-		name = "%s"
-	}
-}`, name)
+  metadata {
+    name = "%s"
+  }
+}
+`, name)
 }
 
 func testAccKubernetesServiceAccountConfig_generatedName(prefix string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_service_account" "test" {
-	metadata {
-		generate_name = "%s"
-	}
-}`, prefix)
+  metadata {
+    generate_name = "%s"
+  }
+}
+`, prefix)
 }
 
 func testAccKubernetesServiceAccountConfig_automount(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_service_account" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	secret {
-		name = "${kubernetes_secret.one.metadata.0.name}"
-	}
-	secret {
-		name = "${kubernetes_secret.two.metadata.0.name}"
-	}
-	image_pull_secret {
-		name = "${kubernetes_secret.three.metadata.0.name}"
-	}
-	image_pull_secret {
-		name = "${kubernetes_secret.four.metadata.0.name}"
-	}
-	automount_service_account_token = true
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  secret {
+    name = "${kubernetes_secret.one.metadata.0.name}"
+  }
+
+  secret {
+    name = "${kubernetes_secret.two.metadata.0.name}"
+  }
+
+  image_pull_secret {
+    name = "${kubernetes_secret.three.metadata.0.name}"
+  }
+
+  image_pull_secret {
+    name = "${kubernetes_secret.four.metadata.0.name}"
+  }
+
+  automount_service_account_token = true
 }
 
 resource "kubernetes_secret" "one" {
-	metadata {
-		name = "%s-one"
-	}
+  metadata {
+    name = "%s-one"
+  }
 }
 
 resource "kubernetes_secret" "two" {
-	metadata {
-		name = "%s-two"
-	}
+  metadata {
+    name = "%s-two"
+  }
 }
 
 resource "kubernetes_secret" "three" {
-	metadata {
-		name = "%s-three"
-	}
+  metadata {
+    name = "%s-three"
+  }
 }
 
 resource "kubernetes_secret" "four" {
-	metadata {
-		name = "%s-four"
-	}
-}`, name, name, name, name, name)
+  metadata {
+    name = "%s-four"
+  }
+}
+`, name, name, name, name, name)
 }

--- a/kubernetes/resource_kubernetes_service_test.go
+++ b/kubernetes/resource_kubernetes_service_test.go
@@ -482,152 +482,179 @@ func testAccCheckKubernetesServiceExists(n string, obj *api.Service) resource.Te
 func testAccKubernetesServiceConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_service" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	spec {
-		port {
-			port = 8080
-			target_port = 80
-		}
-	}
-}`, name)
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    port {
+      port        = 8080
+      target_port = 80
+    }
+  }
+}
+`, name)
 }
 
 func testAccKubernetesServiceConfig_modified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_service" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			Different = "1234"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	spec {
-		port {
-			port = 8081
-			target_port = 80
-		}
-	}
-}`, name)
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      Different         = "1234"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  spec {
+    port {
+      port        = 8081
+      target_port = 80
+    }
+  }
+}
+`, name)
 }
 
 func testAccKubernetesServiceConfig_loadBalancer(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_service" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		external_name = "ext-name-%s"
-		external_ips = ["10.0.0.3", "10.0.0.4"]
-		load_balancer_source_ranges = ["10.0.0.5/32", "10.0.0.6/32"]
-		selector {
-			App = "MyApp"
-		}
-		session_affinity = "ClientIP"
-		port {
-			port = 8888
-			target_port = 80
-		}
-		type = "LoadBalancer"
-	}
-}`, name, name)
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    external_name               = "ext-name-%s"
+    external_ips                = ["10.0.0.3", "10.0.0.4"]
+    load_balancer_source_ranges = ["10.0.0.5/32", "10.0.0.6/32"]
+
+    selector {
+      App = "MyApp"
+    }
+
+    session_affinity = "ClientIP"
+
+    port {
+      port        = 8888
+      target_port = 80
+    }
+
+    type = "LoadBalancer"
+  }
+}
+`, name, name)
 }
 
 func testAccKubernetesServiceConfig_loadBalancer_modified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_service" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		external_name = "ext-name-modified-%s"
-		external_ips = ["10.0.0.4", "10.0.0.5"]
-		load_balancer_source_ranges = ["10.0.0.1/32", "10.0.0.2/32"]
-		selector {
-			App = "MyModifiedApp"
-			NewSelector = "NewValue"
-		}
-		session_affinity = "ClientIP"
-		port {
-			port = 9999
-			target_port = 81
-		}
-		type = "LoadBalancer"
-	}
-}`, name, name)
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    external_name               = "ext-name-modified-%s"
+    external_ips                = ["10.0.0.4", "10.0.0.5"]
+    load_balancer_source_ranges = ["10.0.0.1/32", "10.0.0.2/32"]
+
+    selector {
+      App         = "MyModifiedApp"
+      NewSelector = "NewValue"
+    }
+
+    session_affinity = "ClientIP"
+
+    port {
+      port        = 9999
+      target_port = 81
+    }
+
+    type = "LoadBalancer"
+  }
+}
+`, name, name)
 }
 
 func testAccKubernetesServiceConfig_nodePort(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_service" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		external_name = "ext-name-%s"
-		external_ips = ["10.0.0.4", "10.0.0.5"]
-		load_balancer_ip = "12.0.0.125"
-		selector {
-			App = "MyApp"
-		}
-		session_affinity = "ClientIP"
-		port {
-			name = "first"
-			port = 10222
-			target_port = 22
-		}
-		port {
-			name = "second"
-			port = 10333
-			target_port = 33
-		}
-		type = "NodePort"
-	}
-}`, name, name)
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    external_name    = "ext-name-%s"
+    external_ips     = ["10.0.0.4", "10.0.0.5"]
+    load_balancer_ip = "12.0.0.125"
+
+    selector {
+      App = "MyApp"
+    }
+
+    session_affinity = "ClientIP"
+
+    port {
+      name        = "first"
+      port        = 10222
+      target_port = 22
+    }
+
+    port {
+      name        = "second"
+      port        = 10333
+      target_port = 33
+    }
+
+    type = "NodePort"
+  }
+}
+`, name, name)
 }
 
 func testAccKubernetesServiceConfig_stringTargetPort(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_service" "test" {
-	metadata {
-	  name = "%s"
+  metadata {
+    name = "%s"
 
-	  labels {
-		app  = "helloweb"
-		tier = "frontend"
-	  }
-	}
-  
-	spec {
-	  type = "LoadBalancer"
-  
-	  selector {
-		app  = "helloweb"
-		tier = "frontend"
-	  }
-  
-	  port {
-		port        = 8080
-		target_port = "http-server"
-	  }
-	}
+    labels {
+      app  = "helloweb"
+      tier = "frontend"
+    }
   }
+
+  spec {
+    type = "LoadBalancer"
+
+    selector {
+      app  = "helloweb"
+      tier = "frontend"
+    }
+
+    port {
+      port        = 8080
+      target_port = "http-server"
+    }
+  }
+}
 `, name)
 }
 
@@ -637,18 +664,22 @@ resource "kubernetes_service" "test" {
   metadata {
     name = "%s"
   }
+
   spec {
     selector {
       App = "MyOtherApp"
     }
+
     port {
       name = "http"
       port = 80
     }
+
     port {
       name = "https"
       port = 443
     }
+
     type = "LoadBalancer"
   }
 }
@@ -658,13 +689,14 @@ resource "kubernetes_service" "test" {
 func testAccKubernetesServiceConfig_externalName(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_service" "test" {
-	metadata {
-		name = "%s"
-	}
-	spec {
-		type = "ExternalName"
-		external_name = "terraform.io"
-	}
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    type          = "ExternalName"
+    external_name = "terraform.io"
+  }
 }
 `, name)
 }
@@ -672,14 +704,16 @@ resource "kubernetes_service" "test" {
 func testAccKubernetesServiceConfig_generatedName(prefix string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_service" "test" {
-	metadata {
-		generate_name = "%s"
-	}
-	spec {
-		port {
-			port = 8080
-			target_port = 80
-		}
-	}
-}`, prefix)
+  metadata {
+    generate_name = "%s"
+  }
+
+  spec {
+    port {
+      port        = 8080
+      target_port = 80
+    }
+  }
+}
+`, prefix)
 }

--- a/kubernetes/resource_kubernetes_stateful_set_test.go
+++ b/kubernetes/resource_kubernetes_stateful_set_test.go
@@ -331,83 +331,83 @@ func testAccKubernetesStatefulSetChecksBasic(name string) resource.TestCheckFunc
 func testAccKubernetesStatefulSetConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_stateful_set" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
 
-		labels {
-			TestLabelOne	 = "one"
-			TestLabelTwo	 = "two"
-			TestLabelThree = "three"
-		}
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
 
-		name = "%s"
-	}
+    name = "%s"
+  }
 
-	spec {
-		pod_management_policy	= "OrderedReady"
-		replicas							 = 1
-		revision_history_limit = 11
+  spec {
+    pod_management_policy  = "OrderedReady"
+    replicas               = 1
+    revision_history_limit = 11
 
-		selector {
-			match_labels {
-				app = "ss-test"
-			}
-		}
+    selector {
+      match_labels {
+        app = "ss-test"
+      }
+    }
 
-		service_name = "ss-test-service"
+    service_name = "ss-test-service"
 
-		template {
-			metadata {
-				labels {
-					app = "ss-test"
-				}
-			}
+    template {
+      metadata {
+        labels {
+          app = "ss-test"
+        }
+      }
 
-			spec {
-				container {
-					name	= "ss-test"
-					image = "k8s.gcr.io/pause:latest"
+      spec {
+        container {
+          name  = "ss-test"
+          image = "k8s.gcr.io/pause:latest"
 
-					port {
-						container_port = "80"
-						name					 = "web"
-					}
+          port {
+            container_port = "80"
+            name           = "web"
+          }
 
-					volume_mount {
-						name			 = "workdir"
-						mount_path = "/work-dir"
-					}
-				}
-			}
-		}
+          volume_mount {
+            name       = "workdir"
+            mount_path = "/work-dir"
+          }
+        }
+      }
+    }
 
-		update_strategy {
-			type = "RollingUpdate"
+    update_strategy {
+      type = "RollingUpdate"
 
-			rolling_update {
-				partition = 1
-			}
-		}
+      rolling_update {
+        partition = 1
+      }
+    }
 
-		volume_claim_template {
-			metadata {
-				name = "ss-test"
-			}
+    volume_claim_template {
+      metadata {
+        name = "ss-test"
+      }
 
-			spec {
-				access_modes = ["ReadWriteOnce"]
+      spec {
+        access_modes = ["ReadWriteOnce"]
 
-				resources {
-					requests {
-						storage = "1Gi"
-					}
-				}
-			}
-		}
-	}
+        resources {
+          requests {
+            storage = "1Gi"
+          }
+        }
+      }
+    }
+  }
 }
 `, name)
 }
@@ -415,85 +415,85 @@ resource "kubernetes_stateful_set" "test" {
 func testAccKubernetesStatefulSetConfigUpdatedSelectorLabels(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_stateful_set" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
 
-		labels {
-			TestLabelOne   = "one"
-			TestLabelTwo   = "two"
-			TestLabelThree = "three"
-		}
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
 
-		name = "%s"
-	}
+    name = "%s"
+  }
 
-	spec {
-		pod_management_policy  = "OrderedReady"
-		replicas               = 1
-		revision_history_limit = 11
+  spec {
+    pod_management_policy  = "OrderedReady"
+    replicas               = 1
+    revision_history_limit = 11
 
-		selector {
-			match_labels {
-				app   = "ss-test"
-				layer = "ss-test-layer"
-			}
-		}
+    selector {
+      match_labels {
+        app   = "ss-test"
+        layer = "ss-test-layer"
+      }
+    }
 
-		service_name = "ss-test-service"
+    service_name = "ss-test-service"
 
-		template {
-			metadata {
-				labels {
-					app   = "ss-test"
-					layer = "ss-test-layer"
-				}
-			}
+    template {
+      metadata {
+        labels {
+          app   = "ss-test"
+          layer = "ss-test-layer"
+        }
+      }
 
-			spec {
-				container {
-					name  = "ss-test"
-					image = "k8s.gcr.io/pause:latest"
+      spec {
+        container {
+          name  = "ss-test"
+          image = "k8s.gcr.io/pause:latest"
 
-					port {
-						container_port = "80"
-						name           = "web"
-					}
+          port {
+            container_port = "80"
+            name           = "web"
+          }
 
-					volume_mount {
-						name       = "workdir"
-						mount_path = "/work-dir"
-					}
-				}
-			}
-		}
+          volume_mount {
+            name       = "workdir"
+            mount_path = "/work-dir"
+          }
+        }
+      }
+    }
 
-		update_strategy {
-			type = "RollingUpdate"
+    update_strategy {
+      type = "RollingUpdate"
 
-			rolling_update {
-				partition = 0
-			}
-		}
+      rolling_update {
+        partition = 0
+      }
+    }
 
-		volume_claim_template {
-			metadata {
-				name = "ss-test"
-			}
+    volume_claim_template {
+      metadata {
+        name = "ss-test"
+      }
 
-			spec {
-				access_modes = ["ReadWriteOnce"]
+      spec {
+        access_modes = ["ReadWriteOnce"]
 
-				resources {
-					requests {
-						storage = "1Gi"
-					}
-				}
-			}
-		}
-	}
+        resources {
+          requests {
+            storage = "1Gi"
+          }
+        }
+      }
+    }
+  }
 }
 `, name)
 }
@@ -501,83 +501,83 @@ resource "kubernetes_stateful_set" "test" {
 func testAccKubernetesStatefulSetConfigUpdateReplicas(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_stateful_set" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
 
-		labels {
-			TestLabelOne   = "one"
-			TestLabelTwo   = "two"
-			TestLabelThree = "three"
-		}
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
 
-		name = "%s"
-	}
+    name = "%s"
+  }
 
-	spec {
-		pod_management_policy  = "OrderedReady"
-		replicas               = 5
-		revision_history_limit = 11
+  spec {
+    pod_management_policy  = "OrderedReady"
+    replicas               = 5
+    revision_history_limit = 11
 
-		selector {
-			match_labels {
-				app = "ss-test"
-			}
-		}
+    selector {
+      match_labels {
+        app = "ss-test"
+      }
+    }
 
-		service_name = "ss-test-service"
+    service_name = "ss-test-service"
 
-		template {
-			metadata {
-				labels {
-					app = "ss-test"
-				}
-			}
+    template {
+      metadata {
+        labels {
+          app = "ss-test"
+        }
+      }
 
-			spec {
-				container {
-					name  = "ss-test"
-					image = "k8s.gcr.io/pause:latest"
+      spec {
+        container {
+          name  = "ss-test"
+          image = "k8s.gcr.io/pause:latest"
 
-					port {
-						container_port = "80"
-						name           = "web"
-					}
+          port {
+            container_port = "80"
+            name           = "web"
+          }
 
-					volume_mount {
-						name       = "workdir"
-						mount_path = "/work-dir"
-					}
-				}
-			}
-		}
+          volume_mount {
+            name       = "workdir"
+            mount_path = "/work-dir"
+          }
+        }
+      }
+    }
 
-		update_strategy {
-			type = "RollingUpdate"
+    update_strategy {
+      type = "RollingUpdate"
 
-			rolling_update {
-				partition = 1
-			}
-		}
+      rolling_update {
+        partition = 1
+      }
+    }
 
-		volume_claim_template {
-			metadata {
-				name = "ss-test"
-			}
+    volume_claim_template {
+      metadata {
+        name = "ss-test"
+      }
 
-			spec {
-				access_modes = ["ReadWriteOnce"]
+      spec {
+        access_modes = ["ReadWriteOnce"]
 
-				resources {
-					requests {
-						storage = "1Gi"
-					}
-				}
-			}
-		}
-	}
+        resources {
+          requests {
+            storage = "1Gi"
+          }
+        }
+      }
+    }
+  }
 }
 `, name)
 }
@@ -585,252 +585,252 @@ resource "kubernetes_stateful_set" "test" {
 func testAccKubernetesStatefulSetConfigUpdateTemplateContainerPort(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_stateful_set" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
 
-		labels {
-			TestLabelOne   = "one"
-			TestLabelTwo   = "two"
-			TestLabelThree = "three"
-		}
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
 
-		name = "%s"
-	}
+    name = "%s"
+  }
 
-	spec {
-		pod_management_policy  = "OrderedReady"
-		replicas               = 1
-		revision_history_limit = 11
+  spec {
+    pod_management_policy  = "OrderedReady"
+    replicas               = 1
+    revision_history_limit = 11
 
-		selector {
-			match_labels {
-				app = "ss-test"
-			}
-		}
+    selector {
+      match_labels {
+        app = "ss-test"
+      }
+    }
 
-		service_name = "ss-test-service"
+    service_name = "ss-test-service"
 
-		template {
-			metadata {
-				labels {
-					app = "ss-test"
-				}
-			}
+    template {
+      metadata {
+        labels {
+          app = "ss-test"
+        }
+      }
 
-			spec {
-				container {
-					name  = "ss-test"
-					image = "k8s.gcr.io/pause:latest"
+      spec {
+        container {
+          name  = "ss-test"
+          image = "k8s.gcr.io/pause:latest"
 
-					port {
-						container_port = "80"
-						name           = "web"
-					}
+          port {
+            container_port = "80"
+            name           = "web"
+          }
 
-					port {
-						container_port = "443"
-						name           = "secure"
-					}
+          port {
+            container_port = "443"
+            name           = "secure"
+          }
 
-					volume_mount {
-						name       = "workdir"
-						mount_path = "/work-dir"
-					}
-				}
-			}
-		}
+          volume_mount {
+            name       = "workdir"
+            mount_path = "/work-dir"
+          }
+        }
+      }
+    }
 
-		update_strategy {
-			type = "RollingUpdate"
+    update_strategy {
+      type = "RollingUpdate"
 
-			rolling_update {
-				partition = 1
-			}
-		}
+      rolling_update {
+        partition = 1
+      }
+    }
 
-		volume_claim_template {
-			metadata {
-				name = "ss-test"
-			}
+    volume_claim_template {
+      metadata {
+        name = "ss-test"
+      }
 
-			spec {
-				access_modes = ["ReadWriteOnce"]
+      spec {
+        access_modes = ["ReadWriteOnce"]
 
-				resources {
-					requests {
-						storage = "1Gi"
-					}
-				}
-			}
-		}
-	}
+        resources {
+          requests {
+            storage = "1Gi"
+          }
+        }
+      }
+    }
+  }
 }
-	`, name)
+`, name)
 }
 
 func testAccKubernetesStatefulSetConfigRollingUpdatePartition(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_stateful_set" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
 
-		labels {
-			TestLabelOne   = "one"
-			TestLabelTwo   = "two"
-			TestLabelThree = "three"
-		}
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
 
-		name = "%s"
-	}
+    name = "%s"
+  }
 
-	spec {
-		pod_management_policy  = "OrderedReady"
-		replicas               = 1
-		revision_history_limit = 11
+  spec {
+    pod_management_policy  = "OrderedReady"
+    replicas               = 1
+    revision_history_limit = 11
 
-		selector {
-			match_labels {
-				app = "ss-test"
-			}
-		}
+    selector {
+      match_labels {
+        app = "ss-test"
+      }
+    }
 
-		service_name = "ss-test-service"
+    service_name = "ss-test-service"
 
-		template {
-			metadata {
-				labels {
-					app = "ss-test"
-				}
-			}
+    template {
+      metadata {
+        labels {
+          app = "ss-test"
+        }
+      }
 
-			spec {
-				container {
-					name  = "ss-test"
-					image = "k8s.gcr.io/pause:latest"
+      spec {
+        container {
+          name  = "ss-test"
+          image = "k8s.gcr.io/pause:latest"
 
-					port {
-						container_port = "80"
-						name           = "web"
-					}
+          port {
+            container_port = "80"
+            name           = "web"
+          }
 
-					volume_mount {
-						name       = "workdir"
-						mount_path = "/work-dir"
-					}
-				}
-			}
-		}
+          volume_mount {
+            name       = "workdir"
+            mount_path = "/work-dir"
+          }
+        }
+      }
+    }
 
-		update_strategy {
-			type = "RollingUpdate"
+    update_strategy {
+      type = "RollingUpdate"
 
-			rolling_update {
-				partition = 2
-			}
-		}
+      rolling_update {
+        partition = 2
+      }
+    }
 
-		volume_claim_template {
-			metadata {
-				name = "ss-test"
-			}
+    volume_claim_template {
+      metadata {
+        name = "ss-test"
+      }
 
-			spec {
-				access_modes = ["ReadWriteOnce"]
+      spec {
+        access_modes = ["ReadWriteOnce"]
 
-				resources {
-					requests {
-						storage = "1Gi"
-					}
-				}
-			}
-		}
-	}
+        resources {
+          requests {
+            storage = "1Gi"
+          }
+        }
+      }
+    }
+  }
 }
-	`, name)
+`, name)
 }
 
 func testAccKubernetesStatefulSetConfigUpdateStrategyOnDelete(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_stateful_set" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
 
-		labels {
-			TestLabelOne   = "one"
-			TestLabelTwo   = "two"
-			TestLabelThree = "three"
-		}
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
 
-		name = "%s"
-	}
+    name = "%s"
+  }
 
-	spec {
-		pod_management_policy  = "OrderedReady"
-		replicas               = 1
-		revision_history_limit = 11
+  spec {
+    pod_management_policy  = "OrderedReady"
+    replicas               = 1
+    revision_history_limit = 11
 
-		selector {
-			match_labels {
-				app = "ss-test"
-			}
-		}
+    selector {
+      match_labels {
+        app = "ss-test"
+      }
+    }
 
-		service_name = "ss-test-service"
+    service_name = "ss-test-service"
 
-		template {
-			metadata {
-				labels {
-					app = "ss-test"
-				}
-			}
+    template {
+      metadata {
+        labels {
+          app = "ss-test"
+        }
+      }
 
-			spec {
-				container {
-					name  = "ss-test"
-					image = "k8s.gcr.io/pause:latest"
+      spec {
+        container {
+          name  = "ss-test"
+          image = "k8s.gcr.io/pause:latest"
 
-					port {
-						container_port = "80"
-						name           = "web"
-					}
+          port {
+            container_port = "80"
+            name           = "web"
+          }
 
-					volume_mount {
-						name       = "workdir"
-						mount_path = "/work-dir"
-					}
-				}
-			}
-		}
+          volume_mount {
+            name       = "workdir"
+            mount_path = "/work-dir"
+          }
+        }
+      }
+    }
 
-		update_strategy {
-			type = "OnDelete"
-		}
+    update_strategy {
+      type = "OnDelete"
+    }
 
-		volume_claim_template {
-			metadata {
-				name = "ss-test"
-			}
+    volume_claim_template {
+      metadata {
+        name = "ss-test"
+      }
 
-			spec {
-				access_modes = ["ReadWriteOnce"]
+      spec {
+        access_modes = ["ReadWriteOnce"]
 
-				resources {
-					requests {
-						storage = "1Gi"
-					}
-				}
-			}
-		}
-	}
+        resources {
+          requests {
+            storage = "1Gi"
+          }
+        }
+      }
+    }
+  }
 }
 `, name)
 }

--- a/kubernetes/resource_kubernetes_storage_class_test.go
+++ b/kubernetes/resource_kubernetes_storage_class_test.go
@@ -227,65 +227,79 @@ func testAccCheckKubernetesStorageClassExists(n string, obj *api.StorageClass) r
 func testAccKubernetesStorageClassConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_storage_class" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			TestAnnotationTwo = "two"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelTwo = "two"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	storage_provisioner = "kubernetes.io/gce-pd"
-	reclaim_policy = "Delete"
-	parameters {
-		type = "pd-ssd"
-	}
-}`, name)
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  storage_provisioner = "kubernetes.io/gce-pd"
+  reclaim_policy      = "Delete"
+
+  parameters {
+    type = "pd-ssd"
+  }
+}
+`, name)
 }
 
 func testAccKubernetesStorageClassConfig_modified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_storage_class" "test" {
-	metadata {
-		annotations {
-			TestAnnotationOne = "one"
-			Different = "1234"
-		}
-		labels {
-			TestLabelOne = "one"
-			TestLabelThree = "three"
-		}
-		name = "%s"
-	}
-	storage_provisioner = "kubernetes.io/gce-pd"
-	reclaim_policy = "Retain"
-	parameters {
-		type = "pd-standard"
-		zones = "us-west1-a,us-west1-b"
-	}
-}`, name)
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      Different         = "1234"
+    }
+
+    labels {
+      TestLabelOne   = "one"
+      TestLabelThree = "three"
+    }
+
+    name = "%s"
+  }
+
+  storage_provisioner = "kubernetes.io/gce-pd"
+  reclaim_policy      = "Retain"
+
+  parameters {
+    type  = "pd-standard"
+    zones = "us-west1-a,us-west1-b"
+  }
+}
+`, name)
 }
 
 func testAccKubernetesStorageClassConfig_noParameters(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_storage_class" "test" {
-	metadata {
-		name = "%s"
-	}
-	storage_provisioner = "kubernetes.io/gce-pd"
-}`, name)
+  metadata {
+    name = "%s"
+  }
+
+  storage_provisioner = "kubernetes.io/gce-pd"
+}
+`, name)
 }
 
 func testAccKubernetesStorageClassConfig_generatedName(prefix string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_storage_class" "test" {
-	metadata {
-		generate_name = "%s"
-	}
-	storage_provisioner = "kubernetes.io/gce-pd"
-}`, prefix)
+  metadata {
+    generate_name = "%s"
+  }
+
+  storage_provisioner = "kubernetes.io/gce-pd"
+}
+`, prefix)
 }


### PR DESCRIPTION
This change aligns the formatting of the inline HCL resources used as configuration in tests.

This is the result of running `https://github.com/katbyte/terrafmt` on the `*_test.go` set of files.
Includes some hand-crafted help for the fmt tool.

@terraform-providers/ecosystem 