### PR TITLE
Allow network policy with all namespaces selector ingress

### DIFF
--- a/kubernetes/resource_kubernetes_network_policy_test.go
+++ b/kubernetes/resource_kubernetes_network_policy_test.go
@@ -107,7 +107,7 @@ func TestAccKubernetesNetworkPolicy_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesNetworkPolicyConfig_specModified_all_namespaces(name),
+				Config: testAccKubernetesNetworkPolicyConfig_specModified_allow_all_namespaces(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesNetworkPolicyExists("kubernetes_network_policy.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "metadata.0.annotations.%", "0"),
@@ -127,6 +127,7 @@ func TestAccKubernetesNetworkPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.pod_selector.0.match_expressions.0.values.#", "2"),
 					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.pod_selector.0.match_expressions.0.values.1742479128", "webfront"),
 					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.pod_selector.0.match_expressions.0.values.2902841359", "api"),
+					resource.TestCheckNoResourceAttr("kubernetes_network_policy.test", "spec.0.pod_selector.0.match_labels"),
 					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.ports.#", "2"),
 					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.ports.0.port", "http"),
@@ -135,8 +136,41 @@ func TestAccKubernetesNetworkPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.ports.1.protocol", "UDP"),
 					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.from.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.from.0.namespace_selector.#", "1"),
+					resource.TestCheckNoResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.from.0.pod_selector.0.match_expressions"),
 					resource.TestCheckNoResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.from.0.namespace_selector.0.match_labels"),
 					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.from.0.pod_selector.#", "0"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.policy_types.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.policy_types.0", "Ingress"),
+				),
+			},
+			{
+				Config: testAccKubernetesNetworkPolicyConfig_specModified_deny_other_namespaces(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesNetworkPolicyExists("kubernetes_network_policy.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "metadata.0.annotations.%", "0"),
+					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{}),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "metadata.0.labels.%", "0"),
+					testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{}),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_network_policy.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_network_policy.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_network_policy.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_network_policy.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.pod_selector.#", "1"),
+					resource.TestCheckNoResourceAttr("kubernetes_network_policy.test", "spec.0.pod_selector.0.match_expressions"),
+					resource.TestCheckNoResourceAttr("kubernetes_network_policy.test", "spec.0.pod_selector.0.match_labels"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.ports.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.ports.0.port", "http"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.ports.0.protocol", "TCP"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.ports.1.port", "8125"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.ports.1.protocol", "UDP"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.from.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.from.0.namespace_selector.#", "0"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.from.0.pod_selector.#", "1"),
+					resource.TestCheckNoResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.from.0.pod_selector.0.match_expressions"),
+					resource.TestCheckNoResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.from.0.pod_selector.0.match_labels"),
 					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.policy_types.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.policy_types.0", "Ingress"),
 				),
@@ -480,7 +514,7 @@ resource "kubernetes_network_policy" "test" {
 	`, name)
 }
 
-func testAccKubernetesNetworkPolicyConfig_specModified_all_namespaces(name string) string {
+func testAccKubernetesNetworkPolicyConfig_specModified_allow_all_namespaces(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_network_policy" "test" {
   metadata {
@@ -523,6 +557,42 @@ resource "kubernetes_network_policy" "test" {
 	`, name)
 }
 
