### PR TITLE
Fix Deployment acceptance tests

### DIFF
--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -157,7 +157,7 @@ func TestAccKubernetesDeployment_with_security_context(t *testing.T) {
 	var conf api.Deployment
 
 	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "nginx:1.7.9"
+	imageName := "redis:5.0.2"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -266,7 +266,7 @@ func TestAccKubernetesDeployment_with_container_lifecycle(t *testing.T) {
 	var conf api.Deployment
 
 	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "gcr.io/google_containers/liveness"
+	imageName := "gcr.io/google_containers/busybox"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -297,7 +297,7 @@ func TestAccKubernetesDeployment_with_container_security_context(t *testing.T) {
 	var conf api.Deployment
 
 	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	imageName := "nginx:1.7.9"
+	imageName := "redis:5.0.2"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -944,7 +944,7 @@ resource "kubernetes_deployment" "test" {
         container {
           image = "%s"
           name  = "containername"
-          args  = ["/server"]
+          command = ["sleep", "60"]
 
           lifecycle {
             post_start {


### PR DESCRIPTION
This PR fixes some failing deployment acceptance tests (tested on GKE 1.11.4-gke.8):

```
 make testacc TEST=./kubernetes TESTARGS='-run=TestAccKubernetesDeployment_.* -count=1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./kubernetes -v -run=TestAccKubernetesDeployment_.* -count=1 -timeout 120m
=== RUN   TestAccKubernetesDeployment_basic
--- PASS: TestAccKubernetesDeployment_basic (80.29s)
=== RUN   TestAccKubernetesDeployment_initContainer
--- PASS: TestAccKubernetesDeployment_initContainer (129.77s)
=== RUN   TestAccKubernetesDeployment_importBasic
--- PASS: TestAccKubernetesDeployment_importBasic (129.93s)
=== RUN   TestAccKubernetesDeployment_generatedName
--- PASS: TestAccKubernetesDeployment_generatedName (1.69s)
=== RUN   TestAccKubernetesDeployment_importGeneratedName
--- PASS: TestAccKubernetesDeployment_importGeneratedName (18.11s)
=== RUN   TestAccKubernetesDeployment_with_security_context
--- FAIL: TestAccKubernetesDeployment_with_security_context (600.93s)
        testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:

                * kubernetes_deployment.test: 1 error(s) occurred:

                * kubernetes_deployment.test: Waiting for rollout to finish: 0 of 1 updated replicas are available...
=== RUN   TestAccKubernetesDeployment_with_container_liveness_probe_using_exec
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_exec (3.57s)
=== RUN   TestAccKubernetesDeployment_with_container_liveness_probe_using_http_get
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_http_get (3.54s)
=== RUN   TestAccKubernetesDeployment_with_container_liveness_probe_using_tcp
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_tcp (3.54s)
=== RUN   TestAccKubernetesDeployment_with_container_lifecycle
--- FAIL: TestAccKubernetesDeployment_with_container_lifecycle (600.94s)
        testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:

                * kubernetes_deployment.test: 1 error(s) occurred:

                * kubernetes_deployment.test: Waiting for rollout to finish: 0 of 1 updated replicas are available...
=== RUN   TestAccKubernetesDeployment_with_container_security_context
--- FAIL: TestAccKubernetesDeployment_with_container_security_context (600.97s)
        testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:

                * kubernetes_deployment.test: 1 error(s) occurred:

                * kubernetes_deployment.test: Waiting for rollout to finish: 0 of 1 updated replicas are available...
=== RUN   TestAccKubernetesDeployment_with_volume_mount
--- PASS: TestAccKubernetesDeployment_with_volume_mount (4.70s)
=== RUN   TestAccKubernetesDeployment_with_resource_requirements
--- PASS: TestAccKubernetesDeployment_with_resource_requirements (3.51s)
=== RUN   TestAccKubernetesDeployment_with_empty_dir_volume
--- PASS: TestAccKubernetesDeployment_with_empty_dir_volume (3.51s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-kubernetes/kubernetes 2185.048s
make: *** [GNUmakefile:17: testacc] Error 1
```

The `TestAccKubernetesDeployment_with_security_context` and `TestAccKubernetesDeployment_with_container_security_context` test are timing out with containers in CrashLoopBackOff with the following container logs:

```
2018/12/07 19:00:24 [warn] 1#0: the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:2
nginx: [warn] the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:2
2018/12/07 19:00:24 [emerg] 1#0: mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)
nginx: [emerg] mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)
```

Using nginx images when security contexts define containers to run as non root user is known to cause issues:

- https://github.com/openshift/openshift-docs/pull/10618
- https://medium.com/bitnami-perspectives/non-root-containers-to-show-openshift-some-love-3b32d7218ac6#c258

Work-around: use some other image such as `redis`.

The `TestAccKubernetesDeployment_with_container_lifecycle` test is timing out with containers in CrashLoopBackOff because the `gcr.io/google_containers/liveness` image used in that test only contains the `/server` executable, but no shell, `ls` or `date` executables:

```
# kubectl --context=gke_cloudpublic-sandbox_us-east1_pdecat-terraform-kubernetes-testacc get pod tf-acc-test-nza00o9x1u-dcffd6bf6-jwmx8
NAME                                     READY   STATUS                                                   RESTARTS   AGE
tf-acc-test-nza00o9x1u-dcffd6bf6-jwmx8   0/1     PostStartHookError: command 'ls -al' exited with 126:    5          2m
```

```
# kubectl get event |grep "ls -al"
1m          1m           3       tf-acc-test-nza00o9x1u-dcffd6bf6-jwmx8.156e1e06346f7435          Pod          spec.containers{containername}   Warning   FailedPostStartHook      kubelet, gke-pdecat-terraform-kub-default-pool-318bb3a5-ns08   Exec lifecycle hook ([ls -al]) for Container "containername" in Pod "tf-acc-test-nza00o9x1u-dcffd6bf6-jwmx8_default(e5857cae-fa47-11e8-8ad1-42010a8e0070)" failed - error: command 'ls -al' exited with 126: , message: "rpc error: code = 2 desc = oci runtime error: exec failed: container_linux.go:247: starting container process caused \"exec: \\\"ls\\\": executable file not found in $PATH\"\n\r\n"
```

Work-around: use `gcr.io/google_containers/busybox` image.