### PR TITLE
Convert returned types to pointers

### DIFF
--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -198,7 +198,7 @@ func resourceKubernetesDeploymentCreate(d *schema.ResourceData, meta interface{}
 
 	deployment := appsv1.Deployment{
 		ObjectMeta: metadata,
-		Spec:       spec,
+		Spec:       *spec,
 	}
 
 	log.Printf("[INFO] Creating new deployment: %#v", deployment)

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
@@ -85,9 +85,14 @@ func resourceKubernetesHorizontalPodAutoscalerCreate(d *schema.ResourceData, met
 	conn := meta.(*kubernetes.Clientset)
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
+	spec, err := expandHorizontalPodAutoscalerSpec(d.Get("spec").([]interface{}))
+	if err != nil {
+		return err
+	}
+
 	svc := api.HorizontalPodAutoscaler{
 		ObjectMeta: metadata,
-		Spec:       expandHorizontalPodAutoscalerSpec(d.Get("spec").([]interface{})),
+		Spec:       *spec,
 	}
 	log.Printf("[INFO] Creating new horizontal pod autoscaler: %#v", svc)
 	out, err := conn.AutoscalingV1().HorizontalPodAutoscalers(metadata.Namespace).Create(&svc)

--- a/kubernetes/resource_kubernetes_limit_range.go
+++ b/kubernetes/resource_kubernetes_limit_range.go
@@ -89,7 +89,7 @@ func resourceKubernetesLimitRangeCreate(d *schema.ResourceData, meta interface{}
 	}
 	limitRange := api.LimitRange{
 		ObjectMeta: metadata,
-		Spec:       spec,
+		Spec:       *spec,
 	}
 	log.Printf("[INFO] Creating new limit range: %#v", limitRange)
 	out, err := conn.CoreV1().LimitRanges(metadata.Namespace).Create(&limitRange)

--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -121,7 +121,7 @@ func resourceKubernetesPersistentVolumeCreate(d *schema.ResourceData, meta inter
 	}
 	volume := api.PersistentVolume{
 		ObjectMeta: metadata,
-		Spec:       spec,
+		Spec:       *spec,
 	}
 
 	log.Printf("[INFO] Creating new persistent volume: %#v", volume)

--- a/kubernetes/resource_kubernetes_persistent_volume_claim.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim.go
@@ -56,7 +56,7 @@ func resourceKubernetesPersistentVolumeClaimCreate(d *schema.ResourceData, meta 
 		return err
 	}
 	log.Printf("[INFO] Creating new persistent volume claim: %#v", claim)
-	out, err := conn.CoreV1().PersistentVolumeClaims(claim.Namespace).Create(&claim)
+	out, err := conn.CoreV1().PersistentVolumeClaims(claim.Namespace).Create(claim)
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -57,7 +57,7 @@ func resourceKubernetesPodCreate(d *schema.ResourceData, meta interface{}) error
 
 	pod := api.Pod{
 		ObjectMeta: metadata,
-		Spec:       spec,
+		Spec:       *spec,
 	}
 
 	log.Printf("[INFO] Creating new pod: %#v", pod)

--- a/kubernetes/resource_kubernetes_replication_controller.go
+++ b/kubernetes/resource_kubernetes_replication_controller.go
@@ -86,7 +86,7 @@ func resourceKubernetesReplicationControllerCreate(d *schema.ResourceData, meta 
 
 	rc := api.ReplicationController{
 		ObjectMeta: metadata,
-		Spec:       spec,
+		Spec:       *spec,
 	}
 
 	log.Printf("[INFO] Creating new replication controller: %#v", rc)

--- a/kubernetes/resource_kubernetes_resource_quota.go
+++ b/kubernetes/resource_kubernetes_resource_quota.go
@@ -66,7 +66,7 @@ func resourceKubernetesResourceQuotaCreate(d *schema.ResourceData, meta interfac
 	}
 	resQuota := api.ResourceQuota{
 		ObjectMeta: metadata,
-		Spec:       spec,
+		Spec:       *spec,
 	}
 	log.Printf("[INFO] Creating new resource quota: %#v", resQuota)
 	out, err := conn.CoreV1().ResourceQuotas(metadata.Namespace).Create(&resQuota)
@@ -140,17 +140,16 @@ func resourceKubernetesResourceQuotaUpdate(d *schema.ResourceData, meta interfac
 	}
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
-	var spec api.ResourceQuotaSpec
+	var spec *api.ResourceQuotaSpec
 	waitForChangedSpec := false
 	if d.HasChange("spec") {
-		var err error
-		spec, err = expandResourceQuotaSpec(d.Get("spec").([]interface{}))
+		spec, err := expandResourceQuotaSpec(d.Get("spec").([]interface{}))
 		if err != nil {
 			return err
 		}
 		ops = append(ops, &ReplaceOperation{
 			Path:  "/spec",
-			Value: spec,
+			Value: *spec,
 		})
 		waitForChangedSpec = true
 	}

--- a/kubernetes/resource_kubernetes_resource_quota.go
+++ b/kubernetes/resource_kubernetes_resource_quota.go
@@ -143,7 +143,7 @@ func resourceKubernetesResourceQuotaUpdate(d *schema.ResourceData, meta interfac
 	var spec *api.ResourceQuotaSpec
 	waitForChangedSpec := false
 	if d.HasChange("spec") {
-		spec, err := expandResourceQuotaSpec(d.Get("spec").([]interface{}))
+		spec, err = expandResourceQuotaSpec(d.Get("spec").([]interface{}))
 		if err != nil {
 			return err
 		}

--- a/kubernetes/resource_kubernetes_stateful_set.go
+++ b/kubernetes/resource_kubernetes_stateful_set.go
@@ -49,7 +49,7 @@ func resourceKubernetesStatefulSetCreate(d *schema.ResourceData, meta interface{
 	}
 	statefulSet := api.StatefulSet{
 		ObjectMeta: metadata,
-		Spec:       spec,
+		Spec:       *spec,
 	}
 	log.Printf("[INFO] Creating new StatefulSet: %#v", statefulSet)
 

--- a/kubernetes/structure_horizontal_pod_autoscaler.go
+++ b/kubernetes/structure_horizontal_pod_autoscaler.go
@@ -1,15 +1,17 @@
 package kubernetes
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	api "k8s.io/api/autoscaling/v1"
 )
 
-func expandHorizontalPodAutoscalerSpec(in []interface{}) api.HorizontalPodAutoscalerSpec {
+func expandHorizontalPodAutoscalerSpec(in []interface{}) (*api.HorizontalPodAutoscalerSpec, error) {
+	spec := &api.HorizontalPodAutoscalerSpec{}
 	if len(in) == 0 || in[0] == nil {
-		return api.HorizontalPodAutoscalerSpec{}
+		return nil, fmt.Errorf("failed to expand HorizontalPodAutoscaler.Spec: null or empty input")
 	}
-	spec := api.HorizontalPodAutoscalerSpec{}
 	m := in[0].(map[string]interface{})
 	if v, ok := m["max_replicas"]; ok {
 		spec.MaxReplicas = int32(v.(int))
@@ -24,7 +26,7 @@ func expandHorizontalPodAutoscalerSpec(in []interface{}) api.HorizontalPodAutosc
 		spec.TargetCPUUtilizationPercentage = ptrToInt32(int32(v))
 	}
 
-	return spec
+	return spec, nil
 }
 
 func expandCrossVersionObjectReference(in []interface{}) api.CrossVersionObjectReference {

--- a/kubernetes/structure_persistent_volume_claim.go
+++ b/kubernetes/structure_persistent_volume_claim.go
@@ -39,8 +39,8 @@ func flattenResourceRequirements(in v1.ResourceRequirements) []interface{} {
 
 // Expanders
 
-func expandPersistenVolumeClaim(p map[string]interface{}) (corev1.PersistentVolumeClaim, error) {
-	pvc := corev1.PersistentVolumeClaim{}
+func expandPersistenVolumeClaim(p map[string]interface{}) (*corev1.PersistentVolumeClaim, error) {
+	pvc := &corev1.PersistentVolumeClaim{}
 	if len(p) == 0 {
 		return pvc, nil
 	}
@@ -57,23 +57,22 @@ func expandPersistenVolumeClaim(p map[string]interface{}) (corev1.PersistentVolu
 	if err != nil {
 		return pvc, err
 	}
-	pvc.Spec = spec
+	pvc.Spec = *spec
 	return pvc, nil
 }
 
-func expandPersistentVolumeClaimSpec(l []interface{}) (v1.PersistentVolumeClaimSpec, error) {
+func expandPersistentVolumeClaimSpec(l []interface{}) (*v1.PersistentVolumeClaimSpec, error) {
+	obj := &v1.PersistentVolumeClaimSpec{}
 	if len(l) == 0 || l[0] == nil {
-		return v1.PersistentVolumeClaimSpec{}, nil
+		return obj, nil
 	}
 	in := l[0].(map[string]interface{})
 	resourceRequirements, err := expandResourceRequirements(in["resources"].([]interface{}))
 	if err != nil {
-		return v1.PersistentVolumeClaimSpec{}, err
+		return nil, err
 	}
-	obj := v1.PersistentVolumeClaimSpec{
-		AccessModes: expandPersistentVolumeAccessModes(in["access_modes"].(*schema.Set).List()),
-		Resources:   resourceRequirements,
-	}
+	obj.AccessModes = expandPersistentVolumeAccessModes(in["access_modes"].(*schema.Set).List())
+	obj.Resources = *resourceRequirements
 	if v, ok := in["selector"].([]interface{}); ok && len(v) > 0 {
 		obj.Selector = expandLabelSelector(v)
 	}
@@ -86,25 +85,25 @@ func expandPersistentVolumeClaimSpec(l []interface{}) (v1.PersistentVolumeClaimS
 	return obj, nil
 }
 
-func expandResourceRequirements(l []interface{}) (v1.ResourceRequirements, error) {
+func expandResourceRequirements(l []interface{}) (*v1.ResourceRequirements, error) {
+	obj := &v1.ResourceRequirements{}
 	if len(l) == 0 || l[0] == nil {
-		return v1.ResourceRequirements{}, nil
+		return obj, nil
 	}
 	in := l[0].(map[string]interface{})
-	obj := v1.ResourceRequirements{}
 	if v, ok := in["limits"].(map[string]interface{}); ok && len(v) > 0 {
-		var err error
-		obj.Limits, err = expandMapToResourceList(v)
+		rl, err := expandMapToResourceList(v)
 		if err != nil {
 			return obj, err
 		}
+		obj.Limits = *rl
 	}
 	if v, ok := in["requests"].(map[string]interface{}); ok && len(v) > 0 {
-		var err error
-		obj.Requests, err = expandMapToResourceList(v)
+		rq, err := expandMapToResourceList(v)
 		if err != nil {
 			return obj, err
 		}
+		obj.Requests = *rq
 	}
 	return obj, nil
 }

--- a/kubernetes/structure_persistent_volume_spec.go
+++ b/kubernetes/structure_persistent_volume_spec.go
@@ -839,18 +839,18 @@ func expandPersistentVolumeSource(l []interface{}) v1.PersistentVolumeSource {
 	return obj
 }
 
-func expandPersistentVolumeSpec(l []interface{}) (v1.PersistentVolumeSpec, error) {
+func expandPersistentVolumeSpec(l []interface{}) (*v1.PersistentVolumeSpec, error) {
+	obj := &v1.PersistentVolumeSpec{}
 	if len(l) == 0 || l[0] == nil {
-		return v1.PersistentVolumeSpec{}, nil
+		return obj, nil
 	}
 	in := l[0].(map[string]interface{})
-	obj := v1.PersistentVolumeSpec{}
 	if v, ok := in["capacity"].(map[string]interface{}); ok && len(v) > 0 {
-		var err error
-		obj.Capacity, err = expandMapToResourceList(v)
+		c, err := expandMapToResourceList(v)
 		if err != nil {
 			return obj, err
 		}
+		obj.Capacity = *c
 	}
 	if v, ok := in["persistent_volume_source"].([]interface{}); ok && len(v) > 0 {
 		obj.PersistentVolumeSource = expandPersistentVolumeSource(v)

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -184,8 +184,8 @@ func flattenResourceList(l api.ResourceList) map[string]string {
 	return m
 }
 
-func expandMapToResourceList(m map[string]interface{}) (api.ResourceList, error) {
-	out := make(map[api.ResourceName]resource.Quantity)
+func expandMapToResourceList(m map[string]interface{}) (*api.ResourceList, error) {
+	out := make(api.ResourceList)
 	for stringKey, origValue := range m {
 		key := api.ResourceName(stringKey)
 		var value resource.Quantity
@@ -197,15 +197,15 @@ func expandMapToResourceList(m map[string]interface{}) (api.ResourceList, error)
 			var err error
 			value, err = resource.ParseQuantity(v)
 			if err != nil {
-				return out, err
+				return &out, err
 			}
 		} else {
-			return out, fmt.Errorf("Unexpected value type: %#v", origValue)
+			return &out, fmt.Errorf("Unexpected value type: %#v", origValue)
 		}
 
 		out[key] = value
 	}
-	return out, nil
+	return &out, nil
 }
 
 func flattenPersistentVolumeAccessModes(in []api.PersistentVolumeAccessMode) *schema.Set {
@@ -235,8 +235,8 @@ func flattenResourceQuotaSpec(in api.ResourceQuotaSpec) []interface{} {
 	return out
 }
 
-func expandResourceQuotaSpec(s []interface{}) (api.ResourceQuotaSpec, error) {
-	out := api.ResourceQuotaSpec{}
+func expandResourceQuotaSpec(s []interface{}) (*api.ResourceQuotaSpec, error) {
+	out := &api.ResourceQuotaSpec{}
 	if len(s) < 1 {
 		return out, nil
 	}
@@ -247,7 +247,7 @@ func expandResourceQuotaSpec(s []interface{}) (api.ResourceQuotaSpec, error) {
 		if err != nil {
 			return out, err
 		}
-		out.Hard = list
+		out.Hard = *list
 	}
 
 	if v, ok := m["scopes"]; ok {
@@ -310,8 +310,8 @@ func resourceListEquals(x, y api.ResourceList) bool {
 	return true
 }
 
-func expandLimitRangeSpec(s []interface{}, isNew bool) (api.LimitRangeSpec, error) {
-	out := api.LimitRangeSpec{}
+func expandLimitRangeSpec(s []interface{}, isNew bool) (*api.LimitRangeSpec, error) {
+	out := &api.LimitRangeSpec{}
 	if len(s) < 1 || s[0] == nil {
 		return out, nil
 	}
@@ -341,7 +341,7 @@ func expandLimitRangeSpec(s []interface{}, isNew bool) (api.LimitRangeSpec, erro
 					if err != nil {
 						return out, err
 					}
-					lrItem.DefaultRequest = el
+					lrItem.DefaultRequest = *el
 				}
 			}
 
@@ -350,28 +350,28 @@ func expandLimitRangeSpec(s []interface{}, isNew bool) (api.LimitRangeSpec, erro
 				if err != nil {
 					return out, err
 				}
-				lrItem.Default = el
+				lrItem.Default = *el
 			}
 			if v, ok := limit["max"]; ok {
 				el, err := expandMapToResourceList(v.(map[string]interface{}))
 				if err != nil {
 					return out, err
 				}
-				lrItem.Max = el
+				lrItem.Max = *el
 			}
 			if v, ok := limit["max_limit_request_ratio"]; ok {
 				el, err := expandMapToResourceList(v.(map[string]interface{}))
 				if err != nil {
 					return out, err
 				}
-				lrItem.MaxLimitRequestRatio = el
+				lrItem.MaxLimitRequestRatio = *el
 			}
 			if v, ok := limit["min"]; ok {
 				el, err := expandMapToResourceList(v.(map[string]interface{}))
 				if err != nil {
 					return out, err
 				}
-				lrItem.Min = el
+				lrItem.Min = *el
 			}
 
 			newLimits[i] = lrItem

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -773,6 +773,7 @@ func expandContainerPort(in []interface{}) ([]*v1.ContainerPort, error) {
 	}
 	for i, c := range in {
 		p := c.(map[string]interface{})
+		ports[i] = &v1.ContainerPort{}
 		if containerPort, ok := p["container_port"]; ok {
 			ports[i].ContainerPort = int32(containerPort.(int))
 		}

--- a/kubernetes/structures_deployment.go
+++ b/kubernetes/structures_deployment.go
@@ -38,8 +38,8 @@ func flattenDeploymentSpec(in appsv1.DeploymentSpec) ([]interface{}, error) {
 	return []interface{}{att}, nil
 }
 
-func expandDeploymentSpec(deployment []interface{}) (appsv1.DeploymentSpec, error) {
-	obj := appsv1.DeploymentSpec{}
+func expandDeploymentSpec(deployment []interface{}) (*appsv1.DeploymentSpec, error) {
+	obj := &appsv1.DeploymentSpec{}
 
 	if len(deployment) == 0 || deployment[0] == nil {
 		return obj, nil
@@ -65,13 +65,13 @@ func expandDeploymentSpec(deployment []interface{}) (appsv1.DeploymentSpec, erro
 	if err != nil {
 		return obj, err
 	}
-	obj.Template = template
+	obj.Template = *template
 
 	return obj, nil
 }
 
-func expandPodTemplate(l []interface{}) (corev1.PodTemplateSpec, error) {
-	obj := corev1.PodTemplateSpec{}
+func expandPodTemplate(l []interface{}) (*corev1.PodTemplateSpec, error) {
+	obj := &corev1.PodTemplateSpec{}
 	if len(l) == 0 || l[0] == nil {
 		return obj, nil
 	}
@@ -84,7 +84,7 @@ func expandPodTemplate(l []interface{}) (corev1.PodTemplateSpec, error) {
 		if err != nil {
 			return obj, err
 		}
-		obj.Spec = podSpec
+		obj.Spec = *podSpec
 	}
 	return obj, nil
 }

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -313,8 +313,8 @@ func flattenSecretVolumeSource(in *v1.SecretVolumeSource) []interface{} {
 
 // Expanders
 
-func expandPodSpec(p []interface{}) (v1.PodSpec, error) {
-	obj := v1.PodSpec{}
+func expandPodSpec(p []interface{}) (*v1.PodSpec, error) {
+	obj := &v1.PodSpec{}
 	if len(p) == 0 || p[0] == nil {
 		return obj, nil
 	}

--- a/kubernetes/structures_replication_controller.go
+++ b/kubernetes/structures_replication_controller.go
@@ -23,8 +23,8 @@ func flattenReplicationControllerSpec(in v1.ReplicationControllerSpec) ([]interf
 	return []interface{}{att}, nil
 }
 
-func expandReplicationControllerSpec(rc []interface{}) (v1.ReplicationControllerSpec, error) {
-	obj := v1.ReplicationControllerSpec{}
+func expandReplicationControllerSpec(rc []interface{}) (*v1.ReplicationControllerSpec, error) {
+	obj := &v1.ReplicationControllerSpec{}
 	if len(rc) == 0 || rc[0] == nil {
 		return obj, nil
 	}
@@ -40,7 +40,7 @@ func expandReplicationControllerSpec(rc []interface{}) (v1.ReplicationController
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: obj.Selector,
 		},
-		Spec: podSpec,
+		Spec: *podSpec,
 	}
 
 	return obj, nil

--- a/kubernetes/structures_stateful_set.go
+++ b/kubernetes/structures_stateful_set.go
@@ -13,8 +13,8 @@ import (
 
 // Expanders
 
-func expandStatefulSetSpec(s []interface{}) (v1.StatefulSetSpec, error) {
-	obj := v1.StatefulSetSpec{}
+func expandStatefulSetSpec(s []interface{}) (*v1.StatefulSetSpec, error) {
+	obj := &v1.StatefulSetSpec{}
 	if len(s) == 0 || s[0] == nil {
 		return obj, nil
 	}
@@ -45,14 +45,14 @@ func expandStatefulSetSpec(s []interface{}) (v1.StatefulSetSpec, error) {
 		if err != nil {
 			return obj, err
 		}
-		obj.UpdateStrategy = us
+		obj.UpdateStrategy = *us
 	}
 
 	template, err := expandPodTemplate(in["template"].([]interface{}))
 	if err != nil {
 		return obj, err
 	}
-	obj.Template = template
+	obj.Template = *template
 
 	if v, ok := in["volume_claim_template"].([]interface{}); ok {
 		obj.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{}
@@ -64,13 +64,13 @@ func expandStatefulSetSpec(s []interface{}) (v1.StatefulSetSpec, error) {
 			if err != nil {
 				return obj, err
 			}
-			obj.VolumeClaimTemplates = append(obj.VolumeClaimTemplates, p)
+			obj.VolumeClaimTemplates = append(obj.VolumeClaimTemplates, *p)
 		}
 	}
 	return obj, nil
 }
-func expandStatefulSetSpecUpdateStrategy(s []interface{}) (v1.StatefulSetUpdateStrategy, error) {
-	ust := v1.StatefulSetUpdateStrategy{}
+func expandStatefulSetSpecUpdateStrategy(s []interface{}) (*v1.StatefulSetUpdateStrategy, error) {
+	ust := &v1.StatefulSetUpdateStrategy{}
 	if len(s) == 0 {
 		return ust, nil
 	}
@@ -104,8 +104,8 @@ func expandStatefulSetSpecUpdateStrategy(s []interface{}) (v1.StatefulSetUpdateS
 	return ust, nil
 }
 
-func expandStatefulSetSelectors(s []interface{}) (metav1.LabelSelector, error) {
-	obj := metav1.LabelSelector{}
+func expandStatefulSetSelectors(s []interface{}) (*metav1.LabelSelector, error) {
+	obj := &metav1.LabelSelector{}
 	if len(s) == 0 || s[0] == nil {
 		return obj, nil
 	}


### PR DESCRIPTION
This change aligns expander functions to return pointers to complex types rather than values.

This is a pattern most providers try to adhere to as it helps with detecting malformed data earlier, through exercising the tests and seeing potential panics.

* [x] convert returned values to pointers
* [x] exercise all tests and inspect issues

@terraform-providers/ecosystem 
@tombuildsstuff 