### PR TITLE
add optional secret_key_ref

### DIFF
--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -43,6 +43,8 @@ func TestAccKubernetesPod_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_pod.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_pod.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env.0.value_from.0.secret_key_ref.0.name", secretName),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env.0.value_from.0.secret_key_ref.0.key", "one"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env.0.value_from.0.secret_key_ref.0.optional", "true"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env.1.value_from.0.config_map_key_ref.0.name", configMapName),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env_from.#", "2"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.env_from.0.config_map_ref.#", "1"),
@@ -716,6 +718,7 @@ resource "kubernetes_pod" "test" {
           secret_key_ref {
             name = "${kubernetes_secret.test.metadata.0.name}"
             key  = "one"
+            optional  = true
           }
         }
       },

--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -290,6 +290,11 @@ func containerFields(isUpdatable, isInitContainer bool) map[string]*schema.Schem
 												Required:    true,
 												Description: "Resource to select",
 											},
+											"divisor": {
+												Type:        schema.TypeInt,
+												Optional:    true,
+												Description: "Specifies the output format of the exposed resources, defaults to '1'",
+											},
 										},
 									},
 								},
@@ -309,6 +314,11 @@ func containerFields(isUpdatable, isInitContainer bool) map[string]*schema.Schem
 												Type:        schema.TypeString,
 												Optional:    true,
 												Description: "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+											},
+											"optional": {
+												Type:        schema.TypeBool,
+												Optional:    true,
+												Description: "Specify whether the Secret or it's key must be defined",
 											},
 										},
 									},

--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -290,11 +290,6 @@ func containerFields(isUpdatable, isInitContainer bool) map[string]*schema.Schem
 												Required:    true,
 												Description: "Resource to select",
 											},
-											"divisor": {
-												Type:        schema.TypeInt,
-												Optional:    true,
-												Description: "Specifies the output format of the exposed resources, defaults to '1'",
-											},
 										},
 									},
 								},

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -239,6 +239,9 @@ func flattenSecretKeyRef(in *v1.SecretKeySelector) []interface{} {
 	if in.Name != "" {
 		att["name"] = in.Name
 	}
+	if in.Optional != nil {
+		att["optional"] = *in.Optional
+	}
 	return []interface{}{att}
 }
 
@@ -873,6 +876,9 @@ func expandSecretKeyRef(r []interface{}) (*v1.SecretKeySelector, error) {
 	}
 	if v, ok := in["name"].(string); ok {
 		obj.Name = v
+	}
+	if v, ok := in["optional"]; ok {
+		obj.Optional = ptrToBool(v.(bool))
 	}
 	return obj, nil
 }

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -508,7 +508,6 @@ The following arguments are supported:
 
 - `container_name` - (Optional) The name of the container
 - `resource` - (Required) Resource to select
-- `divisor` - (Optional) Specifies the output format of the exposed resources, defaults to '1'
 
 ### `se_linux_options`
 

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -508,6 +508,7 @@ The following arguments are supported:
 
 - `container_name` - (Optional) The name of the container
 - `resource` - (Required) Resource to select
+- `divisor` - (Optional) Specifies the output format of the exposed resources, defaults to '1'
 
 ### `se_linux_options`
 
@@ -546,6 +547,7 @@ The `items` block supports:
 
 - `key` - (Optional) The key of the secret to select from. Must be a valid secret key.
 - `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+- `optional` - (Optional) Specify whether the Secret or it's key must be defined
 
 ### `secret_ref`
 

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -513,6 +513,7 @@ The following arguments are supported:
 
 * `container_name` - (Optional) The name of the container
 * `resource` - (Required) Resource to select
+* `divisor` - (Optional) Specifies the output format of the exposed resources, defaults to '1'
 
 ### `se_linux_options`
 
@@ -551,6 +552,7 @@ The `items` block supports:
 
 * `key` - (Optional) The key of the secret to select from. Must be a valid secret key.
 * `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+* `optional` - (Optional) Specify whether the Secret or it's key must be defined
 
 ### `secret_ref`
 

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -513,7 +513,6 @@ The following arguments are supported:
 
 * `container_name` - (Optional) The name of the container
 * `resource` - (Required) Resource to select
-* `divisor` - (Optional) Specifies the output format of the exposed resources, defaults to '1'
 
 ### `se_linux_options`
 

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -456,6 +456,7 @@ The following arguments are supported:
 
 * `container_name` - (Optional) The name of the container
 * `resource` - (Required) Resource to select
+* `divisor` - (Optional) Specifies the output format of the exposed resources, defaults to '1'
 
 ### `se_linux_options`
 
@@ -494,6 +495,7 @@ The `items` block supports the following:
 
 * `key` - (Optional) The key of the secret to select from. Must be a valid secret key.
 * `name` - (Optional) Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+* `optional` - (Optional) Specify whether the Secret or it's key must be defined
 
 ### `secret_ref`
 

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -456,7 +456,6 @@ The following arguments are supported:
 
 * `container_name` - (Optional) The name of the container
 * `resource` - (Required) Resource to select
-* `divisor` - (Optional) Specifies the output format of the exposed resources, defaults to '1'
 
 ### `se_linux_options`
 


### PR DESCRIPTION
#### What this does

1. Add [`optional`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#secretkeyselector-v1-core) for secret_key_ref
~~1. Add [`divisor`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#resourcefieldselector-v1-core) field for resource_field_ref~~

Fix: https://github.com/terraform-providers/terraform-provider-kubernetes/issues/240