### PR TITLE
Support for pod spec dnsConfig

### DIFF
--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -33,7 +33,36 @@ func podSpecFields(isUpdatable bool) map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Default:     "ClusterFirst",
-			Description: "Set DNS policy for containers within the pod. One of 'ClusterFirst' or 'Default'. Defaults to 'ClusterFirst'.",
+			Description: "Set DNS policy for containers within the pod. One of 'ClusterFirst', 'Default', 'ClusterFirstWithHostNet', or 'None'. Defaults to 'ClusterFirst'.",
+		},
+		"dns_config": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "DnsCOnfig holds pod-level DNS settings. Optional: Defaults to empty",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"nameservers": {
+						Type:        schema.TypeList,
+						Description: "A list of IP addresses that will be used as DNS servers for the Pod. There can be at most 3 IP addresses specified. When the Pod’s dnsPolicy is set to “None”, the list must contain at least one IP address, otherwise this property is optional. The servers listed will be combined to the base nameservers generated from the specified DNS policy with duplicate addresses removed.",
+						Optional:    true,
+						MaxItems:    3,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+					},
+					"searches": {
+						Type:        schema.TypeList,
+						Description: "A list of DNS search domains for hostname lookup in the Pod. This property is optional. When specified, the provided list will be merged into the base search domain names generated from the chosen DNS policy. Duplicate domain names are removed. Kubernetes allows for at most 6 search domains.",
+						Optional:    true,
+						MaxItems:    6,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+					},
+					"options": {
+						Type:        schema.TypeMap,
+						Description: "An optional list of objects where each object may have a name property (required) and a value property (optional). The contents in this property will be merged to the options generated from the specified DNS policy. Duplicate entries are removed.",
+						Optional:    true,
+					},
+				},
+			},
 		},
 		"host_ipc": {
 			Type:        schema.TypeBool,

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -39,22 +39,24 @@ func podSpecFields(isUpdatable bool) map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Optional:    true,
 			MaxItems:    1,
-			Description: "DnsCOnfig holds pod-level DNS settings. Optional: Defaults to empty",
+			Description: "DnsConfig holds pod-level DNS settings. Optional: Defaults to empty",
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"nameservers": {
-						Type:        schema.TypeList,
+						Type:        schema.TypeSet,
 						Description: "A list of IP addresses that will be used as DNS servers for the Pod. There can be at most 3 IP addresses specified. When the Pod’s dnsPolicy is set to “None”, the list must contain at least one IP address, otherwise this property is optional. The servers listed will be combined to the base nameservers generated from the specified DNS policy with duplicate addresses removed.",
 						Optional:    true,
 						MaxItems:    3,
 						Elem:        &schema.Schema{Type: schema.TypeString},
+						Set:         schema.HashString,
 					},
 					"searches": {
-						Type:        schema.TypeList,
+						Type:        schema.TypeSet,
 						Description: "A list of DNS search domains for hostname lookup in the Pod. This property is optional. When specified, the provided list will be merged into the base search domain names generated from the chosen DNS policy. Duplicate domain names are removed. Kubernetes allows for at most 6 search domains.",
 						Optional:    true,
 						MaxItems:    6,
 						Elem:        &schema.Schema{Type: schema.TypeString},
+						Set:         schema.HashString,
 					},
 					"options": {
 						Type:        schema.TypeMap,

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -1,11 +1,9 @@
 package kubernetes
 
 import (
-	"strconv"
-	"strings"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"k8s.io/api/core/v1"
+	"strconv"
 )
 
 // Flatteners
@@ -29,7 +27,9 @@ func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
 	att["init_container"] = initContainers
 
 	att["dns_policy"] = in.DNSPolicy
-	att["dns_config"] = flattenPodDnsConfig(in.DNSConfig)
+	if in.DNSConfig != nil {
+		att["dns_config"] = flattenPodDnsConfig(in.DNSConfig)
+	}
 
 	att["host_ipc"] = in.HostIPC
 	att["host_network"] = in.HostNetwork
@@ -78,10 +78,10 @@ func flattenPodDnsConfig(in *v1.PodDNSConfig) []interface{} {
 	att := make(map[string]interface{})
 
 	if len(in.Nameservers) > 0 {
-		att["nameservers"] = strings.Join(in.Nameservers, ",")
+		att["nameservers"] = newStringSet(schema.HashString, in.Nameservers)
 	}
 	if len(in.Searches) > 0 {
-		att["searches"] = strings.Join(in.Searches, ",")
+		att["searches"] = newStringSet(schema.HashString, in.Searches)
 	}
 	if len(in.Options) > 0 {
 		items := make([]interface{}, len(in.Options))
@@ -91,7 +91,7 @@ func flattenPodDnsConfig(in *v1.PodDNSConfig) []interface{} {
 			m["value"] = v.Value
 			items[i] = m
 		}
-		att["nameservers"] = items
+		att["options"] = items
 	}
 
 	if len(att) > 0 {
@@ -370,6 +370,10 @@ func expandPodSpec(p []interface{}) (*v1.PodSpec, error) {
 		obj.DNSPolicy = v1.DNSPolicy(v)
 	}
 
+	if v, ok := in["dns_config"].([]interface{}); ok && len(v) > 0 {
+		obj.DNSConfig = expandPodDnsConfig(v)
+	}
+
 	if v, ok := in["host_ipc"]; ok {
 		obj.HostIPC = v.(bool)
 	}
@@ -433,6 +437,25 @@ func expandPodSpec(p []interface{}) (*v1.PodSpec, error) {
 		obj.Volumes = cs
 	}
 	return obj, nil
+}
+
+func expandPodDnsConfig(l []interface{}) *v1.PodDNSConfig {
+	if len(l) == 0 || l[0] == nil {
+		return &v1.PodDNSConfig{}
+	}
+	in := l[0].(map[string]interface{})
+	obj := &v1.PodDNSConfig{}
+	if v, ok := in["nameservers"].(*schema.Set); ok && v.Len() > 0 {
+		obj.Nameservers = sliceOfString(v.List())
+	}
+	if v, ok := in["searches"].(*schema.Set); ok && v.Len() > 0 {
+		obj.Searches = sliceOfString(v.List())
+	}
+	//TODO: Pretty sure this is incorrect
+	//if v, ok := in["options"]; ok {
+	//	obj.Options = v.([]v1.PodDNSConfigOption)
+	//}
+	return obj
 }
 
 func expandPodSecurityContext(l []interface{}) *v1.PodSecurityContext {

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"k8s.io/api/core/v1"
@@ -28,6 +29,7 @@ func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
 	att["init_container"] = initContainers
 
 	att["dns_policy"] = in.DNSPolicy
+	att["dns_config"] = flattenPodDnsConfig(in.DNSConfig)
 
 	att["host_ipc"] = in.HostIPC
 	att["host_network"] = in.HostNetwork
@@ -70,6 +72,32 @@ func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
 		att["volume"] = v
 	}
 	return []interface{}{att}, nil
+}
+
+func flattenPodDnsConfig(in *v1.PodDNSConfig) []interface{} {
+	att := make(map[string]interface{})
+
+	if len(in.Nameservers) > 0 {
+		att["nameservers"] = strings.Join(in.Nameservers, ",")
+	}
+	if len(in.Searches) > 0 {
+		att["searches"] = strings.Join(in.Searches, ",")
+	}
+	if len(in.Options) > 0 {
+		items := make([]interface{}, len(in.Options))
+		for i, v := range in.Options {
+			m := map[string]interface{}{}
+			m["name"] = v.Name
+			m["value"] = v.Value
+			items[i] = m
+		}
+		att["nameservers"] = items
+	}
+
+	if len(att) > 0 {
+		return []interface{}{att}
+	}
+	return []interface{}{}
 }
 
 func flattenPodSecurityContext(in *v1.PodSecurityContext) []interface{} {


### PR DESCRIPTION
Kubernetes now supports configuring pods DNS settings - information at https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy . I have a particular use case where I need to use the "None" option, which requires that a dnsConfig parameter be added.

The Terraform Kubernetes Provider does not support pod dnsConfig, so I've attempted to add it in this PR. While Terraform seems to see / work with the new fields that I've added, when I deploy to GKE the generated YAML that Google shows me doesn't include dnsConfig. 

Clearly I'm missing something additional that I need to change in the Terraform Kubernetes Provider so that the new schema values actually get deployed. Any thoughts / help would be greatly appreciated. Thank you.