+func testAccKubernetesNetworkPolicyConfig_specModified_deny_other_namespaces(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_network_policy" "test" {
+  metadata {
+    name      = "%s"
+    namespace = "default"
+  }
+
+  spec {
+    pod_selector {}
+
+    ingress = [
+      {
+        ports = [
+          {
+            port     = "http"
+          },
+          {
+            port     = "8125"
+            protocol = "UDP"
+          },
+        ]
+
+        from = [
+          {
+            pod_selector {}
+          },
+        ]
+      },
+    ]
+
+	policy_types = [ "Ingress" ]
+  }
+}
+	`, name)
+}
 func testAccKubernetesNetworkPolicyConfig_specModified_pod_selector(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_network_policy" "test" {

--- a/kubernetes/resource_kubernetes_network_policy_test.go
+++ b/kubernetes/resource_kubernetes_network_policy_test.go
@@ -107,7 +107,42 @@ func TestAccKubernetesNetworkPolicy_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesNetworkPolicyConfig_specModified2(name),
+				Config: testAccKubernetesNetworkPolicyConfig_specModified_all_namespaces(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesNetworkPolicyExists("kubernetes_network_policy.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "metadata.0.annotations.%", "0"),
+					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{}),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "metadata.0.labels.%", "0"),
+					testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{}),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_network_policy.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_network_policy.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_network_policy.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_network_policy.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.pod_selector.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.pod_selector.0.match_expressions.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.pod_selector.0.match_expressions.0.key", "name"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.pod_selector.0.match_expressions.0.operator", "In"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.pod_selector.0.match_expressions.0.values.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.pod_selector.0.match_expressions.0.values.1742479128", "webfront"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.pod_selector.0.match_expressions.0.values.2902841359", "api"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.ports.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.ports.0.port", "http"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.ports.0.protocol", "TCP"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.ports.1.port", "8125"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.ports.1.protocol", "UDP"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.from.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.from.0.namespace_selector.#", "1"),
+					resource.TestCheckNoResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.from.0.namespace_selector.0.match_labels"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.ingress.0.from.0.pod_selector.#", "0"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.policy_types.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "spec.0.policy_types.0", "Ingress"),
+				),
+			},
+			{
+				Config: testAccKubernetesNetworkPolicyConfig_specModified_pod_selector(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesNetworkPolicyExists("kubernetes_network_policy.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_network_policy.test", "metadata.0.annotations.%", "0"),
@@ -445,7 +480,50 @@ resource "kubernetes_network_policy" "test" {
 	`, name)
 }
 
-func testAccKubernetesNetworkPolicyConfig_specModified2(name string) string {
+func testAccKubernetesNetworkPolicyConfig_specModified_all_namespaces(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_network_policy" "test" {
+  metadata {
+    name      = "%s"
+    namespace = "default"
+  }
+
+  spec {
+    pod_selector {
+      match_expressions {
+        key      = "name"
+        operator = "In"
+        values   = ["webfront", "api"]
+      }
+    }
+
+    ingress = [
+      {
+        ports = [
+          {
+            port     = "http"
+          },
+          {
+            port     = "8125"
+            protocol = "UDP"
+          },
+        ]
+
+        from = [
+          {
+            namespace_selector {}
+          },
+        ]
+      },
+    ]
+
+	policy_types = [ "Ingress" ]
+  }
+}
+	`, name)
+}
+
+func testAccKubernetesNetworkPolicyConfig_specModified_pod_selector(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_network_policy" "test" {
   metadata {

--- a/kubernetes/structure_label_selector.go
+++ b/kubernetes/structure_label_selector.go
@@ -15,10 +15,7 @@ func flattenLabelSelector(in *metav1.LabelSelector) []interface{} {
 	if len(in.MatchExpressions) > 0 {
 		att["match_expressions"] = flattenLabelSelectorRequirement(in.MatchExpressions)
 	}
-	if len(att) > 0 {
-		return []interface{}{att}
-	}
-	return []interface{}{}
+	return []interface{}{att}
 }
 
 func flattenLabelSelectorRequirement(in []metav1.LabelSelectorRequirement) []interface{} {

--- a/kubernetes/structure_label_selector_test.go
+++ b/kubernetes/structure_label_selector_test.go
@@ -22,7 +22,7 @@ func TestFlattenLabelSelector(t *testing.T) {
 		},
 		{
 			&metav1.LabelSelector{},
-			[]interface{}{},
+			[]interface{}{map[string]interface{}{}},
 		},
 	}
 


### PR DESCRIPTION
Fixes #310.

```
# make testacc TEST=./kubernetes TESTARGS='-run=TestAccKubernetesNetworkPolicy_.* -count=1'                                                                                             
==> Checking that code complies with gofmt requirements...                                                                                                                               
TF_ACC=1 go test ./kubernetes -v -run=TestAccKubernetesNetworkPolicy_.* -count=1 -timeout 120m                                                                                           
=== RUN   TestAccKubernetesNetworkPolicy_basic                                                                                                                                           
--- PASS: TestAccKubernetesNetworkPolicy_basic (0.61s)                                                                                                                                   
=== RUN   TestAccKubernetesNetworkPolicy_withEgressAtCreation                                                                                                                            
--- PASS: TestAccKubernetesNetworkPolicy_withEgressAtCreation (0.15s)                                                                                                                    
=== RUN   TestAccKubernetesNetworkPolicy_importBasic                                                                                                                                     
--- PASS: TestAccKubernetesNetworkPolicy_importBasic (0.11s)                                                                                                                             
PASS                                                                                                                                                                                     
ok      github.com/terraform-providers/terraform-provider-kubernetes/kubernetes 0.901s                                                                                                   
```

Complete acceptance test run in progress.