### PR TITLE
Do not set default namespace for replication controller and deployment pod templates

### DIFF
--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -174,7 +174,7 @@ func resourceKubernetesDeployment() *schema.Resource {
 							MaxItems:    1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"metadata": namespacedMetadataSchema("pod", true),
+									"metadata": namespacedMetadataSchemaIsTemplate("pod", true, true),
 									"spec": {
 										Type:        schema.TypeList,
 										Description: "Spec defines the specification of the desired behavior of the deployment. More info: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#deployment-v1-apps",

--- a/kubernetes/resource_kubernetes_replication_controller.go
+++ b/kubernetes/resource_kubernetes_replication_controller.go
@@ -74,7 +74,7 @@ func resourceKubernetesReplicationController() *schema.Resource {
 }
 
 func replicationControllerTemplateFieldSpec() map[string]*schema.Schema {
-	metadata := namespacedMetadataSchema("replication controller's template", true)
+	metadata := namespacedMetadataSchemaIsTemplate("replication controller's template", true, true)
 	// TODO: make this required once the legacy fields are removed
 	metadata.Computed = true
 	metadata.Required = false

--- a/kubernetes/schema_helpers.go
+++ b/kubernetes/schema_helpers.go
@@ -1,0 +1,9 @@
+package kubernetes
+
+func conditionalDefault(condition bool, defaultValue interface{}) interface{} {
+	if !condition {
+		return nil
+	}
+
+	return defaultValue
+}

--- a/kubernetes/schema_metadata.go
+++ b/kubernetes/schema_metadata.go
@@ -80,13 +80,17 @@ func metadataSchema(objectName string, generatableName bool) *schema.Schema {
 }
 
 func namespacedMetadataSchema(objectName string, generatableName bool) *schema.Schema {
+	return namespacedMetadataSchemaIsTemplate(objectName, generatableName, false)
+}
+
+func namespacedMetadataSchemaIsTemplate(objectName string, generatableName, isTemplate bool) *schema.Schema {
 	fields := metadataFields(objectName)
 	fields["namespace"] = &schema.Schema{
 		Type:        schema.TypeString,
 		Description: fmt.Sprintf("Namespace defines the space within which name of the %s must be unique.", objectName),
 		Optional:    true,
 		ForceNew:    true,
-		Default:     "default",
+		Default:     conditionalDefault(!isTemplate, "default"),
 	}
 	if generatableName {
 		fields["generate_name"] = &schema.Schema{

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -58,7 +58,7 @@ func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schem
 			Type:        schema.TypeString,
 			Optional:    true,
 			Computed:    isComputed,
-			Default:     defaultIfNotComputed(isComputed, "ClusterFirst"),
+			Default:     conditionalDefault(!isComputed, "ClusterFirst"),
 			Description: "Set DNS policy for containers within the pod. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'. Optional: Defaults to 'ClusterFirst', see [Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).",
 			Deprecated:  deprecatedMessage,
 		},
@@ -136,7 +136,7 @@ func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schem
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Computed:    isComputed,
-			Default:     defaultIfNotComputed(isComputed, false),
+			Default:     conditionalDefault(!isComputed, false),
 			Description: "Use the host's ipc namespace. Optional: Defaults to false.",
 			Deprecated:  deprecatedMessage,
 		},
@@ -144,7 +144,7 @@ func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schem
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Computed:    isComputed,
-			Default:     defaultIfNotComputed(isComputed, false),
+			Default:     conditionalDefault(!isComputed, false),
 			Description: "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified.",
 			Deprecated:  deprecatedMessage,
 		},
@@ -153,7 +153,7 @@ func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schem
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Computed:    isComputed,
-			Default:     defaultIfNotComputed(isComputed, false),
+			Default:     conditionalDefault(!isComputed, false),
 			Description: "Use the host's pid namespace.",
 			Deprecated:  deprecatedMessage,
 		},
@@ -206,7 +206,7 @@ func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schem
 			Type:        schema.TypeString,
 			Optional:    true,
 			Computed:    isComputed,
-			Default:     defaultIfNotComputed(isComputed, "Always"),
+			Default:     conditionalDefault(!isComputed, "Always"),
 			Description: "Restart policy for all containers within the pod. One of Always, OnFailure, Never. More info: http://kubernetes.io/docs/user-guide/pod-states#restartpolicy.",
 			Deprecated:  deprecatedMessage,
 		},
@@ -283,7 +283,7 @@ func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schem
 			Type:         schema.TypeInt,
 			Optional:     true,
 			Computed:     isComputed,
-			Default:      defaultIfNotComputed(isComputed, 30),
+			Default:      conditionalDefault(!isComputed, 30),
 			ValidateFunc: validateTerminationGracePeriodSeconds,
 			Description:  "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.",
 			Deprecated:   deprecatedMessage,
@@ -352,13 +352,6 @@ func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schem
 	}
 
 	return s
-}
-
-func defaultIfNotComputed(isComputed bool, defaultValue interface{}) interface{} {
-	if isComputed {
-		return nil
-	}
-	return defaultValue
 }
 
 func volumeSchema() *schema.Resource {


### PR DESCRIPTION
Replication controller and deployment pod templates currently have their `namespace` field defaulting to `default`.

This causes issues when importing replication controllers and deployments with the `namespace` field not set on the pod spec. On the next `terraform plan`, a recreation of the controllers is triggered.

This PR changes that.

# Terraform Version

```
# terraform version
Terraform v0.11.11
+ provider.external v1.0.0
+ provider.google v1.20.0
+ provider.google-beta v1.20.0
+ provider.kubernetes v1.5.0
+ provider.template v1.0.0
```

# Affected Resource(s)

- `kubernetes_deployment`
- `kubernetes_replication_controller`

# Plan output

```
[...]
      spec.0.template.0.metadata.0.name:                                                  "" => <computed>                                                                                
      spec.0.template.0.metadata.0.namespace:                                             "" => "default" (forces new resource)                                                           
      spec.0.template.0.metadata.0.resource_version:                                      "" => <computed>                                                                                
[...]
```