### PR TITLE
Fix updates of stateful set images

### DIFF
--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -701,7 +701,6 @@ func patchPodSpec(pathPrefix, prefix string, d *schema.ResourceData) (PatchOpera
 	ops := make([]PatchOperation, 0)
 
 	if d.HasChange(prefix + "active_deadline_seconds") {
-
 		v := d.Get(prefix + "active_deadline_seconds").(int)
 		ops = append(ops, &ReplaceOperation{
 			Path:  pathPrefix + "/activeDeadlineSeconds",

--- a/kubernetes/structures_stateful_set.go
+++ b/kubernetes/structures_stateful_set.go
@@ -267,7 +267,7 @@ func patchPodTemplateSpec(keyPrefix, pathPrefix string, d *schema.ResourceData) 
 
 	if d.HasChange(keyPrefix + "spec") {
 		log.Printf("[TRACE] StatefulSet.Spec.Template.Spec has changes")
-		p, err := patchPodSpec(pathPrefix+"spec.0.", keyPrefix+"spec/", d)
+		p, err := patchPodSpec(pathPrefix+"spec", keyPrefix+"spec.0.", d)
 		if err != nil {
 			return ops, err
 		}


### PR DESCRIPTION
Images used for container in Stateful Set templates cannot be updated.

TODO:
- [x] add acceptance test
- [x] fix issue

Acceptance test result without fix:
```
# make testacc TEST=./kubernetes TESTARGS='-run=TestAccKubernetesStatefulSet_update_image -count=1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./kubernetes -v -run=TestAccKubernetesStatefulSet_update_image -count=1 -timeout 120m
=== RUN   TestAccKubernetesStatefulSet_update_image
--- FAIL: TestAccKubernetesStatefulSet_update_image (3.01s)
        testing.go:518: Step 1 error: Check failed: 1 error(s) occurred:

                * Check 2/2 error: kubernetes_stateful_set.test: Attribute 'spec.0.template.0.spec.0.container.0.image' expected "k8s.gcr.io/liveness:latest", got "k8s.gcr.io/pause:latest"
FAIL
FAIL    github.com/terraform-providers/terraform-provider-kubernetes/kubernetes 3.059s
make: *** [GNUmakefile:17: testacc] Error 1
```