### PR TITLE
Add allow_privilege_escalation to container security contexts attributes

### DIFF
--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -1028,8 +1028,9 @@ resource "kubernetes_deployment" "test" {
         }
 
         container {
-          image = "%s"
+          image = "gcr.io/google_containers/liveness"
           name  = "containername2"
+          args  = ["/server"]
 
           security_context {
             allow_privilege_escalation = true
@@ -1053,7 +1054,7 @@ resource "kubernetes_deployment" "test" {
     }
   }
 }
-`, rcName, imageName, imageName)
+`, rcName, imageName)
 }
 
 func testAccKubernetesDeploymentConfigWithVolumeMounts(secretName, rcName, imageName string) string {

--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -168,6 +168,7 @@ func TestAccKubernetesDeployment_with_security_context(t *testing.T) {
 				Config: testAccKubernetesDeploymentConfigWithSecurityContext(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.security_context.0.fs_group", "100"),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.security_context.0.run_as_non_root", "true"),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.security_context.0.run_as_user", "101"),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.security_context.0.supplemental_groups.#", "1"),
@@ -308,7 +309,25 @@ func TestAccKubernetesDeployment_with_container_security_context(t *testing.T) {
 				Config: testAccKubernetesDeploymentConfigWithContainerSecurityContext(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.#", "2"),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.security_context.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.security_context.0.capabilities.#", "0"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.security_context.0.privileged", "true"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.security_context.0.se_linux_options.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.0.security_context.0.se_linux_options.0.level", "s0:c123,c456"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.1.security_context.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.1.security_context.0.allow_privilege_escalation", "true"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.1.security_context.0.capabilities.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.1.security_context.0.capabilities.0.add.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.1.security_context.0.capabilities.0.add.0", "NET_BIND_SERVICE"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.1.security_context.0.capabilities.0.drop.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.1.security_context.0.capabilities.0.drop.0", "all"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.1.security_context.0.privileged", "true"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.1.security_context.0.read_only_root_filesystem", "true"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.1.security_context.0.run_as_non_root", "true"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.1.security_context.0.run_as_user", "201"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.1.security_context.0.se_linux_options.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.container.1.security_context.0.se_linux_options.0.level", "s0:c123,c789"),
 				),
 			},
 		},
@@ -752,6 +771,7 @@ resource "kubernetes_deployment" "test" {
 
       spec {
         security_context {
+          fs_group            = 100
           run_as_non_root     = true
           run_as_user         = 101
           supplemental_groups = [101]
@@ -1006,11 +1026,34 @@ resource "kubernetes_deployment" "test" {
             }
           }
         }
+
+        container {
+          image = "%s"
+          name  = "containername2"
+
+          security_context {
+            allow_privilege_escalation = true
+
+            capabilities {
+              drop = ["all"]
+              add = ["NET_BIND_SERVICE"]
+            }
+
+            privileged                = true
+            read_only_root_filesystem = true
+            run_as_non_root           = true
+            run_as_user               = 201
+
+            se_linux_options {
+              level = "s0:c123,c789"
+            }
+          }
+        }
       }
     }
   }
 }
