### PR TITLE
Add kubernetes_secret datasource to docs sidebar.

### DIFF
--- a/website/kubernetes.erb
+++ b/website/kubernetes.erb
@@ -18,6 +18,9 @@
         <li<%= sidebar_current("docs-kubernetes-data-source") %>>
           <a href="#">Data Sources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-kubernetes-data-source-secret") %>>
+              <a href="/docs/providers/kubernetes/d/secret.html">kubernetes_secret</a>
+            </li>
             <li<%= sidebar_current("docs-kubernetes-data-source-service") %>>
               <a href="/docs/providers/kubernetes/d/service.html">kubernetes_service</a>
             </li>


### PR DESCRIPTION
This change is adding the already existing `kubernetes_secret` to the docs sidebar.
This was omitted in #243. 