### PR TITLE
select default_secret for service account if there is more than one

### DIFF
--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -110,6 +110,7 @@ func resourceKubernetesServiceAccountCreate(d *schema.ResourceData, meta interfa
 		for _, secret := range diff {
 			if strings.Contains(secret.Name, "token") {
 				defaultSecret = secret
+				break
 			}
 		}
 	}

--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -113,6 +113,7 @@ func resourceKubernetesServiceAccountCreate(d *schema.ResourceData, meta interfa
 				break
 			}
 		}
+		log.Printf("[WARN] Expected 1 generated default secret but %d found (%s), selected: %s", len(diff), diff, defaultSecret.Name)
 	}
 
 	d.Set("default_secret_name", defaultSecret.Name)

--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -90,33 +90,38 @@ func resourceKubernetesServiceAccountCreate(d *schema.ResourceData, meta interfa
 
 	// Here we get the only chance to identify and store default secret name
 	// so we can avoid showing it in diff as it's not managed by Terraform
-	var resp *api.ServiceAccount
+	var svcAccTokens []api.Secret
 	err = resource.Retry(30*time.Second, func() *resource.RetryError {
-		var err error
-		resp, err = conn.CoreV1().ServiceAccounts(out.Namespace).Get(out.Name, metav1.GetOptions{})
+		resp, err := conn.CoreV1().ServiceAccounts(out.Namespace).Get(out.Name, metav1.GetOptions{})
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
-		if len(resp.Secrets) > len(svcAcc.Secrets) {
-			return nil
+
+		if len(resp.Secrets) == len(svcAcc.Secrets) {
+			return resource.RetryableError(fmt.Errorf("Waiting for default secret of %q to appear", d.Id()))
 		}
-		return resource.RetryableError(fmt.Errorf("Waiting for default secret of %q to appear", d.Id()))
+
+		diff := diffObjectReferences(svcAcc.Secrets, resp.Secrets)
+		secretList, err := conn.CoreV1().Secrets(out.Namespace).List(metav1.ListOptions{})
+		for _, secret := range secretList.Items {
+			for _, svcSecret := range diff {
+				if secret.Name != svcSecret.Name {
+					break
+				}
+				if secret.Type == api.SecretTypeServiceAccountToken {
+					svcAccTokens = append(svcAccTokens, secret)
+				}
+			}
+		}
+
+		if len(svcAccTokens) > 1 {
+			return resource.NonRetryableError(fmt.Errorf("Expected 1 generated service account token, %d found: %s", len(svcAccTokens), err))
+		}
+
+		return nil
 	})
-
-	diff := diffObjectReferences(svcAcc.Secrets, resp.Secrets)
-	var svcAccTokens []*api.Secret
-	for _, svcSecret := range diff {
-		secret, err := conn.CoreV1().Secrets(out.Namespace).Get(svcSecret.Name, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		if secret.Type == api.SecretTypeServiceAccountToken {
-			svcAccTokens = append(svcAccTokens, secret)
-		}
-	}
-
-	if len(svcAccTokens) != 1 {
-		return fmt.Errorf("Expected 1 generated service account token, %d found: %s", len(svcAccTokens), err)
+	if err != nil {
+		return err
 	}
 
 	d.Set("default_secret_name", svcAccTokens[0].Name)

--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -108,7 +108,7 @@ func resourceKubernetesServiceAccountCreate(d *schema.ResourceData, meta interfa
 	defaultSecret := diff[0]
 	if len(diff) > 1 {
 		for _, secret := range diff {
-			if strings.Contains(secret.Name, "token") {
+			if strings.Contains(secret.Name, "-token-") {
 				defaultSecret = secret
 				break
 			}

--- a/website/docs/r/service_account.html.markdown
+++ b/website/docs/r/service_account.html.markdown
@@ -76,4 +76,4 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
-* `default_secret_name` - Name of the default secret the is created & managed by the service
+* `default_secret_name` - Name of the default secret created & managed by the service. If there is more than one secret, the first with "token" in name is selected or, if none, the first in list.

--- a/website/docs/r/service_account.html.markdown
+++ b/website/docs/r/service_account.html.markdown
@@ -76,4 +76,4 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
-* `default_secret_name` - Name of the default secret created & managed by the service. If there is more than one secret, the first with "token" in name is selected or, if none, the first in list.
+* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service.


### PR DESCRIPTION
Proposal to fix #94 

If there is more than one secret created by default with a service account (ex: openshift), default to the first and override by a secret with "token" in the name if there is any.