### PR TITLE
Alter ClusterRole validation to closer match that of Kubernetes

### DIFF
--- a/kubernetes/resource_kubernetes_cluster_role_test.go
+++ b/kubernetes/resource_kubernetes_cluster_role_test.go
@@ -37,7 +37,7 @@ func TestAccKubernetesClusterRole_basic(t *testing.T) {
 				Config: testAccKubernetesClusterRoleConfig_modified(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesClusterRoleExists("kubernetes_cluster_role.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.#", "3"),
 					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.0.verbs.#", "3"),
 					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.0.verbs.2", "watch"),
 					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.1.api_groups.#", "1"),
@@ -46,6 +46,10 @@ func TestAccKubernetesClusterRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.1.verbs.#", "2"),
 					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.1.verbs.0", "get"),
 					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.1.verbs.1", "list"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.2.non_resource_urls.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.2.non_resource_urls.0", "/metrics"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.2.verbs.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.2.verbs.0", "get"),
 				),
 			},
 		},
@@ -144,6 +148,11 @@ resource "kubernetes_cluster_role" "test" {
     api_groups = [""]
     resources  = ["deployments"]
     verbs      = ["get", "list"]
+  }
+
+  rule {
+    non_resource_urls = ["/metrics"]
+    verbs = ["get"]
   }
 }
 `, name)

--- a/kubernetes/schema_rbac.go
+++ b/kubernetes/schema_rbac.go
@@ -58,7 +58,7 @@ func policyRuleSchema() map[string]*schema.Schema {
 		"api_groups": {
 			Type:        schema.TypeList,
 			Description: "APIGroups is the name of the APIGroup that contains the resources. If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.",
-			Required:    true,
+			Optional:    true,
 			MinItems:    1,
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
@@ -83,7 +83,7 @@ func policyRuleSchema() map[string]*schema.Schema {
 		"verbs": {
 			Type:        schema.TypeList,
 			Description: "Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. VerbAll represents all kinds.",
-			Optional:    true,
+			Required:    true,
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 	}

--- a/website/docs/r/cluster_role.html.markdown
+++ b/website/docs/r/cluster_role.html.markdown
@@ -13,7 +13,7 @@ A ClusterRole creates a role at the cluster level and in all namespaces.
 ## Example Usage
 
 ```hcl
-resource "kubernetes_cluster_role "example" {
+resource "kubernetes_cluster_role" "example" {
     metadata {
         name = "terraform-example"
     }
@@ -55,11 +55,11 @@ The following arguments are supported:
 
 #### Arguments
 
-- `api_groups` - (Required) APIGroups is the name of the APIGroup that contains the resources. If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.
+- `api_groups` - (Optional) APIGroups is the name of the APIGroup that contains the resources. If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.
 - `non_resource_urls` - (Optional) NonResourceURLs is a set of partial urls that a user should have access to. \*s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"), but not both.
 - `resource_names` - (Optional) ResourceNames is an optional white list of names that the rule applies to. An empty set means that everything is allowed.
 - `resources` - (Optional) Resources is a list of resources this rule applies to. ResourceAll represents all resources.
-- `verbs` - (Optional) Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. VerbAll represents all kinds.
+- `verbs` - (Required) Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. VerbAll represents all kinds.
 
 ## Import
 


### PR DESCRIPTION
This fix makes it possible to have rules which are `nonResourceUrls`.
Partially fixes #285