### PR TITLE
Fix service datasource

### DIFF
--- a/kubernetes/data_source_kubernetes_service.go
+++ b/kubernetes/data_source_kubernetes_service.go
@@ -82,6 +82,12 @@ func dataSourceKubernetesService() *schema.Resource {
 								},
 							},
 						},
+						"publish_not_ready_addresses": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "When set to true, indicates that DNS implementations must publish the `notReadyAddresses` of subsets for the Endpoints associated with the Service. The default value is `false`. The primary use case for setting this field is to use a StatefulSet's Headless Service to propagate `SRV` records for its Pods without respect to their readiness for purpose of peer discovery.",
+						},
 						"selector": {
 							Type:        schema.TypeMap,
 							Description: "Route service traffic to pods with label keys and values matching this selector. Only applies to types `ClusterIP`, `NodePort`, and `LoadBalancer`. More info: http://kubernetes.io/docs/user-guide/services#overview",


### PR DESCRIPTION
It was broken by #306.

```
# make testacc TEST=./kubernetes TESTARGS='-run=TestAccKubernetes.*Service_.* -count=1'                                                                                                 
==> Checking that code complies with gofmt requirements...                                                                                                                               
TF_ACC=1 go test ./kubernetes -v -run=TestAccKubernetes.*Service_.* -count=1 -timeout 120m                                                                                               
=== RUN   TestAccKubernetesDataSourceService_basic                                                                                                                                       
--- PASS: TestAccKubernetesDataSourceService_basic (8.04s)                                                                                                                               
=== RUN   TestAccKubernetesService_basic                                                                                                                                                 
--- PASS: TestAccKubernetesService_basic (2.18s)                                                                                                                                         
=== RUN   TestAccKubernetesService_loadBalancer                                                                                                                                          
--- SKIP: TestAccKubernetesService_loadBalancer (0.03s)                                                                                                                                  
    provider_test.go:207: The Kubernetes endpoint must come from an environment which supports load balancer provisioning for this test to run - skipping                                
=== RUN   TestAccKubernetesService_nodePort                                                                                                                                              
--- PASS: TestAccKubernetesService_nodePort (0.45s)                                                                                                                                      
=== RUN   TestAccKubernetesService_noTargetPort                                                                                                                                          
--- SKIP: TestAccKubernetesService_noTargetPort (0.01s)                                                                                                                                  
    provider_test.go:207: The Kubernetes endpoint must come from an environment which supports load balancer provisioning for this test to run - skipping                                
=== RUN   TestAccKubernetesService_stringTargetPort                                                                                                                                      
--- SKIP: TestAccKubernetesService_stringTargetPort (0.01s)                                                                                                                              
    provider_test.go:207: The Kubernetes endpoint must come from an environment which supports load balancer provisioning for this test to run - skipping                                
=== RUN   TestAccKubernetesService_externalName                                                                                                                                          
--- PASS: TestAccKubernetesService_externalName (0.89s)                                                                                                                                  
=== RUN   TestAccKubernetesService_importBasic                                                                                                                                           
--- PASS: TestAccKubernetesService_importBasic (0.64s)                                                                                                                                   
=== RUN   TestAccKubernetesService_generatedName                                                                                                                                         
--- PASS: TestAccKubernetesService_generatedName (0.97s)                                                                                                                                 
=== RUN   TestAccKubernetesService_importGeneratedName                                                                                                                                   
--- PASS: TestAccKubernetesService_importGeneratedName (0.42s)                                                                                                                           
PASS                                                                                                                                                                                     
ok      github.com/terraform-providers/terraform-provider-kubernetes/kubernetes 13.668s                                                                                                  
```