### PR TITLE
Whitelist "internal" annotations/labels that the user is managing in the resource

### DIFF
--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -204,12 +204,15 @@ func skipIfNoAwsSettingsFound(t *testing.T) {
 }
 
 func skipIfNoLoadBalancersAvailable(t *testing.T) {
-	// TODO: Support AWS ELBs
 	isInGke, err := isRunningInGke()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !isInGke {
+	isInEks, err := isRunningInEks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isInGke && !isInEks {
 		t.Skip("The Kubernetes endpoint must come from an environment which supports " +
 			"load balancer provisioning for this test to run - skipping")
 	}
@@ -268,6 +271,19 @@ func isRunningInGke() (bool, error) {
 
 	labels := node.GetLabels()
 	if _, ok := labels["cloud.google.com/gke-nodepool"]; ok {
+		return true, nil
+	}
+	return false, nil
+}
+
+func isRunningInEks() (bool, error) {
+	node, err := getFirstNode()
+	if err != nil {
+		return false, err
+	}
+
+	labels := node.GetLabels()
+	if _, ok := labels["failure-domain.beta.kubernetes.io/region"]; ok {
 		return true, nil
 	}
 	return false, nil

--- a/kubernetes/resource_kubernetes_cluster_role.go
+++ b/kubernetes/resource_kubernetes_cluster_role.go
@@ -96,7 +96,7 @@ func resourceKubernetesClusterRoleRead(d *schema.ResourceData, meta interface{})
 		return err
 	}
 	log.Printf("[INFO] Received cluster role: %#v", cRole)
-	err = d.Set("metadata", flattenMetadata(cRole.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(cRole.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_cluster_role_binding.go
+++ b/kubernetes/resource_kubernetes_cluster_role_binding.go
@@ -81,7 +81,7 @@ func resourceKubernetesClusterRoleBindingRead(d *schema.ResourceData, meta inter
 	}
 
 	log.Printf("[INFO] Received ClusterRoleBinding: %#v", binding)
-	err = d.Set("metadata", flattenMetadata(binding.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(binding.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_config_map.go
+++ b/kubernetes/resource_kubernetes_config_map.go
@@ -74,7 +74,7 @@ func resourceKubernetesConfigMapRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 	log.Printf("[INFO] Received config map: %#v", cfgMap)
-	err = d.Set("metadata", flattenMetadata(cfgMap.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(cfgMap.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_daemonset.go
+++ b/kubernetes/resource_kubernetes_daemonset.go
@@ -206,7 +206,7 @@ func resourceKubernetesDaemonSetRead(d *schema.ResourceData, meta interface{}) e
 	}
 	log.Printf("[INFO] Received daemonset: %#v", daemonset)
 
-	err = d.Set("metadata", flattenMetadata(daemonset.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(daemonset.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -289,7 +289,7 @@ func resourceKubernetesDeploymentRead(d *schema.ResourceData, meta interface{}) 
 	}
 	log.Printf("[INFO] Received deployment: %#v", deployment)
 
-	err = d.Set("metadata", flattenMetadata(deployment.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(deployment.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -294,7 +294,7 @@ func resourceKubernetesDeploymentRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	spec, err := flattenDeploymentSpec(deployment.Spec)
+	spec, err := flattenDeploymentSpec(deployment.Spec, d)
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_endpoints.go
+++ b/kubernetes/resource_kubernetes_endpoints.go
@@ -148,7 +148,7 @@ func resourceKubernetesEndpointsRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Failed to read endpoint because: %s", err)
 	}
 	log.Printf("[INFO] Received endpoints: %#v", ep)
-	err = d.Set("metadata", flattenMetadata(ep.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(ep.ObjectMeta, d))
 	if err != nil {
 		return fmt.Errorf("Failed to read endpoints because: %s", err)
 	}

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
@@ -120,7 +120,7 @@ func resourceKubernetesHorizontalPodAutoscalerRead(d *schema.ResourceData, meta 
 		return err
 	}
 	log.Printf("[INFO] Received horizontal pod autoscaler: %#v", svc)
-	err = d.Set("metadata", flattenMetadata(svc.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(svc.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_ingress.go
+++ b/kubernetes/resource_kubernetes_ingress.go
@@ -149,7 +149,7 @@ func resourceKubernetesIngressRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Failed to read Ingress '%s' because: %s", buildId(ing.ObjectMeta), err)
 	}
 	log.Printf("[INFO] Received ingress: %#v", ing)
-	err = d.Set("metadata", flattenMetadata(ing.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(ing.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_ingress_test.go
+++ b/kubernetes/resource_kubernetes_ingress_test.go
@@ -107,49 +107,46 @@ func TestAccKubernetesIngress_TLS(t *testing.T) {
 		},
 	})
 }
+func TestAccKubernetesIngress_InternalKey(t *testing.T) {
+	var conf api.Ingress
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
-// Test disabled until internal annotations issue is resolved.
-//
-// func TestAccKubernetesIngress_InternalKey(t *testing.T) {
-// 	var conf api.Ingress
-// 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-
-// 	resource.Test(t, resource.TestCase{
-// 		PreCheck:      func() { testAccPreCheck(t) },
-// 		IDRefreshName: "kubernetes_ingress.test",
-// 		Providers:     testAccProviders,
-// 		CheckDestroy:  testAccCheckKubernetesIngressDestroy,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: testAccKubernetesIngressConfig_internalKey(name),
-// 				Check: resource.ComposeAggregateTestCheckFunc(
-// 					testAccCheckKubernetesIngressExists("kubernetes_ingress.test", &conf),
-// 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "metadata.0.name", name),
-// 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "metadata.0.annotations.kubernetes.io/ingress-anno", "one"),
-// 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "metadata.0.labels.kubernetes.io/ingress-label", "one"),
-// 				),
-// 			},
-// 			{
-// 				Config: testAccKubernetesIngressConfig_internalKey_removed(name),
-// 				Check: resource.ComposeAggregateTestCheckFunc(
-// 					testAccCheckKubernetesIngressExists("kubernetes_ingress.test", &conf),
-// 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "metadata.0.name", name),
-// 					resource.TestCheckNoResourceAttr("kubernetes_ingress.test", "metadata.0.annotations.kubernetes.io/ingress-anno"),
-// 					resource.TestCheckNoResourceAttr("kubernetes_ingress.test", "metadata.0.labels.kubernetes.io/ingress-label"),
-// 				),
-// 			},
-// 			{
-// 				Config: testAccKubernetesIngressConfig_internalKey(name),
-// 				Check: resource.ComposeAggregateTestCheckFunc(
-// 					testAccCheckKubernetesIngressExists("kubernetes_ingress.test", &conf),
-// 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "metadata.0.name", name),
-// 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "metadata.0.annotations.kubernetes.io/ingress-anno", "one"),
-// 					resource.TestCheckResourceAttr("kubernetes_ingress.test", "metadata.0.labels.kubernetes.io/ingress-label", "one"),
-// 				),
-// 			},
-// 		},
-// 	})
-// }
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "kubernetes_ingress.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesIngressDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesIngressConfig_internalKey(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesIngressExists("kubernetes_ingress.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_ingress.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttr("kubernetes_ingress.test", "metadata.0.annotations.kubernetes.io/ingress-anno", "one"),
+					resource.TestCheckResourceAttr("kubernetes_ingress.test", "metadata.0.labels.kubernetes.io/ingress-label", "one"),
+				),
+			},
+			{
+				Config: testAccKubernetesIngressConfig_internalKey_removed(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesIngressExists("kubernetes_ingress.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_ingress.test", "metadata.0.name", name),
+					resource.TestCheckNoResourceAttr("kubernetes_ingress.test", "metadata.0.annotations.kubernetes.io/ingress-anno"),
+					resource.TestCheckNoResourceAttr("kubernetes_ingress.test", "metadata.0.labels.kubernetes.io/ingress-label"),
+				),
+			},
+			{
+				Config: testAccKubernetesIngressConfig_internalKey(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesIngressExists("kubernetes_ingress.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_ingress.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttr("kubernetes_ingress.test", "metadata.0.annotations.kubernetes.io/ingress-anno", "one"),
+					resource.TestCheckResourceAttr("kubernetes_ingress.test", "metadata.0.labels.kubernetes.io/ingress-label", "one"),
+				),
+			},
+		},
+	})
+}
 
 func testAccCheckKubernetesIngressDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*kubernetes.Clientset)

--- a/kubernetes/resource_kubernetes_limit_range.go
+++ b/kubernetes/resource_kubernetes_limit_range.go
@@ -117,7 +117,7 @@ func resourceKubernetesLimitRangeRead(d *schema.ResourceData, meta interface{}) 
 	}
 	log.Printf("[INFO] Received limit range: %#v", limitRange)
 
-	err = d.Set("metadata", flattenMetadata(limitRange.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(limitRange.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_namespace.go
+++ b/kubernetes/resource_kubernetes_namespace.go
@@ -60,7 +60,7 @@ func resourceKubernetesNamespaceRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 	log.Printf("[INFO] Received namespace: %#v", namespace)
-	err = d.Set("metadata", flattenMetadata(namespace.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(namespace.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_network_policy.go
+++ b/kubernetes/resource_kubernetes_network_policy.go
@@ -274,7 +274,7 @@ func resourceKubernetesNetworkPolicyRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 	log.Printf("[INFO] Received network policy: %#v", svc)
-	err = d.Set("metadata", flattenMetadata(svc.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(svc.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -196,7 +196,7 @@ func resourceKubernetesPersistentVolumeRead(d *schema.ResourceData, meta interfa
 		return err
 	}
 	log.Printf("[INFO] Received persistent volume: %#v", volume)
-	err = d.Set("metadata", flattenMetadata(volume.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(volume.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_persistent_volume_claim.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim.go
@@ -124,7 +124,7 @@ func resourceKubernetesPersistentVolumeClaimRead(d *schema.ResourceData, meta in
 		return err
 	}
 	log.Printf("[INFO] Received persistent volume claim: %#v", claim)
-	err = d.Set("metadata", flattenMetadata(claim.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(claim.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -148,7 +148,7 @@ func resourceKubernetesPodRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	log.Printf("[INFO] Received pod: %#v", pod)
 
-	err = d.Set("metadata", flattenMetadata(pod.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(pod.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_replication_controller.go
+++ b/kubernetes/resource_kubernetes_replication_controller.go
@@ -167,7 +167,7 @@ func resourceKubernetesReplicationControllerRead(d *schema.ResourceData, meta in
 	}
 	log.Printf("[INFO] Received replication controller: %#v", rc)
 
-	err = d.Set("metadata", flattenMetadata(rc.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(rc.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_replication_controller.go
+++ b/kubernetes/resource_kubernetes_replication_controller.go
@@ -172,7 +172,7 @@ func resourceKubernetesReplicationControllerRead(d *schema.ResourceData, meta in
 		return err
 	}
 
-	spec, err := flattenReplicationControllerSpec(rc.Spec, useDeprecatedSpecFields(d))
+	spec, err := flattenReplicationControllerSpec(rc.Spec, d, useDeprecatedSpecFields(d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_resource_quota.go
+++ b/kubernetes/resource_kubernetes_resource_quota.go
@@ -119,7 +119,7 @@ func resourceKubernetesResourceQuotaRead(d *schema.ResourceData, meta interface{
 		}
 	}
 
-	err = d.Set("metadata", flattenMetadata(resQuota.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(resQuota.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_role.go
+++ b/kubernetes/resource_kubernetes_role.go
@@ -103,7 +103,7 @@ func resourceKubernetesRoleRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	log.Printf("[INFO] Received role: %#v", role)
-	err = d.Set("metadata", flattenMetadata(role.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(role.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_role_binding.go
+++ b/kubernetes/resource_kubernetes_role_binding.go
@@ -84,7 +84,7 @@ func resourceKubernetesRoleBindingRead(d *schema.ResourceData, meta interface{})
 	}
 
 	log.Printf("[INFO] Received RoleBinding: %#v", binding)
-	err = d.Set("metadata", flattenMetadata(binding.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(binding.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_secret.go
+++ b/kubernetes/resource_kubernetes_secret.go
@@ -83,7 +83,7 @@ func resourceKubernetesSecretRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	log.Printf("[INFO] Received secret: %#v", secret)
-	err = d.Set("metadata", flattenMetadata(secret.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(secret.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_service.go
+++ b/kubernetes/resource_kubernetes_service.go
@@ -212,7 +212,7 @@ func resourceKubernetesServiceRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 	log.Printf("[INFO] Received service: %#v", svc)
-	err = d.Set("metadata", flattenMetadata(svc.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(svc.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -164,7 +164,7 @@ func resourceKubernetesServiceAccountRead(d *schema.ResourceData, meta interface
 		return err
 	}
 	log.Printf("[INFO] Received service account: %#v", svcAcc)
-	err = d.Set("metadata", flattenMetadata(svcAcc.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(svcAcc.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_stateful_set.go
+++ b/kubernetes/resource_kubernetes_stateful_set.go
@@ -112,7 +112,7 @@ func resourceKubernetesStatefulSetRead(d *schema.ResourceData, meta interface{})
 	if d.Set("metadata", flattenMetadata(statefulSet.ObjectMeta, d)) != nil {
 		return fmt.Errorf("Error setting `metadata`: %+v", err)
 	}
-	sss, err := flattenStatefulSetSpec(statefulSet.Spec)
+	sss, err := flattenStatefulSetSpec(statefulSet.Spec, d)
 	if err != nil {
 		return fmt.Errorf("Error flattening `spec`: %+v", err)
 	}

--- a/kubernetes/resource_kubernetes_stateful_set.go
+++ b/kubernetes/resource_kubernetes_stateful_set.go
@@ -109,7 +109,7 @@ func resourceKubernetesStatefulSetRead(d *schema.ResourceData, meta interface{})
 		}
 	}
 	log.Printf("[INFO] Received stateful set: %#v", statefulSet)
-	if d.Set("metadata", flattenMetadata(statefulSet.ObjectMeta)) != nil {
+	if d.Set("metadata", flattenMetadata(statefulSet.ObjectMeta, d)) != nil {
 		return fmt.Errorf("Error setting `metadata`: %+v", err)
 	}
 	sss, err := flattenStatefulSetSpec(statefulSet.Spec)

--- a/kubernetes/resource_kubernetes_storage_class.go
+++ b/kubernetes/resource_kubernetes_storage_class.go
@@ -101,7 +101,7 @@ func resourceKubernetesStorageClassRead(d *schema.ResourceData, meta interface{}
 		return err
 	}
 	log.Printf("[INFO] Received storage class: %#v", storageClass)
-	err = d.Set("metadata", flattenMetadata(storageClass.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(storageClass.ObjectMeta, d))
 	if err != nil {
 		return err
 	}

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -120,7 +120,7 @@ func flattenMetadata(meta metav1.ObjectMeta, d *schema.ResourceData, metaPrefix 
 	if meta.GenerateName != "" {
 		m["generate_name"] = meta.GenerateName
 	}
-	configLabels := d.Get("metadata.0.labels").(map[string]interface{})
+	configLabels := d.Get(prefix + "metadata.0.labels").(map[string]interface{})
 	m["labels"] = removeInternalKeys(meta.Labels, configLabels)
 	m["name"] = meta.Name
 	m["resource_version"] = meta.ResourceVersion

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -109,9 +109,13 @@ func expandStringSlice(s []interface{}) []string {
 	return result
 }
 
-func flattenMetadata(meta metav1.ObjectMeta, d *schema.ResourceData) []interface{} {
+func flattenMetadata(meta metav1.ObjectMeta, d *schema.ResourceData, metaPrefix ...string) []interface{} {
 	m := make(map[string]interface{})
-	configAnnotations := d.Get("metadata.0.annotations").(map[string]interface{})
+	prefix := ""
+	if len(metaPrefix) > 0 {
+		prefix = metaPrefix[0]
+	}
+	configAnnotations := d.Get(prefix + "metadata.0.annotations").(map[string]interface{})
 	m["annotations"] = removeInternalKeys(meta.Annotations, configAnnotations)
 	if meta.GenerateName != "" {
 		m["generate_name"] = meta.GenerateName

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -111,7 +111,8 @@ func expandStringSlice(s []interface{}) []string {
 
 func flattenMetadata(meta metav1.ObjectMeta) []interface{} {
 	m := make(map[string]interface{})
-	m["annotations"] = removeInternalKeys(meta.Annotations)
+	// m["annotations"] = removeInternalKeys(meta.Annotations)
+	m["annotations"] = meta.Annotations
 	if meta.GenerateName != "" {
 		m["generate_name"] = meta.GenerateName
 	}

--- a/kubernetes/structures_daemonset.go
+++ b/kubernetes/structures_daemonset.go
@@ -26,7 +26,7 @@ func flattenDaemonSetSpec(in appsv1.DaemonSetSpec, d *schema.ResourceData) ([]in
 	}
 	template := make(map[string]interface{})
 	template["spec"] = podSpec
-	template["metadata"] = flattenMetadata(in.Template.ObjectMeta)
+	template["metadata"] = flattenMetadata(in.Template.ObjectMeta, d, "spec.0.template.0.")
 	att["template"] = []interface{}{template}
 
 	return []interface{}{att}, nil

--- a/kubernetes/structures_deployment.go
+++ b/kubernetes/structures_deployment.go
@@ -1,12 +1,13 @@
 package kubernetes
 
 import (
+	"github.com/hashicorp/terraform/helper/schema"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func flattenDeploymentSpec(in appsv1.DeploymentSpec) ([]interface{}, error) {
+func flattenDeploymentSpec(in appsv1.DeploymentSpec, d *schema.ResourceData) ([]interface{}, error) {
 	att := make(map[string]interface{})
 	att["min_ready_seconds"] = in.MinReadySeconds
 

--- a/kubernetes/structures_deployment.go
+++ b/kubernetes/structures_deployment.go
@@ -34,7 +34,7 @@ func flattenDeploymentSpec(in appsv1.DeploymentSpec) ([]interface{}, error) {
 	}
 	template := make(map[string]interface{})
 	template["spec"] = podSpec
-	template["metadata"] = flattenMetadata(in.Template.ObjectMeta)
+	template["metadata"] = flattenMetadata(in.Template.ObjectMeta, d, "spec.0.template.0.")
 	att["template"] = []interface{}{template}
 
 	return []interface{}{att}, nil

--- a/kubernetes/structures_replication_controller.go
+++ b/kubernetes/structures_replication_controller.go
@@ -3,10 +3,11 @@ package kubernetes
 import (
 	"errors"
 
+	"github.com/hashicorp/terraform/helper/schema"
 	"k8s.io/api/core/v1"
 )
 
-func flattenReplicationControllerSpec(in v1.ReplicationControllerSpec, useDeprecatedSpecFields bool) ([]interface{}, error) {
+func flattenReplicationControllerSpec(in v1.ReplicationControllerSpec, d *schema.ResourceData, useDeprecatedSpecFields bool) ([]interface{}, error) {
 	att := make(map[string]interface{})
 	att["min_ready_seconds"] = in.MinReadySeconds
 
@@ -33,7 +34,7 @@ func flattenReplicationControllerSpec(in v1.ReplicationControllerSpec, useDeprec
 		} else {
 			// Use new fields
 			template["spec"] = podSpec
-			template["metadata"] = flattenMetadata(in.Template.ObjectMeta)
+			template["metadata"] = flattenMetadata(in.Template.ObjectMeta, d)
 		}
 
 		att["template"] = []interface{}{template}

--- a/kubernetes/structures_stateful_set.go
+++ b/kubernetes/structures_stateful_set.go
@@ -153,7 +153,7 @@ func expandMatchExpressions(in []interface{}) ([]metav1.LabelSelectorRequirement
 
 // Flattners
 
-func flattenStatefulSetSpec(spec v1.StatefulSetSpec) ([]interface{}, error) {
+func flattenStatefulSetSpec(spec v1.StatefulSetSpec, d *schema.ResourceData) ([]interface{}, error) {
 	att := make(map[string]interface{})
 
 	if spec.PodManagementPolicy != "" {
@@ -171,18 +171,18 @@ func flattenStatefulSetSpec(spec v1.StatefulSetSpec) ([]interface{}, error) {
 	if spec.ServiceName != "" {
 		att["service_name"] = spec.ServiceName
 	}
-	template, err := flattenPodTemplateSpec(spec.Template)
+	template, err := flattenPodTemplateSpec(spec.Template, d)
 	if err != nil {
 		return []interface{}{att}, err
 	}
 	att["template"] = template
-	att["volume_claim_template"] = flattenPersistentVolumeClaim(spec.VolumeClaimTemplates)
+	att["volume_claim_template"] = flattenPersistentVolumeClaim(spec.VolumeClaimTemplates, d)
 	att["update_strategy"] = flattenStatefulSetSpecUpdateStrategy(spec.UpdateStrategy)
 
 	return []interface{}{att}, nil
 }
 
-func flattenPodTemplateSpec(t corev1.PodTemplateSpec) ([]interface{}, error) {
+func flattenPodTemplateSpec(t corev1.PodTemplateSpec, d *schema.ResourceData) ([]interface{}, error) {
 	template := make(map[string]interface{})
 
 	template["metadata"] = flattenMetadata(t.ObjectMeta, d, "spec.0.template.0.")
@@ -195,12 +195,12 @@ func flattenPodTemplateSpec(t corev1.PodTemplateSpec) ([]interface{}, error) {
 	return []interface{}{template}, nil
 }
 
-func flattenPersistentVolumeClaim(in []corev1.PersistentVolumeClaim) []interface{} {
+func flattenPersistentVolumeClaim(in []corev1.PersistentVolumeClaim, d *schema.ResourceData) []interface{} {
 	pvcs := make([]interface{}, 0, len(in))
 
-	for _, pvc := range in {
+	for i, pvc := range in {
 		p := make(map[string]interface{})
-		p["metadata"] = flattenMetadata(pvc.ObjectMeta)
+		p["metadata"] = flattenMetadata(pvc.ObjectMeta, d, fmt.Sprintf("spec.0.volume_claim_template.%d.", i))
 		p["spec"] = flattenPersistentVolumeClaimSpec(pvc.Spec)
 		pvcs = append(pvcs, p)
 	}

--- a/kubernetes/structures_stateful_set.go
+++ b/kubernetes/structures_stateful_set.go
@@ -185,7 +185,7 @@ func flattenStatefulSetSpec(spec v1.StatefulSetSpec) ([]interface{}, error) {
 func flattenPodTemplateSpec(t corev1.PodTemplateSpec) ([]interface{}, error) {
 	template := make(map[string]interface{})
 
-	template["metadata"] = flattenMetadata(t.ObjectMeta)
+	template["metadata"] = flattenMetadata(t.ObjectMeta, d, "spec.0.template.0.")
 	spec, err := flattenPodSpec(t.Spec)
 	if err != nil {
 		return []interface{}{template}, err

--- a/kubernetes/validators.go
+++ b/kubernetes/validators.go
@@ -21,10 +21,6 @@ func validateAnnotations(value interface{}, key string) (ws []string, es []error
 				es = append(es, fmt.Errorf("%s (%q) %s", key, k, e))
 			}
 		}
-
-		if isInternalKey(k) {
-			es = append(es, fmt.Errorf("%s: %q is internal Kubernetes annotation", key, k))
-		}
 	}
 	return
 }

--- a/website/docs/r/cluster_role.html.markdown
+++ b/website/docs/r/cluster_role.html.markdown
@@ -39,9 +39,13 @@ The following arguments are supported:
 
 #### Arguments
 
-- `annotations` - (Optional) An unstructured key value map stored with the cluster role binding that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+- `annotations` - (Optional) An unstructured key value map stored with the cluster role binding that may be used to store arbitrary metadata. 
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 - `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#idempotency)
-- `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the cluster role binding. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+- `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the cluster role binding. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 - `name` - (Optional) Name of the cluster role binding, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 
 #### Attributes

--- a/website/docs/r/cluster_role_binding.html.markdown
+++ b/website/docs/r/cluster_role_binding.html.markdown
@@ -56,9 +56,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the cluster role binding that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `annotations` - (Optional) An unstructured key value map stored with the cluster role binding that may be used to store arbitrary metadata. 
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the cluster role binding. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the cluster role binding. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the cluster role binding, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 
 #### Attributes

--- a/website/docs/r/config_map.html.markdown
+++ b/website/docs/r/config_map.html.markdown
@@ -47,9 +47,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the config map that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `annotations` - (Optional) An unstructured key value map stored with the config map that may be used to store arbitrary metadata.
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the config map. May match selectors of replication controllers and services. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the config map. May match selectors of replication controllers and services.
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the config map, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the config map must be unique.
 

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -88,9 +88,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the deployment that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `annotations` - (Optional) An unstructured key value map stored with the deployment that may be used to store arbitrary metadata. 
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the deployment. **Must match `selector`**. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the deployment. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+**Must match `selector`**. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the deployment, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the deployment must be unique.
 

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -88,9 +88,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the deployment that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `annotations` - (Optional) An unstructured key value map stored with the deployment that may be used to store arbitrary metadata. 
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the deployment. **Must match `selector`**. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the deployment. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+**Must match `selector`**. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the deployment, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the deployment must be unique.
 

--- a/website/docs/r/endpoints.html.markdown
+++ b/website/docs/r/endpoints.html.markdown
@@ -96,9 +96,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the endpoints resource that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `annotations` - (Optional) An unstructured key value map stored with the endpoints resource that may be used to store arbitrary metadata. 
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the endpoints resource. May match selectors of replication controllers and services. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the endpoints resource. May match selectors of replication controllers and services. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the endpoints resource, must be unique. Cannot be updated. This name should correspond with an accompanying Service resource. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the endpoints resource must be unique.
 

--- a/website/docs/r/horizontal_pod_autoscaler.html.markdown
+++ b/website/docs/r/horizontal_pod_autoscaler.html.markdown
@@ -42,9 +42,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the horizontal pod autoscaler that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `annotations` - (Optional) An unstructured key value map stored with the horizontal pod autoscaler that may be used to store arbitrary metadata. 
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the horizontal pod autoscaler. May match selectors of replication controllers and services. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the horizontal pod autoscaler. May match selectors of replication controllers and services. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the horizontal pod autoscaler, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the horizontal pod autoscaler must be unique.
 

--- a/website/docs/r/ingress.html.markdown
+++ b/website/docs/r/ingress.html.markdown
@@ -105,9 +105,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the ingress that may be used to store arbitrary metadata. More info: http://kubernetes.io/docs/user-guide/annotations
+* `annotations` - (Optional) An unstructured key value map stored with the ingress that may be used to store arbitrary metadata. 
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+More info: http://kubernetes.io/docs/user-guide/annotations
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#idempotency
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the service. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the service. May match selectors of replication controllers and services. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+More info: http://kubernetes.io/docs/user-guide/labels
 * `name` - (Optional) Name of the service, must be unique. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names
 * `namespace` - (Optional) Namespace defines the space within which name of the service must be unique.
 

--- a/website/docs/r/limit_range.html.markdown
+++ b/website/docs/r/limit_range.html.markdown
@@ -75,9 +75,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the limit range that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `annotations` - (Optional) An unstructured key value map stored with the limit range that may be used to store arbitrary metadata. 
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the limit range. May match selectors of replication controllers and services. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the limit range. May match selectors of replication controllers and services.
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the limit range, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the limit range must be unique.
 

--- a/website/docs/r/namespace.html.markdown
+++ b/website/docs/r/namespace.html.markdown
@@ -42,9 +42,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the namespace that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `annotations` - (Optional) An unstructured key value map stored with the namespace that may be used to store arbitrary metadata. 
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more about [name idempotency](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency).
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) namespaces. May match selectors of replication controllers and services. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) namespaces. May match selectors of replication controllers and services. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the namespace, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 
 #### Attributes

--- a/website/docs/r/network_policy.html.markdown
+++ b/website/docs/r/network_policy.html.markdown
@@ -84,9 +84,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the network policy that may be used to store arbitrary metadata. More info: http://kubernetes.io/docs/user-guide/annotations
+* `annotations` - (Optional) An unstructured key value map stored with the network policy that may be used to store arbitrary metadata. 
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+More info: http://kubernetes.io/docs/user-guide/annotations
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more about [name idempotency](https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#idempotency).
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) network policies. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) network policies. May match selectors of replication controllers and services. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+More info: http://kubernetes.io/docs/user-guide/labels
 * `name` - (Optional) Name of the network policy, must be unique. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names
 
 #### Attributes

--- a/website/docs/r/persistent_volume.html.markdown
+++ b/website/docs/r/persistent_volume.html.markdown
@@ -213,12 +213,15 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the persistent volume that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the persistent volume. May match selectors of replication controllers and services. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `annotations` - (Optional) An unstructured key value map stored with the persistent volume that may be used to store arbitrary metadata. 
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the persistent volume. May match selectors of replication controllers and services. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the persistent volume, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 
 #### Attributes
-
 
 * `generation` - A sequence number representing a specific generation of the desired state.
 * `resource_version` - An opaque value that represents the internal version of this persistent volume that can be used by clients to determine when persistent volume has changed. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#concurrency-control-and-consistency)

--- a/website/docs/r/persistent_volume_claim.html.markdown
+++ b/website/docs/r/persistent_volume_claim.html.markdown
@@ -60,9 +60,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the persistent volume claim that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `annotations` - (Optional) An unstructured key value map stored with the persistent volume claim that may be used to store arbitrary metadata. 
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the persistent volume claim. May match selectors of replication controllers and services. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the persistent volume claim. May match selectors of replication controllers and services. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the persistent volume claim, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the persistent volume claim must be unique.
 

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -78,9 +78,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the pod that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `annotations` - (Optional) An unstructured key value map stored with the pod that may be used to store arbitrary metadata. 
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the pod. May match selectors of replication controllers and services. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the pod. May match selectors of replication controllers and services. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the pod, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the pod must be unique.
 

--- a/website/docs/r/replication_controller.html.markdown
+++ b/website/docs/r/replication_controller.html.markdown
@@ -86,9 +86,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the replication controller that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `annotations` - (Optional) An unstructured key value map stored with the replication controller that may be used to store arbitrary metadata.
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the replication controller. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the replication controller.
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the replication controller, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the replication controller must be unique.
 

--- a/website/docs/r/resource_quota.html.markdown
+++ b/website/docs/r/resource_quota.html.markdown
@@ -40,8 +40,12 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the resource quota that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the resource quota. May match selectors of replication controllers and services. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `annotations` - (Optional) An unstructured key value map stored with the resource quota that may be used to store arbitrary metadata. 
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the resource quota. May match selectors of replication controllers and services. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the resource quota, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the resource quota must be unique.
 

--- a/website/docs/r/role.html.markdown
+++ b/website/docs/r/role.html.markdown
@@ -49,9 +49,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the role that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `annotations` - (Optional) An unstructured key value map stored with the role that may be used to store arbitrary metadata.
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the role. **Must match `selector`**. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the role. **Must match `selector`**.
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the role, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the role must be unique.
 

--- a/website/docs/r/role_binding.html.markdown
+++ b/website/docs/r/role_binding.html.markdown
@@ -56,9 +56,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the role binding that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `annotations` - (Optional) An unstructured key value map stored with the role binding that may be used to store arbitrary metadata. 
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the role binding. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the role binding. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the role binding, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the role binding must be unique.
 

--- a/website/docs/r/secret.html.markdown
+++ b/website/docs/r/secret.html.markdown
@@ -63,9 +63,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the secret that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `annotations` - (Optional) An unstructured key value map stored with the secret that may be used to store arbitrary metadata.
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the secret. May match selectors of replication controllers and services. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the secret. May match selectors of replication controllers and services.
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the secret, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the secret must be unique.
 

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -62,9 +62,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the service that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `annotations` - (Optional) An unstructured key value map stored with the service that may be used to store arbitrary metadata.
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the service. May match selectors of replication controllers and services. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the service. May match selectors of replication controllers and services. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the service, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the service must be unique.
 

--- a/website/docs/r/service_account.html.markdown
+++ b/website/docs/r/service_account.html.markdown
@@ -46,9 +46,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the service account that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `annotations` - (Optional) An unstructured key value map stored with the service account that may be used to store arbitrary metadata. 
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the service account. May match selectors of replication controllers and services. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the service account. May match selectors of replication controllers and services. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the service account, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the service account must be unique.
 

--- a/website/docs/r/stateful_set.html.markdown
+++ b/website/docs/r/stateful_set.html.markdown
@@ -221,9 +221,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the stateful set that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `annotations` - (Optional) An unstructured key value map stored with the stateful set that may be used to store arbitrary metadata. 
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the stateful set. **Must match `selector`**. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the stateful set. **Must match `selector`**. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the stateful set, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the stateful set must be unique.
 

--- a/website/docs/r/storage_class.html.markdown
+++ b/website/docs/r/storage_class.html.markdown
@@ -44,9 +44,13 @@ The following arguments are supported:
 
 #### Arguments
 
-* `annotations` - (Optional) An unstructured key value map stored with the storage class that may be used to store arbitrary metadata. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `annotations` - (Optional) An unstructured key value map stored with the storage class that may be used to store arbitrary metadata. 
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
 * `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#idempotency)
-* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the storage class. May match selectors of replication controllers and services. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the storage class. May match selectors of replication controllers and services. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the storage class, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 
 #### Attributes


### PR DESCRIPTION
This PR is an alternative to #244 that closes #199 and closes #200. It is mostly a cherry picking of the strategy used in the fork of @sl1pm4t with a few small updates from me to catch up with the recent changes. I'm hoping it is okay to submit his code, and given that it follows the same licensing, should be mergeable.

At a high level, instead of having the user actively manage a whitelist as #244 does, this instead "automatically whitelists" any annotations/labels that the user is actively stating that they want to manage by its presence in the annotations or labels metadata. To do this, flattenMetadata is passed the resource spec, from which it extracts the list of annotations that the user has specified.

Any annotations/labels added by the Kubernetes system itself with the .kubernetes.io domain are still ignored the same way as before and will not come up as false changes in the plan. If the user does try to modify the annotation/label that is actually internal and system managed, they will get the issues of either continually being asked to update the resource or Kubernetes rejecting the change; the user will learn quickly not to try to manage the annotation. With this, the user no longer has to manage the whitelist at the provider level, reducing confusion.