### PR TITLE
add missing automount_service_account_token to the pod spec

### DIFF
--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -194,8 +194,6 @@ func resourceKubernetesDeploymentCreate(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	spec.Template.Spec.AutomountServiceAccountToken = ptrToBool(false)
-
 	deployment := appsv1.Deployment{
 		ObjectMeta: metadata,
 		Spec:       *spec,

--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -53,8 +53,6 @@ func resourceKubernetesPodCreate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	spec.AutomountServiceAccountToken = ptrToBool(false)
-
 	pod := api.Pod{
 		ObjectMeta: metadata,
 		Spec:       *spec,

--- a/kubernetes/resource_kubernetes_replication_controller.go
+++ b/kubernetes/resource_kubernetes_replication_controller.go
@@ -82,8 +82,6 @@ func resourceKubernetesReplicationControllerCreate(d *schema.ResourceData, meta 
 		return err
 	}
 
-	spec.Template.Spec.AutomountServiceAccountToken = ptrToBool(false)
-
 	rc := api.ReplicationController{
 		ObjectMeta: metadata,
 		Spec:       *spec,

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -12,6 +12,12 @@ func podSpecFields(isUpdatable bool) map[string]*schema.Schema {
 			ValidateFunc: validatePositiveInteger,
 			Description:  "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
 		},
+		"automount_service_account_token": {
+			Type: schema.TypeBool,
+			Optional: true,
+			Default: false,
+			Description: "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.",
+		},
 		"container": {
 			Type:        schema.TypeList,
 			Optional:    true,

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -15,6 +15,8 @@ func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
 		att["active_deadline_seconds"] = *in.ActiveDeadlineSeconds
 	}
 
+	att["automount_service_account_token"] = in.AutomountServiceAccountToken
+
 	containers, err := flattenContainers(in.Containers)
 	if err != nil {
 		return nil, err
@@ -322,6 +324,10 @@ func expandPodSpec(p []interface{}) (*v1.PodSpec, error) {
 
 	if v, ok := in["active_deadline_seconds"].(int); ok && v > 0 {
 		obj.ActiveDeadlineSeconds = ptrToInt64(int64(v))
+	}
+
+	if v, ok := in["automount_service_account_token"]; ok {
+		obj.AutomountServiceAccountToken = ptrToBool(v.(bool))
 	}
 
 	if v, ok := in["container"].([]interface{}); ok && len(v) > 0 {


### PR DESCRIPTION
This change propagates to the replication_controller, services and
deployments.

See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#pod-v1-core