### PR TITLE
GKE test infra writes kubeconfig file

### DIFF
--- a/kubernetes/test-infra/gke/kubeconfig-template.yaml
+++ b/kubernetes/test-infra/gke/kubeconfig-template.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Config
+preferences:
+  colors: true
+current-context: tf-k8s-gcp-test
+contexts:
+- context:
+    cluster: ${cluster_name}
+    namespace: default
+    user: ${user_name}
+  name: tf-k8s-gcp-test
+clusters:
+- cluster:
+    server: https://${endpoint}
+    certificate-authority-data: ${cluster_ca}
+  name: ${cluster_name}
+users:
+- name: ${user_name}
+  user:
+    password: ${user_password}
+    username: ${user_name}
+    client-certificate-data: ${client_cert}
+    client-key-data: ${client_cert_key}

--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -66,6 +66,14 @@ resource "local_file" "kubeconfig" {
   filename = "${path.module}/kubeconfig"
 }
 
+output "google_zone" {
+  value = "${data.google_compute_zones.available.names[0]}"
+}
+
+output "node_version" {
+  value = "${google_container_cluster.primary.node_version}"
+}
+
 output "kubeconfig_path" {
   value = "${local_file.kubeconfig.filename}"
 }

--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -7,9 +7,11 @@ data "google_compute_zones" "available" {}
 resource "random_id" "cluster_name" {
   byte_length = 10
 }
+
 resource "random_id" "username" {
   byte_length = 14
 }
+
 resource "random_id" "password" {
   byte_length = 16
 }
@@ -18,14 +20,14 @@ resource "random_id" "password" {
 variable "kubernetes_version" {}
 
 resource "google_container_cluster" "primary" {
-  name = "tf-acc-test-${random_id.cluster_name.hex}"
-  zone = "${data.google_compute_zones.available.names[0]}"
+  name               = "tf-acc-test-${random_id.cluster_name.hex}"
+  zone               = "${data.google_compute_zones.available.names[0]}"
   initial_node_count = 3
-  node_version = "${var.kubernetes_version}"
+  node_version       = "${var.kubernetes_version}"
   min_master_version = "${var.kubernetes_version}"
 
   additional_zones = [
-    "${data.google_compute_zones.available.names[1]}"
+    "${data.google_compute_zones.available.names[1]}",
   ]
 
   master_auth {
@@ -35,43 +37,35 @@ resource "google_container_cluster" "primary" {
 
   node_config {
     machine_type = "n1-standard-4"
+
     oauth_scopes = [
       "https://www.googleapis.com/auth/compute",
       "https://www.googleapis.com/auth/devstorage.read_only",
       "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring"
+      "https://www.googleapis.com/auth/monitoring",
     ]
   }
 }
 
-output "google_zone" {
-  value = "${data.google_compute_zones.available.names[0]}"
+data "template_file" "kubeconfig" {
+  template = "${file("kubeconfig-template.yaml")}"
+
+  vars {
+    cluster_name    = "${google_container_cluster.primary.name}"
+    user_name       = "${google_container_cluster.primary.master_auth.0.username}"
+    user_password   = "${google_container_cluster.primary.master_auth.0.password}"
+    endpoint        = "${google_container_cluster.primary.endpoint}"
+    cluster_ca      = "${google_container_cluster.primary.master_auth.0.cluster_ca_certificate}"
+    client_cert     = "${google_container_cluster.primary.master_auth.0.client_certificate}"
+    client_cert_key = "${google_container_cluster.primary.master_auth.0.client_key}"
+  }
 }
 
-output "endpoint" {
-  value = "${google_container_cluster.primary.endpoint}"
+resource "local_file" "kubeconfig" {
+  content  = "${data.template_file.kubeconfig.rendered}"
+  filename = "${path.module}/kubeconfig"
 }
 
-output "username" {
-  value = "${google_container_cluster.primary.master_auth.0.username}"
-}
-
-output "password" {
-  value = "${google_container_cluster.primary.master_auth.0.password}"
-}
-
-output "client_certificate_b64" {
-  value = "${google_container_cluster.primary.master_auth.0.client_certificate}"
-}
-
-output "client_key_b64" {
-  value = "${google_container_cluster.primary.master_auth.0.client_key}"
-}
-
-output "cluster_ca_certificate_b64" {
-  value = "${google_container_cluster.primary.master_auth.0.cluster_ca_certificate}"
-}
-
-output "node_version" {
-  value = "${google_container_cluster.primary.node_version}"
+output "kubeconfig_path" {
+  value = "${local_file.kubeconfig.filename}"
 }


### PR DESCRIPTION
This change allows the template that constructs the GKE test infrastructure to write the cluster access configuration to a kubeconfig file in the local build folder. 

This is to allow the test infrastructure to be easily used for local development and test runs. Exporting the kubeconfig allows it to be easily accessed using `kubectl` as well as other client-go based apps.

Previously, seven different template outputs would be presented to the user and would have to manually be injected into clients.

To use it, set the `KUBECONFIG` environment variable like this:

`export KUBECONFIG="${KUBECONFIG}:$(terraform output kubeconfig_path)"`