### PR TITLE
Correct automount_service_account_token location

### DIFF
--- a/website/docs/r/service_account.html.markdown
+++ b/website/docs/r/service_account.html.markdown
@@ -38,6 +38,7 @@ The following arguments are supported:
 * `metadata` - (Required) Standard service account's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#metadata)
 * `image_pull_secret` - (Optional) A list of references to secrets in the same namespace to use for pulling any images in pods that reference this Service Account. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/secrets#manually-specifying-an-imagepullsecret)
 * `secret` - (Optional) A list of secrets allowed to be used by pods running using this Service Account. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/secrets)
+* `automount_service_account_token` - (Optional) Boolean, `true` to enable automatic mounting of the service account token
 
 ## Nested Blocks
 
@@ -50,7 +51,6 @@ The following arguments are supported:
 * `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the service account. May match selectors of replication controllers and services. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the service account, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the service account must be unique.
-* `automount_service_account_token` - (Optional) Boolean, `true` to enable automatic mounting of the service account token
 
 #### Attributes
 


### PR DESCRIPTION
The `automount_service_account_token` does not belong under the metadata block. It is in-fact in line with metadata. 