### PR TITLE
add kubernetes_secret datasource

### DIFF
--- a/kubernetes/data_source_kubernetes_secret.go
+++ b/kubernetes/data_source_kubernetes_secret.go
@@ -1,0 +1,37 @@
+package kubernetes
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func dataSourceKubernetesSecret() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceKubernetesSecretRead,
+
+		Schema: map[string]*schema.Schema{
+			"metadata": namespacedMetadataSchema("secret", false),
+			"data": {
+				Type:        schema.TypeMap,
+				Description: "A map of the secret data.",
+				Computed:    true,
+				Sensitive:   true,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Description: "Type of secret",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceKubernetesSecretRead(d *schema.ResourceData, meta interface{}) error {
+	om := meta_v1.ObjectMeta{
+		Namespace: d.Get("metadata.0.namespace").(string),
+		Name:      d.Get("metadata.0.name").(string),
+	}
+	d.SetId(buildId(om))
+
+	return resourceKubernetesSecretRead(d, meta)
+}

--- a/kubernetes/data_source_kubernetes_secret_test.go
+++ b/kubernetes/data_source_kubernetes_secret_test.go
@@ -1,0 +1,50 @@
+package kubernetes
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccKubernetesDataSourceSecret_basic(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesDataSourceSecretConfig_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("data.kubernetes_secret.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_secret.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_secret.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_secret.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "metadata.0.annotations.%", "2"),
+					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "metadata.0.annotations.TestAnnotationOne", "one"),
+					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "metadata.0.annotations.TestAnnotationTwo", "two"),
+					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "metadata.0.labels.TestLabelOne", "one"),
+					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "metadata.0.labels.TestLabelTwo", "two"),
+					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "metadata.0.labels.TestLabelThree", "three"),
+					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "data.%", "2"),
+					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "data.one", "first"),
+					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "data.two", "second"),
+					resource.TestCheckResourceAttr("data.kubernetes_secret.test", "type", "Opaque"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKubernetesDataSourceSecretConfig_basic(name string) string {
+	return testAccKubernetesSecretConfig_basic(name) + `
+data "kubernetes_secret" "test" {
+	metadata {
+		name = "${kubernetes_secret.test.metadata.0.name}"
+	}
+}
+`
+}

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -104,6 +104,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"kubernetes_secret":        dataSourceKubernetesSecret(),
 			"kubernetes_service":       dataSourceKubernetesService(),
 			"kubernetes_storage_class": dataSourceKubernetesStorageClass(),
 		},

--- a/website/docs/d/secret.html.markdown
+++ b/website/docs/d/secret.html.markdown
@@ -1,0 +1,54 @@
+---
+layout: "kubernetes"
+page_title: "Kubernetes: kubernetes_secret"
+sidebar_current: "docs-kubernetes-resource-secret"
+description: |-
+  The resource provides mechanisms to inject containers with sensitive information while keeping containers agnostic of Kubernetes.
+---
+
+# kubernetes_secret
+
+The resource provides mechanisms to inject containers with sensitive information, such as passwords, while keeping containers agnostic of Kubernetes.
+Secrets can be used to store sensitive information either as individual properties or coarse-grained entries like entire files or JSON blobs.
+The resource will by default create a secret which is available to any pod in the specified (or default) namespace.
+
+~> Read more about security properties and risks involved with using Kubernetes secrets: [Kubernetes reference](https://kubernetes.io/docs/user-guide/secrets/#security-properties)
+
+~> **Note:** All arguments including the secret data will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
+
+## Example Usage
+
+```hcl
+data "kubernetes_secret" "example" {
+  metadata {
+    name = "basic-auth"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `metadata` - (Required) Standard secret's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#metadata)
+
+## Nested Blocks
+
+### `metadata`
+
+#### Arguments
+
+* `name` - (Required) Name of the secret, must be unique. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+* `namespace` - (Optional) Namespace defines the space within which name of the secret must be unique.
+
+#### Attributes
+
+* `generation` - A sequence number representing a specific generation of the desired state.
+* `resource_version` - An opaque value that represents the internal version of this secret that can be used by clients to determine when secret has changed. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#concurrency-control-and-consistency)
+* `self_link` - A URL representing this secret.
+* `uid` - The unique in time and space value for this secret. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#uids)
+
+## Attribute Reference
+
+* `data` - A map of the secret data.
+* `type` - The secret type. Defaults to `Opaque`. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/c7151dd8dd7e487e96e5ce34c6a416bb3b037609/contributors/design-proposals/auth/secrets.md#proposed-design)


### PR DESCRIPTION
adds data_source_kubernetes_secret

fixes: https://github.com/terraform-providers/terraform-provider-kubernetes/issues/241

example use case:
```
resource "kubernetes_service_account" "example" {
  metadata {
    name = "terraform-example"
  }
}

data "kubernetes_secret" "example" {
  metadata = {
    name      = "${kubernetes_service_account.example.default_secret_name}"
    namespace = "${kubernetes_service_account.example.metadata.0.namespace}"
  }
}

output "token" {
  value = "${lookup(data.kubernetes_secret.example.data, "token", "")}"
}
```