### PR TITLE
Add a resource to allow management of the system created kube-system namespace

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -113,6 +113,7 @@ func Provider() terraform.ResourceProvider {
 			"kubernetes_config_map":                resourceKubernetesConfigMap(),
 			"kubernetes_deployment":                resourceKubernetesDeployment(),
 			"kubernetes_horizontal_pod_autoscaler": resourceKubernetesHorizontalPodAutoscaler(),
+			"kubernetes_kubesystem_namespace":      resourceKubernetesKubeSystemNamespace(),
 			"kubernetes_limit_range":               resourceKubernetesLimitRange(),
 			"kubernetes_namespace":                 resourceKubernetesNamespace(),
 			"kubernetes_persistent_volume":         resourceKubernetesPersistentVolume(),

--- a/kubernetes/resource_kubernetes_kubesystem_namespace.go
+++ b/kubernetes/resource_kubernetes_kubesystem_namespace.go
@@ -1,0 +1,52 @@
+package kubernetes
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func resourceKubernetesKubeSystemNamespace() *schema.Resource {
+	// reuse kubernetes_namespace schema, and methods for READ, UPDATE
+	kubeSystemNamespace := resourceKubernetesNamespace()
+	kubeSystemNamespace.Create = resourceKubernetesKubeSystemNamespaceCreate
+	kubeSystemNamespace.Delete = resourceKubernetesKubeSystemNamespaceDelete
+
+	// cidr_block is a computed value for Default VPCs
+	kubeSystemNamespace.Schema["cidr_block"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
+	// instance_tenancy is a computed value for Default VPCs
+	kubeSystemNamespace.Schema["instance_tenancy"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
+	// assign_generated_ipv6_cidr_block is a computed value for Default VPCs
+	kubeSystemNamespace.Schema["assign_generated_ipv6_cidr_block"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Computed: true,
+	}
+
+	return kubeSystemNamespace
+}
+
+func resourceKubernetesKubeSystemNamespaceCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*kubernetes.Clientset)
+
+	namespace, err := conn.CoreV1().Namespaces().Get("kube-system", meta_v1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(namespace.Name)
+
+	return resourceKubernetesNamespaceUpdate(d, meta)
+}
+
+func resourceKubernetesKubeSystemNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy the kube-system namespace. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}

--- a/kubernetes/resource_kubernetes_kubesystem_namespace_test.go
+++ b/kubernetes/resource_kubernetes_kubesystem_namespace_test.go
@@ -1,0 +1,86 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	api "k8s.io/api/core/v1"
+)
+
+func TestAccKubernetesKubeSystemNamespace_basic(t *testing.T) {
+	var conf api.Namespace
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesKubeSystemNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesKubeSystemNamespaceConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKubernetesNamespaceExists("kubernetes_namespace.kube-system", &conf),
+					resource.TestCheckResourceAttr("kubernetes_namespace.kube-system", "metadata.0.annotations.%", "0"),
+					resource.TestCheckResourceAttr("kubernetes_namespace.kube-system", "metadata.0.labels.%", "0"),
+					resource.TestCheckResourceAttr("kubernetes_namespace.kube-system", "metadata.0.name", "kube-system"),
+					resource.TestCheckResourceAttrSet("kubernetes_namespace.kube-system", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_namespace.kube-system", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_namespace.kube-system", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_namespace.kube-system", "metadata.0.uid"),
+				),
+			},
+			{
+				Config: testAccKubernetesKubeSystemNamespaceConfigAnnotations,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesNamespaceExists("kubernetes_namespace.kube-system", &conf),
+					resource.TestCheckResourceAttr("kubernetes_namespace.kube-system", "metadata.0.annotations.%", "2"),
+					resource.TestCheckResourceAttr("kubernetes_namespace.kube-system", "metadata.0.annotations.TestAnnotationOne", "one"),
+					resource.TestCheckResourceAttr("kubernetes_namespace.kube-system", "metadata.0.annotations.TestAnnotationTwo", "two"),
+					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{"TestAnnotationOne": "one", "TestAnnotationTwo": "two"}),
+					resource.TestCheckResourceAttr("kubernetes_namespace.kube-system", "metadata.0.labels.%", "0"),
+					resource.TestCheckResourceAttr("kubernetes_namespace.kube-system", "metadata.0.name", "kube-system"),
+					resource.TestCheckResourceAttrSet("kubernetes_namespace.kube-system", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_namespace.kube-system", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_namespace.kube-system", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_namespace.kube-system", "metadata.0.uid"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckKubernetesKubeSystemNamespaceDestroy(s *terraform.State) error {
+	// We expect the kube-system namespace to still exist
+	return nil
+}
+
+const testAccKubernetesKubeSystemNamespaceConfigBasic = `
+provider "kubernetes" {
+  config_context_auth_info = "ops"
+  config_context_cluster   = "mycluster"
+}
+
+resource "kubernetes_kube_system_namespace" "kube-system" {
+  metadata {
+    name = "kube-system"
+  }
+}
+`
+
+const testAccKubernetesKubeSystemNamespaceConfigAnnotations = `
+provider "kubernetes" {
+  config_context_auth_info = "ops"
+  config_context_cluster   = "mycluster"
+}
+
+resource "kubernetes_kube_system_namespace" "kube-system" {
+  metadata {
+    name = "kube-system"
+  }
+
+  annotations {
+    TestAnnotationOne = "one"
+    TestAnnotationTwo = "two"
+  }
+}
+`

