### PR TITLE
Expose 'wait_until_bound' only on stand-alone PVCs

### DIFF
--- a/kubernetes/resource_kubernetes_persistent_volume_claim.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim.go
@@ -15,6 +15,15 @@ import (
 )
 
 func resourceKubernetesPersistentVolumeClaim() *schema.Resource {
+	fields := persistentVolumeClaimFields()
+	// The 'wait_until_bound' control attribute only makes sense in stand-alone PVCs,
+	// so adding it on top of the standard PVC fields which are re-usable for other resources.
+	fields["wait_until_bound"] = &schema.Schema{
+		Type:        schema.TypeBool,
+		Description: "Whether to wait for the claim to reach `Bound` state (to find volume in which to claim the space)",
+		Optional:    true,
+		Default:     true,
+	}
 	return &schema.Resource{
 		Create: resourceKubernetesPersistentVolumeClaimCreate,
 		Read:   resourceKubernetesPersistentVolumeClaimRead,
@@ -32,7 +41,7 @@ func resourceKubernetesPersistentVolumeClaim() *schema.Resource {
 			Create: schema.DefaultTimeout(5 * time.Minute),
 		},
 
-		Schema: persistentVolumeClaimFields(),
+		Schema: fields,
 	}
 }
 

--- a/kubernetes/schema_persistent_volume_claim.go
+++ b/kubernetes/schema_persistent_volume_claim.go
@@ -18,12 +18,6 @@ func persistentVolumeClaimFields() map[string]*schema.Schema {
 				Schema: persistentVolumeClaimSpecFields(),
 			},
 		},
-		"wait_until_bound": {
-			Type:        schema.TypeBool,
-			Description: "Whether to wait for the claim to reach `Bound` state (to find volume in which to claim the space)",
-			Optional:    true,
-			Default:     true,
-		},
 	}
 }
 


### PR DESCRIPTION
This fixes a recently introduced regression which caused StatefulSet acceptance tests to fail.

With StatefulSets, PVC schema fields were refactored to be re-used in both stand-alone PVCs and as part of StatefulSet objects.
In doing this, the 'wait_until_bound' attribute is being included in the StatefulSet schema. However, since it is just a control attribute for use by Terraform internally, it has no meaning embedded in a StatefulSet.

This change fixes the PVC embedding issue by only including `wait_until_bound` in stand-alone PVCs.

@terraform-providers/ecosystem 
