### PR TITLE
Skip TestProvider_configure test when TF_ACC is set

### DIFF
--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -39,6 +39,11 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func TestProvider_configure(t *testing.T) {
+	if os.Getenv("TF_ACC") != "" {
+		t.Skip("The environment variable TF_ACC is set, and this test prevents acceptance tests" +
+			" from running as it alters environment variables - skipping")
+	}
+
 	resetEnv := unsetEnv(t)
 	defer resetEnv()
 


### PR DESCRIPTION
The `TestProvider_configure` unit test alters environment variables and thus prevents following acceptance tests from running properly:

```
# make testacc TEST=./kubernetes
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./kubernetes -v -count=1 -timeout 120m
=== RUN   TestAccKubernetesDataSourceSecret_basic
--- PASS: TestAccKubernetesDataSourceSecret_basic (2.29s)
=== RUN   TestAccKubernetesDataSourceService_basic
--- PASS: TestAccKubernetesDataSourceService_basic (1.16s)
=== RUN   TestAccKubernetesDataSourceStorageClass_basic
--- PASS: TestAccKubernetesDataSourceStorageClass_basic (1.58s)
=== RUN   TestDiffStringMap
=== RUN   TestDiffStringMap/0
=== RUN   TestDiffStringMap/1
=== RUN   TestDiffStringMap/2
=== RUN   TestDiffStringMap/3
=== RUN   TestDiffStringMap/4
=== RUN   TestDiffStringMap/5
=== RUN   TestDiffStringMap/6
--- PASS: TestDiffStringMap (0.00s)
    --- PASS: TestDiffStringMap/0 (0.00s)
    --- PASS: TestDiffStringMap/1 (0.00s)
    --- PASS: TestDiffStringMap/2 (0.00s)
    --- PASS: TestDiffStringMap/3 (0.00s)
    --- PASS: TestDiffStringMap/4 (0.00s)
    --- PASS: TestDiffStringMap/5 (0.00s)
    --- PASS: TestDiffStringMap/6 (0.00s)
=== RUN   TestEscapeJsonPointer
--- PASS: TestEscapeJsonPointer (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.02s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestProvider_configure
--- PASS: TestProvider_configure (0.00s)
=== RUN   TestAccKubernetesClusterRoleBinding
--- FAIL: TestAccKubernetesClusterRoleBinding (0.00s)
    provider_test.go:182: Failed to load config (/home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/kubernetes/test-infra/gke/kubeconfig; overriden context; config ctx: /home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/kubernetes/test-infra/gke/kubeconfig): context "/home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/kubernetes/test-infra/gke/kubeconfig" does not exist
=== RUN   TestAccKubernetesClusterRoleBinding_importBasic
--- FAIL: TestAccKubernetesClusterRoleBinding_importBasic (0.00s)
    provider_test.go:182: Failed to load config (/home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/kubernetes/test-infra/gke/kubeconfig; overriden context; config ctx: /home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/kubernetes/test-infra/gke/kubeconfig): context "/home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/kubernetes/test-infra/gke/kubeconfig" does not exist
[...]
```

With this change:

```
# make testacc TEST=./kubernetes
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./kubernetes -v  -timeout 120m
=== RUN   TestAccKubernetesDataSourceSecret_basic
--- PASS: TestAccKubernetesDataSourceSecret_basic (1.66s)
=== RUN   TestAccKubernetesDataSourceService_basic
--- PASS: TestAccKubernetesDataSourceService_basic (1.28s)
=== RUN   TestAccKubernetesDataSourceStorageClass_basic
--- PASS: TestAccKubernetesDataSourceStorageClass_basic (1.27s)
=== RUN   TestDiffStringMap
=== RUN   TestDiffStringMap/0
=== RUN   TestDiffStringMap/1
=== RUN   TestDiffStringMap/2
=== RUN   TestDiffStringMap/3
=== RUN   TestDiffStringMap/4
=== RUN   TestDiffStringMap/5
=== RUN   TestDiffStringMap/6
--- PASS: TestDiffStringMap (0.00s)
    --- PASS: TestDiffStringMap/0 (0.00s)
    --- PASS: TestDiffStringMap/1 (0.00s)
    --- PASS: TestDiffStringMap/2 (0.00s)
    --- PASS: TestDiffStringMap/3 (0.00s)
    --- PASS: TestDiffStringMap/4 (0.00s)
    --- PASS: TestDiffStringMap/5 (0.00s)
    --- PASS: TestDiffStringMap/6 (0.00s)
=== RUN   TestEscapeJsonPointer
--- PASS: TestEscapeJsonPointer (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.02s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestProvider_configure
--- SKIP: TestProvider_configure (0.00s)
    provider_test.go:43: The environment variable TF_ACC is set, and this test prevents acceptance tests from running as it alters environment variables - skipping
=== RUN   TestAccKubernetesClusterRoleBinding
--- PASS: TestAccKubernetesClusterRoleBinding (2.01s)
=== RUN   TestAccKubernetesClusterRoleBinding_importBasic
--- PASS: TestAccKubernetesClusterRoleBinding_importBasic (1.27s)
[...]
```

This avoids the need to pass `TESTARGS="-run '^TestAcc'"` to `make testacc`