--- a/website/docs/r/kubesystem_namespace.html.markdown
+++ b/website/docs/r/kubesystem_namespace.html.markdown
@@ -1,0 +1,68 @@
+---
+layout: "kubernetes"
+page_title: "Kubernetes: kubernetes_kubesystem_namespace"
+sidebar_current: "docs-kubernetes-resource-kubesystem-namespace"
+description: |-
+  Manage the system generated kube-system Kubernetes namespace.
+---
+
+# kubernetes_kubesystem_namespace
+
+Provides a resource to manage the system generated kube-system namespace.
+Read more about namespaces at [Kubernetes reference](https://kubernetes.io/docs/user-guide/namespaces)
+
+**This is an advanced resource**, and has special caveats to be aware of when
+using it. Please read this document in its entirety before using this resource.
+
+The `kubernetes_kubesystem_namespace` behaves differently from normal resources, in that
+Terraform does not _create_ this resource, but instead "adopts" it
+into management.
+
+## Example Usage
+
+Add an annotation to the kube-system namespace:
+
+```hcl
+resource "kubernetes_kubesystem_namespace" "kube-system" {
+  metadata {
+    name = "kube-system"
+
+    annotations {
+      foo = "bar"
+    }
+  }
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `metadata` - (Required) Standard namespace's [metadata](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#metadata).
+
+## Nested Blocks
+
+### `metadata`
+
+#### Arguments
+
+* `annotations` - (Optional) An unstructured key value map stored with the namespace that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more about [name idempotency](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency).
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) namespaces. May match selectors of replication controllers and services. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `name` - (Optional) Name of the namespace, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+
+#### Attributes
+
+* `generation` - A sequence number representing a specific generation of the desired state.
+* `resource_version` - An opaque value that represents the internal version of this namespace that can be used by clients to determine when namespaces have changed. Read more about [concurrency control and consistency](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#concurrency-control-and-consistency).
+* `self_link` - A URL representing this namespace.
+* `uid` - The unique in time and space value for this namespace. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#uids)
+
+## Import
+
+Namespaces can be imported using their name, e.g.
+
+```
+$ terraform import kubernetes_namespace.kube-system kube-system
+```

--- a/website/kubernetes.erb
+++ b/website/kubernetes.erb
@@ -43,6 +43,9 @@
             <li<%= sidebar_current("docs-kubernetes-resource-horizontal-pod-autoscaler") %>>
               <a href="/docs/providers/kubernetes/r/horizontal_pod_autoscaler.html">kubernetes_horizontal_pod_autoscaler</a>
             </li>
+            <li<%= sidebar_current("docs-kubernetes-kubesystem-namespace") %>>
+              <a href="/docs/providers/kubernetes/r/kubesystem_namespace.html">kubernetes_kubesystem_namespace</a>
+            </li>
             <li<%= sidebar_current("docs-kubernetes-resource-limit-range") %>>
               <a href="/docs/providers/kubernetes/r/limit_range.html">kubernetes_limit_range</a>
             </li>


### PR DESCRIPTION
Allows adding annotations (needed for KIAM) and labels to the system created `kube-system` kubernetes `namespace` object.
I took inspiration from the AWS provider's `aws_default_vpc` resource for this.