-`, rcName, imageName)
+`, rcName, imageName, imageName)
 }
 
 func testAccKubernetesDeploymentConfigWithVolumeMounts(secretName, rcName, imageName string) string {

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -268,6 +268,7 @@ func TestAccKubernetesPod_with_pod_security_context(t *testing.T) {
 				Config: testAccKubernetesPodConfigWithSecurityContext(podName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.security_context.0.fs_group", "100"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.security_context.0.run_as_non_root", "true"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.security_context.0.run_as_user", "101"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.security_context.0.supplemental_groups.#", "1"),
@@ -822,6 +823,7 @@ resource "kubernetes_pod" "test" {
 
   spec {
     security_context {
+      fs_group            = 100
       run_as_non_root     = true
       run_as_user         = 101
       supplemental_groups = [101]

--- a/kubernetes/resource_kubernetes_replication_controller_test.go
+++ b/kubernetes/resource_kubernetes_replication_controller_test.go
@@ -187,6 +187,7 @@ func TestAccKubernetesReplicationController_with_security_context(t *testing.T) 
 				Config: testAccKubernetesReplicationControllerConfigWithSecurityContext(rcName, imageName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesReplicationControllerExists("kubernetes_replication_controller.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.security_context.0.fs_group", "100"),
 					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.security_context.0.run_as_non_root", "true"),
 					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.security_context.0.run_as_user", "101"),
 					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.security_context.0.supplemental_groups.#", "1"),
@@ -651,6 +652,7 @@ resource "kubernetes_replication_controller" "test" {
 
     template {
       security_context {
+        fs_group            = 100
         run_as_non_root     = true
         run_as_user         = 101
         supplemental_groups = [101]

--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -587,36 +587,11 @@ func probeSchema() *schema.Resource {
 
 func securityContextSchema() *schema.Resource {
 	m := map[string]*schema.Schema{
-		"privileged": {
+		"allow_privilege_escalation": {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     false,
-			Description: `Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host.`,
-		},
-		"read_only_root_filesystem": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: "Whether this container has a read-only root filesystem.",
-		},
-		"run_as_non_root": {
-			Type:        schema.TypeBool,
-			Description: "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.",
-			Optional:    true,
-		},
-		"run_as_user": {
-			Type:        schema.TypeInt,
-			Description: "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified",
-			Optional:    true,
-		},
-		"se_linux_options": {
-			Type:        schema.TypeList,
-			Description: "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod",
-			Optional:    true,
-			MaxItems:    1,
-			Elem: &schema.Resource{
-				Schema: seLinuxOptionsField(),
-			},
+			Description: `AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN`,
 		},
 		"capabilities": {
 			Type:        schema.TypeList,
@@ -638,6 +613,37 @@ func securityContextSchema() *schema.Resource {
 						Description: "Removed capabilities",
 					},
 				},
+			},
+		},
+		"privileged": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: `Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.`,
+		},
+		"read_only_root_filesystem": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Whether this container has a read-only root filesystem. Default is false.",
+		},
+		"run_as_non_root": {
+			Type:        schema.TypeBool,
+			Description: "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+			Optional:    true,
+		},
+		"run_as_user": {
+			Type:        schema.TypeInt,
+			Description: "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+			Optional:    true,
+		},
+		"se_linux_options": {
+			Type:        schema.TypeList,
+			Description: "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+			Optional:    true,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: seLinuxOptionsField(),
 			},
 		},
 	}

--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -590,7 +590,7 @@ func securityContextSchema() *schema.Resource {
 		"allow_privilege_escalation": {
 			Type:        schema.TypeBool,
 			Optional:    true,
-			Default:     false,
+			Default:     true,
 			Description: `AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN`,
 		},
 		"capabilities": {

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -107,21 +107,13 @@ func podSpecFields(isUpdatable bool) map[string]*schema.Schema {
 					},
 					"run_as_non_root": {
 						Type:        schema.TypeBool,
-						Description: "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.",
+						Description: "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
 						Optional:    true,
 					},
 					"run_as_user": {
 						Type:        schema.TypeInt,
-						Description: "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified",
+						Description: "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
 						Optional:    true,
-					},
-					"supplemental_groups": {
-						Type:        schema.TypeSet,
-						Description: "A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.",
-						Optional:    true,
-						Elem: &schema.Schema{
-							Type: schema.TypeInt,
-						},
 					},
 					"se_linux_options": {
 						Type:        schema.TypeList,
@@ -130,6 +122,14 @@ func podSpecFields(isUpdatable bool) map[string]*schema.Schema {
 						MaxItems:    1,
 						Elem: &schema.Resource{
 							Schema: seLinuxOptionsField(),
+						},
+					},
+					"supplemental_groups": {
+						Type:        schema.TypeSet,
+						Description: "A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.",
+						Optional:    true,
+						Elem: &schema.Schema{
+							Type: schema.TypeInt,
 						},
 					},
 				},

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -18,25 +18,26 @@ func flattenCapability(in []v1.Capability) []string {
 func flattenContainerSecurityContext(in *v1.SecurityContext) []interface{} {
 	att := make(map[string]interface{})
 
+	if in.AllowPrivilegeEscalation != nil {
+		att["allow_privilege_escalation"] = *in.AllowPrivilegeEscalation
+	}
+	if in.Capabilities != nil {
+		att["capabilities"] = flattenSecurityCapabilities(in.Capabilities)
+	}
 	if in.Privileged != nil {
 		att["privileged"] = *in.Privileged
 	}
 	if in.ReadOnlyRootFilesystem != nil {
 		att["read_only_root_filesystem"] = *in.ReadOnlyRootFilesystem
 	}
-
 	if in.RunAsNonRoot != nil {
 		att["run_as_non_root"] = *in.RunAsNonRoot
 	}
 	if in.RunAsUser != nil {
 		att["run_as_user"] = *in.RunAsUser
 	}
-
 	if in.SELinuxOptions != nil {
 		att["se_linux_options"] = flattenSeLinuxOptions(in.SELinuxOptions)
-	}
-	if in.Capabilities != nil {
-		att["capabilities"] = flattenSecurityCapabilities(in.Capabilities)
 	}
 	return []interface{}{att}
 
@@ -541,6 +542,12 @@ func expandContainerSecurityContext(l []interface{}) *v1.SecurityContext {
 	}
 	in := l[0].(map[string]interface{})
 	obj := v1.SecurityContext{}
+	if v, ok := in["allow_privilege_escalation"]; ok {
+		obj.AllowPrivilegeEscalation = ptrToBool(v.(bool))
+	}
+	if v, ok := in["capabilities"].([]interface{}); ok && len(v) > 0 {
+		obj.Capabilities = expandSecurityCapabilities(v)
+	}
 	if v, ok := in["privileged"]; ok {
 		obj.Privileged = ptrToBool(v.(bool))
 	}
@@ -555,9 +562,6 @@ func expandContainerSecurityContext(l []interface{}) *v1.SecurityContext {
 	}
 	if v, ok := in["se_linux_options"].([]interface{}); ok && len(v) > 0 {
 		obj.SELinuxOptions = expandSeLinuxOptions(v)
-	}
-	if v, ok := in["capabilities"].([]interface{}); ok && len(v) > 0 {
-		obj.Capabilities = expandSecurityCapabilities(v)
 	}
 
 	return &obj

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -74,18 +74,16 @@ func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
 
 func flattenPodSecurityContext(in *v1.PodSecurityContext) []interface{} {
 	att := make(map[string]interface{})
+
 	if in.FSGroup != nil {
 		att["fs_group"] = *in.FSGroup
 	}
-
 	if in.RunAsNonRoot != nil {
 		att["run_as_non_root"] = *in.RunAsNonRoot
 	}
-
 	if in.RunAsUser != nil {
 		att["run_as_user"] = *in.RunAsUser
 	}
-
 	if len(in.SupplementalGroups) > 0 {
 		att["supplemental_groups"] = newInt64Set(schema.HashSchema(&schema.Schema{
 			Type: schema.TypeInt,
@@ -424,12 +422,11 @@ func expandPodSecurityContext(l []interface{}) *v1.PodSecurityContext {
 	if v, ok := in["run_as_user"].(int); ok {
 		obj.RunAsUser = ptrToInt64(int64(v))
 	}
-	if v, ok := in["supplemental_groups"].(*schema.Set); ok {
-		obj.SupplementalGroups = schemaSetToInt64Array(v)
-	}
-
 	if v, ok := in["se_linux_options"].([]interface{}); ok && len(v) > 0 {
 		obj.SELinuxOptions = expandSeLinuxOptions(v)
+	}
+	if v, ok := in["supplemental_groups"].(*schema.Set); ok {
+		obj.SupplementalGroups = schemaSetToInt64Array(v)
 	}
 
 	return obj

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -558,13 +558,32 @@ The `items` block supports:
 
 * `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 
-### `security_context`
+### container `security_context`
+
+#### Arguments
+
+* `allow_privilege_escalation` - (Optional) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+* `capabilities` - (Optional) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+* `privileged` - (Optional) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+* `read_only_root_filesystem` - (Optional) Whether this container has a read-only root filesystem. Default is false.
+* `run_as_non_root` - (Optional) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+* `run_as_user` - (Optional) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+* `se_linux_options` - (Optional) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+### `capabilities`
+
+#### Arguments
+
+* `add` - (Optional) A list of added capabilities.
+* `drop` - (Optional) A list of removed capabilities.
+
+### pod `security_context`
 
 #### Arguments
 
 * `fs_group` - (Optional) A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- If unset, the Kubelet will not modify the ownership and permissions of any volume.
-* `run_as_non_root` - (Optional) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.
-* `run_as_user` - (Optional) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified
+* `run_as_non_root` - (Optional) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+* `run_as_user` - (Optional) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
 * `se_linux_options` - (Optional) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
 * `supplemental_groups` - (Optional) A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.
 

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -501,13 +501,32 @@ The `items` block supports the following:
 
 * `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 
-### `security_context`
+### container `security_context`
+
+#### Arguments
+
+* `allow_privilege_escalation` - (Optional) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+* `capabilities` - (Optional) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+* `privileged` - (Optional) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+* `read_only_root_filesystem` - (Optional) Whether this container has a read-only root filesystem. Default is false.
+* `run_as_non_root` - (Optional) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+* `run_as_user` - (Optional) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+* `se_linux_options` - (Optional) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+### `capabilities`
+
+#### Arguments
+
+* `add` - (Optional) A list of added capabilities.
+* `drop` - (Optional) A list of removed capabilities.
+
+### pod `security_context`
 
 #### Arguments
 
 * `fs_group` - (Optional) A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- If unset, the Kubelet will not modify the ownership and permissions of any volume.
-* `run_as_non_root` - (Optional) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.
-* `run_as_user` - (Optional) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified
+* `run_as_non_root` - (Optional) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+* `run_as_user` - (Optional) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
 * `se_linux_options` - (Optional) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
 * `supplemental_groups` - (Optional) A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.
 

--- a/website/docs/r/replication_controller.html.markdown
+++ b/website/docs/r/replication_controller.html.markdown
@@ -520,13 +520,32 @@ The `items` block supports:
 
 * `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 
-### `security_context`
+### container `security_context`
+
+#### Arguments
+
+* `allow_privilege_escalation` - (Optional) AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+* `capabilities` - (Optional) The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+* `privileged` - (Optional) Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+* `read_only_root_filesystem` - (Optional) Whether this container has a read-only root filesystem. Default is false.
+* `run_as_non_root` - (Optional) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+* `run_as_user` - (Optional) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+* `se_linux_options` - (Optional) The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+
+### `capabilities`
+
+#### Arguments
+
+* `add` - (Optional) A list of added capabilities.
+* `drop` - (Optional) A list of removed capabilities.
+
+### pod `security_context`
 
 #### Arguments
 
 * `fs_group` - (Optional) A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- If unset, the Kubelet will not modify the ownership and permissions of any volume.
-* `run_as_non_root` - (Optional) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.
-* `run_as_user` - (Optional) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified
+* `run_as_non_root` - (Optional) Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+* `run_as_user` - (Optional) The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
 * `se_linux_options` - (Optional) The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container. May also be set in SecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
 * `supplemental_groups` - (Optional) A list of groups applied to the first process run in each container, in addition to the container's primary GID. If unspecified, no groups will be added to any container.
 


### PR DESCRIPTION
This adds the following attributes to container security context:

- `allow_privilege_escalation`
- ~`run_as_group`~ (alpha since 1.10)

And those to pod security context:

- ~`run_as_group`~ (alpha since 1.10)

Re-ordered fields alphabetically to match reference docs:

- Container SecurityContext: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#securitycontext-v1-core
- Pod SecurityContext: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#podsecuritycontext-v1-core

Added the completely missing Container SecurityContext docs.

Note: this is based on https://github.com/terraform-providers/terraform-provider-kubernetes/pull/248 to fix `Deployment` acceptance tests before any code changes.

TODO:

- [x] rebase once #248 is merged
- [x] make acceptance tests pass

Resolves #247 