### PR TITLE
Pod Affinity (ported from @sl1pm4t fork)

### DIFF
--- a/kubernetes/resource_kubernetes_affinity_test.go
+++ b/kubernetes/resource_kubernetes_affinity_test.go
@@ -136,7 +136,8 @@ func TestAccKubernetesPod_with_pod_affinity_with_preferred_during_scheduling_ign
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.0.match_expressions.0.values.1996459178", "bar"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.0.match_expressions.0.values.2356372769", "foo"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.0.match_labels.%", "0"),
-					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.namespaces.#", "0"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.namespaces.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.namespaces.3814588639", "default"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.topology_key", "kubernetes.io/hostname"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.weight", "100"),
 				),
@@ -343,6 +344,7 @@ func testAccKubernetesPodConfigWithPodAffinityWithPreferredDuringSchedulingIgnor
 									values = ["foo", "bar"]
 								}
 							}
+              namespaces = ["default"]
 							topology_key = "kubernetes.io/hostname"
 						}
 					}

--- a/kubernetes/resource_kubernetes_affinity_test.go
+++ b/kubernetes/resource_kubernetes_affinity_test.go
@@ -1,0 +1,427 @@
+package kubernetes
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	api "k8s.io/api/core/v1"
+)
+
+func TestAccKubernetesPod_with_node_affinity_with_required_during_scheduling_ignored_during_execution(t *testing.T) {
+	var conf api.Pod
+	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := "nginx:1.7.9"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesPodDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesPodConfigWithNodeAffinityWithRequiredDuringSchedulingIgnoredDuringExecution(podName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.required_during_scheduling_ignored_during_execution.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.required_during_scheduling_ignored_during_execution.0.node_selector_term.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.required_during_scheduling_ignored_during_execution.0.node_selector_term.0.match_expressions.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.required_during_scheduling_ignored_during_execution.0.node_selector_term.0.match_expressions.0.key", "kubernetes.io/hostname"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.required_during_scheduling_ignored_during_execution.0.node_selector_term.0.match_expressions.0.operator", "NotIn"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.required_during_scheduling_ignored_during_execution.0.node_selector_term.0.match_expressions.0.values.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.required_during_scheduling_ignored_during_execution.0.node_selector_term.0.match_expressions.0.values.2356372769", "foo"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.required_during_scheduling_ignored_during_execution.0.node_selector_term.0.match_expressions.0.values.1996459178", "bar"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.required_during_scheduling_ignored_during_execution.0.node_selector_term.0.match_expressions.1.key", "beta.kubernetes.io/os"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.required_during_scheduling_ignored_during_execution.0.node_selector_term.0.match_expressions.1.operator", "In"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.required_during_scheduling_ignored_during_execution.0.node_selector_term.0.match_expressions.1.values.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.required_during_scheduling_ignored_during_execution.0.node_selector_term.0.match_expressions.1.values.2450605903", "linux"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesPod_with_node_affinity_with_preferred_during_scheduling_ignored_during_execution(t *testing.T) {
+	var conf api.Pod
+	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := "nginx:1.7.9"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesPodDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesPodConfigWithNodeAffinityWithPreferredDuringSchedulingIgnoredDuringExecution(podName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.preferred_during_scheduling_ignored_during_execution.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.preferred_during_scheduling_ignored_during_execution.0.preference.0.match_expressions.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.preferred_during_scheduling_ignored_during_execution.0.preference.0.match_expressions.0.key", "kubernetes.io/hostname"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.preferred_during_scheduling_ignored_during_execution.0.preference.0.match_expressions.0.operator", "NotIn"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.preferred_during_scheduling_ignored_during_execution.0.preference.0.match_expressions.0.values.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.preferred_during_scheduling_ignored_during_execution.0.preference.0.match_expressions.0.values.1996459178", "bar"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.preferred_during_scheduling_ignored_during_execution.0.preference.0.match_expressions.0.values.2356372769", "foo"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.preferred_during_scheduling_ignored_during_execution.0.preference.0.match_expressions.1.key", "beta.kubernetes.io/os"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.preferred_during_scheduling_ignored_during_execution.0.preference.0.match_expressions.1.operator", "In"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.preferred_during_scheduling_ignored_during_execution.0.preference.0.match_expressions.1.values.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.preferred_during_scheduling_ignored_during_execution.0.preference.0.match_expressions.1.values.2450605903", "linux"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.node_affinity.0.preferred_during_scheduling_ignored_during_execution.0.weight", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesPod_with_pod_affinity_with_required_during_scheduling_ignored_during_execution(t *testing.T) {
+	var conf api.Pod
+	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := "nginx:1.7.9"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesPodDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesPodConfigWithPodAffinityWithRequiredDuringSchedulingIgnoredDuringExecution(podName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.required_during_scheduling_ignored_during_execution.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.required_during_scheduling_ignored_during_execution.0.label_selector.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.required_during_scheduling_ignored_during_execution.0.label_selector.0.match_expressions.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.required_during_scheduling_ignored_during_execution.0.label_selector.0.match_expressions.0.key", "security"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.required_during_scheduling_ignored_during_execution.0.label_selector.0.match_expressions.0.operator", "NotIn"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.required_during_scheduling_ignored_during_execution.0.label_selector.0.match_expressions.0.values.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.required_during_scheduling_ignored_during_execution.0.label_selector.0.match_expressions.0.values.1996459178", "bar"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.required_during_scheduling_ignored_during_execution.0.label_selector.0.match_expressions.0.values.2356372769", "foo"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.required_during_scheduling_ignored_during_execution.0.label_selector.0.match_labels.%", "0"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.required_during_scheduling_ignored_during_execution.0.namespaces.#", "0"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.required_during_scheduling_ignored_during_execution.0.topology_key", "kubernetes.io/hostname"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesPod_with_pod_affinity_with_preferred_during_scheduling_ignored_during_execution(t *testing.T) {
+	var conf api.Pod
+	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := "nginx:1.7.9"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesPodDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesPodConfigWithPodAffinityWithPreferredDuringSchedulingIgnoredDuringExecution(podName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.0.match_expressions.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.0.match_expressions.0.key", "security"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.0.match_expressions.0.operator", "NotIn"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.0.match_expressions.0.values.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.0.match_expressions.0.values.1996459178", "bar"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.0.match_expressions.0.values.2356372769", "foo"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.0.match_labels.%", "0"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.namespaces.#", "0"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.topology_key", "kubernetes.io/hostname"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_affinity.0.preferred_during_scheduling_ignored_during_execution.0.weight", "100"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesPod_with_pod_anti_affinity_with_required_during_scheduling_ignored_during_execution(t *testing.T) {
+	var conf api.Pod
+	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := "nginx:1.7.9"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesPodDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesPodConfigWithPodAntiAffinityWithRequiredDuringSchedulingIgnoredDuringExecution(podName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.required_during_scheduling_ignored_during_execution.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.required_during_scheduling_ignored_during_execution.0.label_selector.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.required_during_scheduling_ignored_during_execution.0.label_selector.0.match_expressions.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.required_during_scheduling_ignored_during_execution.0.label_selector.0.match_expressions.0.key", "security"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.required_during_scheduling_ignored_during_execution.0.label_selector.0.match_expressions.0.operator", "NotIn"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.required_during_scheduling_ignored_during_execution.0.label_selector.0.match_expressions.0.values.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.required_during_scheduling_ignored_during_execution.0.label_selector.0.match_expressions.0.values.1996459178", "bar"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.required_during_scheduling_ignored_during_execution.0.label_selector.0.match_expressions.0.values.2356372769", "foo"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.required_during_scheduling_ignored_during_execution.0.label_selector.0.match_labels.%", "0"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.required_during_scheduling_ignored_during_execution.0.namespaces.#", "0"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.required_during_scheduling_ignored_during_execution.0.topology_key", "kubernetes.io/hostname"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesPod_with_pod_anti_affinity_with_preferred_during_scheduling_ignored_during_execution(t *testing.T) {
+	var conf api.Pod
+	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := "nginx:1.7.9"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesPodDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesPodConfigWithPodAntiAffinityWithPreferredDuringSchedulingIgnoredDuringExecution(podName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.preferred_during_scheduling_ignored_during_execution.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.0.match_expressions.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.0.match_expressions.0.key", "security"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.0.match_expressions.0.operator", "NotIn"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.0.match_expressions.0.values.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.0.match_expressions.0.values.1996459178", "bar"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.0.match_expressions.0.values.2356372769", "foo"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.label_selector.0.match_labels.%", "0"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.namespaces.#", "0"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.preferred_during_scheduling_ignored_during_execution.0.pod_affinity_term.0.topology_key", "kubernetes.io/hostname"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.affinity.0.pod_anti_affinity.0.preferred_during_scheduling_ignored_during_execution.0.weight", "100"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKubernetesPodConfigWithNodeAffinityWithRequiredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
+	return fmt.Sprintf(`
+	resource "kubernetes_pod" "test" {
+		metadata {
+			labels {
+				app = "pod_label"
+			}
+			name = "%s"
+		}
+		spec {
+			affinity {
+				node_affinity {
+					required_during_scheduling_ignored_during_execution {
+						node_selector_term {
+							match_expressions {
+								key = "kubernetes.io/hostname"
+								operator = "NotIn"
+								values = ["foo", "bar"]
+							}
+							match_expressions {
+								key = "beta.kubernetes.io/os"
+								operator = "In"
+								values = ["linux"]
+							}
+						}
+					}
+				}
+			}
+			container {
+				image = "%s"
+				name  = "containername"
+			}
+		}
+	}
+		`, podName, imageName)
+}
+
+func testAccKubernetesPodConfigWithNodeAffinityWithPreferredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
+	return fmt.Sprintf(`
+	resource "kubernetes_pod" "test" {
+		metadata {
+			labels {
+				app = "pod_label"
+			}
+			name = "%s"
+		}
+		spec {
+			affinity {
+				node_affinity {
+					preferred_during_scheduling_ignored_during_execution {
+						weight = 1
+						preference {
+							match_expressions {
+								key = "kubernetes.io/hostname"
+								operator = "NotIn"
+								values = ["foo", "bar"]
+							}
+							match_expressions {
+								key = "beta.kubernetes.io/os"
+								operator = "In"
+								values = ["linux"]
+							}
+						}
+					}
+				}
+			}
+			container {
+				image = "%s"
+				name  = "containername"
+			}
+		}
+	}
+		`, podName, imageName)
+}
+
+func testAccKubernetesPodConfigWithPodAffinityWithRequiredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
+	return fmt.Sprintf(`
+	resource "kubernetes_pod" "test" {
+		metadata {
+			labels {
+				app = "pod_label"
+			}
+			name = "%s"
+		}
+		spec {
+			affinity {
+				pod_affinity {
+					required_during_scheduling_ignored_during_execution {
+						label_selector {
+							match_expressions {
+								key = "security"
+								operator = "NotIn"
+								values = ["foo", "bar"]
+							}
+						}
+						topology_key = "kubernetes.io/hostname"
+					}
+				}
+			}
+			container {
+				image = "%s"
+				name  = "containername"
+			}
+		}
+	}
+		`, podName, imageName)
+}
+
+func testAccKubernetesPodConfigWithPodAffinityWithPreferredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
+	return fmt.Sprintf(`
+	resource "kubernetes_pod" "test" {
+		metadata {
+			labels {
+				app = "pod_label"
+			}
+			name = "%s"
+		}
+		spec {
+			affinity {
+				pod_affinity {
+					preferred_during_scheduling_ignored_during_execution {
+						weight = 100
+						pod_affinity_term {
+							label_selector {
+								match_expressions {
+									key = "security"
+									operator = "NotIn"
+									values = ["foo", "bar"]
+								}
+							}
+							topology_key = "kubernetes.io/hostname"
+						}
+					}
+				}
+			}
+			container {
+				image = "%s"
+				name  = "containername"
+			}
+		}
+	}
+		`, podName, imageName)
+}
+
+func testAccKubernetesPodConfigWithPodAntiAffinityWithRequiredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
+	return fmt.Sprintf(`
+	resource "kubernetes_pod" "test" {
+		metadata {
+			labels {
+				app = "pod_label"
+			}
+			name = "%s"
+		}
+		spec {
+			affinity {
+				pod_anti_affinity {
+					required_during_scheduling_ignored_during_execution {
+						label_selector {
+							match_expressions {
+								key = "security"
+								operator = "NotIn"
+								values = ["foo", "bar"]
+							}
+						}
+						topology_key = "kubernetes.io/hostname"
+					}
+				}
+			}
+			container {
+				image = "%s"
+				name  = "containername"
+			}
+		}
+	}
+		`, podName, imageName)
+}
+
+func testAccKubernetesPodConfigWithPodAntiAffinityWithPreferredDuringSchedulingIgnoredDuringExecution(podName, imageName string) string {
+	return fmt.Sprintf(`
+	resource "kubernetes_pod" "test" {
+		metadata {
+			labels {
+				app = "pod_label"
+			}
+			name = "%s"
+		}
+		spec {
+			affinity {
+				pod_anti_affinity {
+					preferred_during_scheduling_ignored_during_execution {
+						weight = 100
+						pod_affinity_term {
+							label_selector {
+								match_expressions {
+									key = "security"
+									operator = "NotIn"
+									values = ["foo", "bar"]
+								}
+							}
+							topology_key = "kubernetes.io/hostname"
+						}
+					}
+				}
+			}
+			container {
+				image = "%s"
+				name  = "containername"
+			}
+		}
+	}
+		`, podName, imageName)
+}

--- a/kubernetes/resource_kubernetes_affinity_test.go
+++ b/kubernetes/resource_kubernetes_affinity_test.go
@@ -218,7 +218,7 @@ func testAccKubernetesPodConfigWithNodeAffinityWithRequiredDuringSchedulingIgnor
 	return fmt.Sprintf(`
 	resource "kubernetes_pod" "test" {
 		metadata {
-			labels {
+			labels = {
 				app = "pod_label"
 			}
 			name = "%s"

--- a/kubernetes/resource_kubernetes_affinity_test.go
+++ b/kubernetes/resource_kubernetes_affinity_test.go
@@ -255,7 +255,7 @@ func testAccKubernetesPodConfigWithNodeAffinityWithPreferredDuringSchedulingIgno
 	return fmt.Sprintf(`
 	resource "kubernetes_pod" "test" {
 		metadata {
-			labels {
+			labels = {
 				app = "pod_label"
 			}
 			name = "%s"
@@ -293,7 +293,7 @@ func testAccKubernetesPodConfigWithPodAffinityWithRequiredDuringSchedulingIgnore
 	return fmt.Sprintf(`
 	resource "kubernetes_pod" "test" {
 		metadata {
-			labels {
+			labels = {
 				app = "pod_label"
 			}
 			name = "%s"
@@ -326,7 +326,7 @@ func testAccKubernetesPodConfigWithPodAffinityWithPreferredDuringSchedulingIgnor
 	return fmt.Sprintf(`
 	resource "kubernetes_pod" "test" {
 		metadata {
-			labels {
+			labels = {
 				app = "pod_label"
 			}
 			name = "%s"
@@ -363,7 +363,7 @@ func testAccKubernetesPodConfigWithPodAntiAffinityWithRequiredDuringSchedulingIg
 	return fmt.Sprintf(`
 	resource "kubernetes_pod" "test" {
 		metadata {
-			labels {
+			labels = {
 				app = "pod_label"
 			}
 			name = "%s"
@@ -396,7 +396,7 @@ func testAccKubernetesPodConfigWithPodAntiAffinityWithPreferredDuringSchedulingI
 	return fmt.Sprintf(`
 	resource "kubernetes_pod" "test" {
 		metadata {
-			labels {
+			labels = {
 				app = "pod_label"
 			}
 			name = "%s"

--- a/kubernetes/schema_affinity_spec.go
+++ b/kubernetes/schema_affinity_spec.go
@@ -1,0 +1,185 @@
+package kubernetes
+
+import "github.com/hashicorp/terraform/helper/schema"
+
+func affinityFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"node_affinity": {
+			Type:        schema.TypeList,
+			Description: "Node affinity scheduling rules for the pod.",
+			Optional:    true,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: nodeAffinityFields(),
+			},
+		},
+		"pod_affinity": {
+			Type:        schema.TypeList,
+			Description: "Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.)",
+			Optional:    true,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: podAffinityFields(),
+			},
+		},
+		"pod_anti_affinity": {
+			Type:        schema.TypeList,
+			Description: "Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.)",
+			Optional:    true,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: podAffinityFields(),
+			},
+		},
+	}
+}
+
+func nodeAffinityFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"required_during_scheduling_ignored_during_execution": {
+			Type:        schema.TypeList,
+			Description: "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a node label update), the system may or may not try to eventually evict the pod from its node.",
+			Optional:    true,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: nodeSelectorFields(),
+			},
+		},
+		"preferred_during_scheduling_ignored_during_execution": {
+			Type:        schema.TypeList,
+			Description: "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred.",
+			Optional:    true,
+			Elem: &schema.Resource{
+				Schema: preferredSchedulingTermFields(),
+			},
+		},
+	}
+}
+
+func nodeSelectorFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"node_selector_term": {
+			Type:        schema.TypeList,
+			Description: "List of node selector terms. The terms are ORed.",
+			Optional:    true,
+			Elem: &schema.Resource{
+				Schema: nodeSelectorRequirementsFields(),
+			},
+		},
+	}
+}
+
+func preferredSchedulingTermFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"weight": {
+			Type:        schema.TypeInt,
+			Description: "weight is in the range 1-100",
+			Required:    true,
+		},
+		"preference": {
+			Type:        schema.TypeList,
+			Description: "A node selector term, associated with the corresponding weight.",
+			Required:    true,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: nodeSelectorRequirementsFields(),
+			},
+		},
+	}
+}
+
+func nodeSelectorRequirementsFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"match_expressions": {
+			Type:        schema.TypeList,
+			Description: "List of node selector requirements. The requirements are ANDed.",
+			Optional:    true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"key": {
+						Type:        schema.TypeString,
+						Description: "The label key that the selector applies to.",
+						Optional:    true,
+					},
+					"operator": {
+						Type:        schema.TypeString,
+						Description: "Operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+						Optional:    true,
+					},
+					"values": {
+						Type:        schema.TypeSet,
+						Description: "Values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+						Optional:    true,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						Set:         schema.HashString,
+					},
+				},
+			},
+		},
+	}
+}
+
+func podAffinityFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"required_during_scheduling_ignored_during_execution": {
+			Type:        schema.TypeList,
+			Description: "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each PodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+			Optional:    true,
+			Elem: &schema.Resource{
+				Schema: podAffinityTermFields(),
+			},
+		},
+		"preferred_during_scheduling_ignored_during_execution": {
+			Type:        schema.TypeList,
+			Description: "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, RequiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding 'weight' to the sum if the node matches the corresponding MatchExpressions; the node(s) with the highest sum are the most preferred.",
+			Optional:    true,
+			Elem: &schema.Resource{
+				Schema: weightedPodAffinityTermFields(),
+			},
+		},
+	}
+}
+
+func podAffinityTermFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"label_selector": {
+			Type:        schema.TypeList,
+			Description: "A label query over a set of resources, in this case pods.",
+			Optional:    true,
+			Elem: &schema.Resource{
+				Schema: labelSelectorFields(),
+			},
+		},
+		"namespaces": {
+			Type:        schema.TypeSet,
+			Description: "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means 'this pod's namespace'",
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Set:         schema.HashString,
+		},
+		"topology_key": {
+			Type:        schema.TypeString,
+			Description: "empty topology key is interpreted by the scheduler as 'all topologies'",
+			Optional:    true,
+		},
+	}
+}
+
+func weightedPodAffinityTermFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"weight": {
+			Type:        schema.TypeInt,
+			Description: "weight associated with matching the corresponding podAffinityTerm, in the range 1-100",
+			Required:    true,
+		},
+		"pod_affinity_term": {
+			Type:        schema.TypeList,
+			Description: "A pod affinity term, associated with the corresponding weight",
+			Required:    true,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: podAffinityTermFields(),
+			},
+		},
+	}
+}

--- a/kubernetes/schema_affinity_spec.go
+++ b/kubernetes/schema_affinity_spec.go
@@ -1,6 +1,11 @@
 package kubernetes
 
-import "github.com/hashicorp/terraform/helper/schema"
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
 
 func affinityFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
@@ -102,9 +107,10 @@ func nodeSelectorRequirementsFields() map[string]*schema.Schema {
 						Optional:    true,
 					},
 					"operator": {
-						Type:        schema.TypeString,
-						Description: "Operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
-						Optional:    true,
+						Type:         schema.TypeString,
+						Description:  "Operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+						Optional:     true,
+						ValidateFunc: validation.StringInSlice([]string{"In", "NotIn", "Exists", "DoesNotExist", "Gt", "Lt"}, false),
 					},
 					"values": {
 						Type:        schema.TypeSet,
@@ -158,9 +164,10 @@ func podAffinityTermFields() map[string]*schema.Schema {
 			Set:         schema.HashString,
 		},
 		"topology_key": {
-			Type:        schema.TypeString,
-			Description: "empty topology key is interpreted by the scheduler as 'all topologies'",
-			Optional:    true,
+			Type:         schema.TypeString,
+			Description:  "empty topology key is interpreted by the scheduler as 'all topologies'",
+			Optional:     true,
+			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^.+$`), "value cannot be empty"),
 		},
 	}
 }

--- a/kubernetes/schema_affinity_spec.go
+++ b/kubernetes/schema_affinity_spec.go
@@ -147,7 +147,7 @@ func podAffinityTermFields() map[string]*schema.Schema {
 			Description: "A label query over a set of resources, in this case pods.",
 			Optional:    true,
 			Elem: &schema.Resource{
-				Schema: labelSelectorFields(),
+				Schema: labelSelectorFields(false),
 			},
 		},
 		"namespaces": {

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -11,6 +11,15 @@ func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schem
 		deprecatedMessage = "This field is deprecated because template was incorrectly defined as a PodSpec preventing the definition of metadata. Please use the one under the spec field"
 	}
 	s := map[string]*schema.Schema{
+		"affinity": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Optional pod scheduling constraints.",
+			Elem: &schema.Resource{
+				Schema: affinityFields(),
+			},
+		},
 		"active_deadline_seconds": {
 			Type:         schema.TypeInt,
 			Optional:     true,

--- a/kubernetes/structure_persistent_volume_spec.go
+++ b/kubernetes/structure_persistent_volume_spec.go
@@ -1506,7 +1506,7 @@ func patchPersistentVolumeSource(pathPrefix, prefix string, d *schema.ResourceDa
 func flattenVolumeNodeAffinity(in *v1.VolumeNodeAffinity) []interface{} {
 	att := make(map[string]interface{})
 	nodeSelector := map[string]interface{}{
-		"node_selector_term": flattenNodeSelectorTerm(in.Required.NodeSelectorTerms[0]),
+		"node_selector_term": flattenNodeSelectorTerms(in.Required.NodeSelectorTerms),
 	}
 	att["required"] = []interface{}{nodeSelector}
 	return []interface{}{att}
@@ -1529,7 +1529,7 @@ func expandVolumeNodeAffinity(l []interface{}) *v1.VolumeNodeAffinity {
 	}
 	obj := &v1.VolumeNodeAffinity{
 		Required: &v1.NodeSelector{
-			NodeSelectorTerms: []v1.NodeSelectorTerm{expandNodeSelectorTerm(nodeSelector["node_selector_term"].([]interface{}))},
+			NodeSelectorTerms: expandNodeSelectorTerms(nodeSelector["node_selector_term"].([]interface{})),
 		},
 	}
 	return obj

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -543,9 +543,9 @@ func flattenNodeSelectorTerm(in api.NodeSelectorTerm) []interface{} {
 	return []interface{}{att}
 }
 
-func expandNodeSelectorTerm(l []interface{}) api.NodeSelectorTerm {
+func expandNodeSelectorTerm(l []interface{}) *api.NodeSelectorTerm {
 	if len(l) == 0 || l[0] == nil {
-		return api.NodeSelectorTerm{}
+		return &api.NodeSelectorTerm{}
 	}
 	in := l[0].(map[string]interface{})
 	obj := api.NodeSelectorTerm{}
@@ -554,6 +554,25 @@ func expandNodeSelectorTerm(l []interface{}) api.NodeSelectorTerm {
 	}
 	if v, ok := in["match_fields"].([]interface{}); ok && len(v) > 0 {
 		obj.MatchFields = expandNodeSelectorRequirementList(v)
+	}
+	return &obj
+}
+
+func flattenNodeSelectorTerms(in []api.NodeSelectorTerm) []interface{} {
+	att := make([]interface{}, len(in), len(in))
+	for i, n := range in {
+		att[i] = flattenNodeSelectorTerm(n)[0]
+	}
+	return att
+}
+
+func expandNodeSelectorTerms(l []interface{}) []api.NodeSelectorTerm {
+	if len(l) == 0 || l[0] == nil {
+		return []api.NodeSelectorTerm{}
+	}
+	obj := make([]api.NodeSelectorTerm, len(l), len(l))
+	for i, n := range l {
+		obj[i] = *expandNodeSelectorTerm([]interface{}{n})
 	}
 	return obj
 }

--- a/kubernetes/structures_affinity.go
+++ b/kubernetes/structures_affinity.go
@@ -1,0 +1,319 @@
+package kubernetes
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"k8s.io/api/core/v1"
+)
+
+// Flatteners
+
+func flattenAffinity(in *v1.Affinity) []interface{} {
+	att := make(map[string]interface{})
+	if in.NodeAffinity != nil {
+		att["node_affinity"] = flattenNodeAffinity(in.NodeAffinity)
+	}
+	if in.PodAffinity != nil {
+		att["pod_affinity"] = flattenPodAffinity(in.PodAffinity)
+	}
+	if in.PodAntiAffinity != nil {
+		att["pod_anti_affinity"] = flattenPodAntiAffinity(in.PodAntiAffinity)
+	}
+	if len(att) > 0 {
+		return []interface{}{att}
+	}
+	return []interface{}{}
+}
+
+func flattenNodeAffinity(in *v1.NodeAffinity) []interface{} {
+	att := make(map[string]interface{})
+	if in.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		att["required_during_scheduling_ignored_during_execution"] = flattenNodeSelector(in.RequiredDuringSchedulingIgnoredDuringExecution)
+	}
+	if in.PreferredDuringSchedulingIgnoredDuringExecution != nil {
+		att["preferred_during_scheduling_ignored_during_execution"] = flattenPreferredSchedulingTerm(in.PreferredDuringSchedulingIgnoredDuringExecution)
+	}
+	if len(att) > 0 {
+		return []interface{}{att}
+	}
+	return []interface{}{}
+}
+
+func flattenPodAffinity(in *v1.PodAffinity) []interface{} {
+	att := make(map[string]interface{})
+	if len(in.RequiredDuringSchedulingIgnoredDuringExecution) > 0 {
+		att["required_during_scheduling_ignored_during_execution"] = flattenPodAffinityTerms(in.RequiredDuringSchedulingIgnoredDuringExecution)
+	}
+	if len(in.PreferredDuringSchedulingIgnoredDuringExecution) > 0 {
+		att["preferred_during_scheduling_ignored_during_execution"] = flattenWeightedPodAffinityTerms(in.PreferredDuringSchedulingIgnoredDuringExecution)
+	}
+	if len(att) > 0 {
+		return []interface{}{att}
+	}
+	return []interface{}{}
+}
+
+func flattenPodAntiAffinity(in *v1.PodAntiAffinity) []interface{} {
+	att := make(map[string]interface{})
+	if len(in.RequiredDuringSchedulingIgnoredDuringExecution) > 0 {
+		att["required_during_scheduling_ignored_during_execution"] = flattenPodAffinityTerms(in.RequiredDuringSchedulingIgnoredDuringExecution)
+	}
+	if len(in.PreferredDuringSchedulingIgnoredDuringExecution) > 0 {
+		att["preferred_during_scheduling_ignored_during_execution"] = flattenWeightedPodAffinityTerms(in.PreferredDuringSchedulingIgnoredDuringExecution)
+	}
+	if len(att) > 0 {
+		return []interface{}{att}
+	}
+	return []interface{}{}
+}
+
+func flattenWeightedPodAffinityTerms(in []v1.WeightedPodAffinityTerm) []interface{} {
+	att := make([]interface{}, len(in), len(in))
+	for i, n := range in {
+		m := make(map[string]interface{})
+		m["weight"] = int(n.Weight)
+		m["pod_affinity_term"] = flattenPodAffinityTerms([]v1.PodAffinityTerm{n.PodAffinityTerm})
+		att[i] = m
+	}
+	return att
+}
+
+func flattenPodAffinityTerms(in []v1.PodAffinityTerm) []interface{} {
+	att := make([]interface{}, len(in), len(in))
+	for i, n := range in {
+		m := make(map[string]interface{})
+		m["topology_key"] = n.TopologyKey
+		if n.LabelSelector != nil {
+			m["label_selector"] = flattenLabelSelector(n.LabelSelector)
+		}
+		att[i] = m
+	}
+	return att
+}
+
+func flattenNodeSelector(in *v1.NodeSelector) []interface{} {
+	att := make(map[string]interface{})
+	if len(in.NodeSelectorTerms) > 0 {
+		att["node_selector_term"] = flattenNodeSelectorTerms(in.NodeSelectorTerms)
+	}
+	if len(att) > 0 {
+		return []interface{}{att}
+	}
+	return []interface{}{}
+}
+
+func flattenNodeSelectorTerms(in []v1.NodeSelectorTerm) []interface{} {
+	att := make([]interface{}, len(in), len(in))
+	for i, n := range in {
+		m := make(map[string]interface{})
+		if len(n.MatchExpressions) > 0 {
+			m["match_expressions"] = flattenNodeSelectorRequirements(n.MatchExpressions)
+		}
+		att[i] = m
+	}
+	return att
+}
+
+func flattenNodeSelectorRequirements(in []v1.NodeSelectorRequirement) []interface{} {
+	att := make([]interface{}, len(in), len(in))
+	for i, n := range in {
+		m := make(map[string]interface{})
+		m["key"] = n.Key
+		m["operator"] = n.Operator
+		m["values"] = newStringSet(schema.HashString, n.Values)
+		att[i] = m
+	}
+	return att
+}
+
+func flattenPreferredSchedulingTerm(in []v1.PreferredSchedulingTerm) []interface{} {
+	att := make([]interface{}, len(in), len(in))
+	for i, n := range in {
+		m := make(map[string]interface{})
+		m["weight"] = int(n.Weight)
+		m["preference"] = flattenNodeSelectorTerm(n.Preference)
+		att[i] = m
+	}
+	return att
+}
+
+func flattenNodeSelectorTerm(in v1.NodeSelectorTerm) []interface{} {
+	if len(in.MatchExpressions) > 0 {
+		m := make(map[string]interface{})
+		m["match_expressions"] = flattenNodeSelectorRequirements(in.MatchExpressions)
+		return []interface{}{m}
+	}
+	return []interface{}{}
+}
+
+// Expanders
+
+func expandAffinity(a []interface{}) (*v1.Affinity, error) {
+	if len(a) == 0 || a[0] == nil {
+		return &v1.Affinity{}, nil
+	}
+	in := a[0].(map[string]interface{})
+	obj := v1.Affinity{}
+	if v, ok := in["node_affinity"].([]interface{}); ok && len(v) > 0 {
+		obj.NodeAffinity = expandNodeAffinity(v)
+	}
+	if v, ok := in["pod_affinity"].([]interface{}); ok && len(v) > 0 {
+		obj.PodAffinity = expandPodAffinity(v)
+	}
+	if v, ok := in["pod_anti_affinity"].([]interface{}); ok && len(v) > 0 {
+		obj.PodAntiAffinity = expandPodAntiAffinity(v)
+	}
+	return &obj, nil
+}
+
+func expandNodeAffinity(a []interface{}) *v1.NodeAffinity {
+	if len(a) == 0 || a[0] == nil {
+		return &v1.NodeAffinity{}
+	}
+	in := a[0].(map[string]interface{})
+	obj := v1.NodeAffinity{}
+	if v, ok := in["required_during_scheduling_ignored_during_execution"].([]interface{}); ok && len(v) > 0 {
+		obj.RequiredDuringSchedulingIgnoredDuringExecution = expandNodeSelector(v)
+	}
+	if v, ok := in["preferred_during_scheduling_ignored_during_execution"].([]interface{}); ok && len(v) > 0 {
+		obj.PreferredDuringSchedulingIgnoredDuringExecution = expandPreferredSchedulingTerms(v)
+	}
+	return &obj
+}
+
+func expandPodAffinity(a []interface{}) *v1.PodAffinity {
+	if len(a) == 0 || a[0] == nil {
+		return &v1.PodAffinity{}
+	}
+	in := a[0].(map[string]interface{})
+	obj := v1.PodAffinity{}
+	if v, ok := in["required_during_scheduling_ignored_during_execution"].([]interface{}); ok && len(v) > 0 {
+		obj.RequiredDuringSchedulingIgnoredDuringExecution = expandPodAffinityTerms(v)
+	}
+	if v, ok := in["preferred_during_scheduling_ignored_during_execution"].([]interface{}); ok && len(v) > 0 {
+		obj.PreferredDuringSchedulingIgnoredDuringExecution = expandWeightedPodAffinityTerms(v)
+	}
+	return &obj
+}
+
+func expandPodAntiAffinity(a []interface{}) *v1.PodAntiAffinity {
+	if len(a) == 0 || a[0] == nil {
+		return &v1.PodAntiAffinity{}
+	}
+	in := a[0].(map[string]interface{})
+	obj := v1.PodAntiAffinity{}
+	if v, ok := in["required_during_scheduling_ignored_during_execution"].([]interface{}); ok && len(v) > 0 {
+		obj.RequiredDuringSchedulingIgnoredDuringExecution = expandPodAffinityTerms(v)
+	}
+	if v, ok := in["preferred_during_scheduling_ignored_during_execution"].([]interface{}); ok && len(v) > 0 {
+		obj.PreferredDuringSchedulingIgnoredDuringExecution = expandWeightedPodAffinityTerms(v)
+	}
+	return &obj
+}
+
+func expandPreferredSchedulingTerms(t []interface{}) []v1.PreferredSchedulingTerm {
+	if len(t) == 0 || t[0] == nil {
+		return []v1.PreferredSchedulingTerm{}
+	}
+	obj := make([]v1.PreferredSchedulingTerm, len(t), len(t))
+	for i, n := range t {
+		in := n.(map[string]interface{})
+		if v, ok := in["weight"].(int); ok {
+			obj[i].Weight = int32(v)
+		}
+		if v, ok := in["preference"].([]interface{}); ok && len(v) > 0 {
+			obj[i].Preference = expandNodeSelectorTerm(v)
+		}
+	}
+	return obj
+}
+
+func expandNodeSelectorTerm(t []interface{}) v1.NodeSelectorTerm {
+	if len(t) == 0 || t[0] == nil {
+		return v1.NodeSelectorTerm{}
+	}
+	in := t[0].(map[string]interface{})
+	obj := v1.NodeSelectorTerm{}
+	if v, ok := in["match_expressions"].([]interface{}); ok && len(v) > 0 {
+		obj.MatchExpressions = expandNodeSelectorRequirements(v)
+	}
+	return obj
+}
+
+func expandNodeSelector(s []interface{}) *v1.NodeSelector {
+	if len(s) == 0 || s[0] == nil {
+		return &v1.NodeSelector{}
+	}
+	in := s[0].(map[string]interface{})
+	obj := v1.NodeSelector{}
+	if v, ok := in["node_selector_term"].([]interface{}); ok && len(v) > 0 {
+		obj.NodeSelectorTerms = expandNodeSelectorTerms(v)
+	}
+	return &obj
+}
+
+func expandNodeSelectorTerms(t []interface{}) []v1.NodeSelectorTerm {
+	if len(t) == 0 || t[0] == nil {
+		return []v1.NodeSelectorTerm{}
+	}
+	obj := make([]v1.NodeSelectorTerm, len(t), len(t))
+	for i, n := range t {
+		in := n.(map[string]interface{})
+		if v, ok := in["match_expressions"].([]interface{}); ok && len(v) > 0 {
+			obj[i].MatchExpressions = expandNodeSelectorRequirements(v)
+		}
+	}
+	return obj
+}
+
+func expandNodeSelectorRequirements(r []interface{}) []v1.NodeSelectorRequirement {
+	if len(r) == 0 || r[0] == nil {
+		return []v1.NodeSelectorRequirement{}
+	}
+	obj := make([]v1.NodeSelectorRequirement, len(r), len(r))
+	for i, n := range r {
+		in := n.(map[string]interface{})
+		obj[i] = v1.NodeSelectorRequirement{
+			Key:      in["key"].(string),
+			Operator: v1.NodeSelectorOperator(in["operator"].(string)),
+			Values:   sliceOfString(in["values"].(*schema.Set).List()),
+		}
+	}
+	return obj
+}
+
+func expandPodAffinityTerms(t []interface{}) []v1.PodAffinityTerm {
+	if len(t) == 0 || t[0] == nil {
+		return []v1.PodAffinityTerm{}
+	}
+	obj := make([]v1.PodAffinityTerm, len(t), len(t))
+	for i, n := range t {
+		in := n.(map[string]interface{})
+		if v, ok := in["label_selector"].([]interface{}); ok && len(v) > 0 {
+			obj[i].LabelSelector = expandLabelSelector(v)
+		}
+		if v, ok := in["namespaces"].(*schema.Set); ok {
+			obj[i].Namespaces = sliceOfString(v.List())
+		}
+		if v, ok := in["topology_key"].(string); ok {
+			obj[i].TopologyKey = v
+		}
+	}
+	return obj
+}
+
+func expandWeightedPodAffinityTerms(t []interface{}) []v1.WeightedPodAffinityTerm {
+	if len(t) == 0 || t[0] == nil {
+		return []v1.WeightedPodAffinityTerm{}
+	}
+	obj := make([]v1.WeightedPodAffinityTerm, len(t), len(t))
+	for i, n := range t {
+		in := n.(map[string]interface{})
+		if v, ok := in["weight"].(int); ok {
+			obj[i].Weight = int32(v)
+		}
+		if v, ok := in["pod_affinity_term"].([]interface{}); ok && len(v) > 0 {
+			obj[i].PodAffinityTerm = expandPodAffinityTerms(v)[0]
+		}
+	}
+	return obj
+}

--- a/kubernetes/structures_affinity.go
+++ b/kubernetes/structures_affinity.go
@@ -81,6 +81,7 @@ func flattenPodAffinityTerms(in []v1.PodAffinityTerm) []interface{} {
 	att := make([]interface{}, len(in), len(in))
 	for i, n := range in {
 		m := make(map[string]interface{})
+		m["namespaces"] = newStringSet(schema.HashString, n.Namespaces)
 		m["topology_key"] = n.TopologyKey
 		if n.LabelSelector != nil {
 			m["label_selector"] = flattenLabelSelector(n.LabelSelector)

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -16,6 +16,10 @@ func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
 		att["active_deadline_seconds"] = *in.ActiveDeadlineSeconds
 	}
 
+	if in.Affinity != nil {
+		att["affinity"] = flattenAffinity(in.Affinity)
+	}
+
 	containers, err := flattenContainers(in.Containers)
 	if err != nil {
 		return nil, err
@@ -375,6 +379,14 @@ func expandPodSpec(p []interface{}) (*v1.PodSpec, error) {
 
 	if v, ok := in["active_deadline_seconds"].(int); ok && v > 0 {
 		obj.ActiveDeadlineSeconds = ptrToInt64(int64(v))
+	}
+
+	if v, ok := in["affinity"].([]interface{}); ok && len(v) > 0 {
+		a, err := expandAffinity(v)
+		if err != nil {
+			return obj, err
+		}
+		obj.Affinity = a
 	}
 
 	if v, ok := in["container"].([]interface{}); ok && len(v) > 0 {

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -164,11 +164,16 @@ The following arguments are supported:
 
 ## `node_selector_term`
 
+#### Arguments
+
+
 * `match_expressions` - (Optional) A list of node selector requirements by node's labels.
 
 * `match_fields` - (Optional) A list of node selector requirements by node's fields.
 
 ### `match_expressions` / `match_fields`
+
+#### Arguments
 
 * `key` - (Required) The label key that the selector applies to.
 
@@ -218,15 +223,17 @@ The following arguments are supported:
 
 * `preferred_during_scheduling_ignored_during_execution` - (Optional) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.
 
-### `required_during_scheduling_ignored_during_execution`
+### `required_during_scheduling_ignored_during_execution` (pod_affinity_term)
 
-#### Arguments (pod_affinity_term)
+#### Arguments
 
 * `label_selector` - (Optional) A label query over a set of resources, in this case pods.
 * `namespaces` - (Optional) Specifies which namespaces the `label_selector` applies to (matches against). Null or empty list means "this pod's namespace"
 * `topology_key` - (Optional) This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the `label_selector` in the specified namespaces, where co-located is defined as running on a node whose value of the label with key `topology_key` matches that of any node on which any of the selected pods is running. Empty `topology_key` is not allowed.
 
 ### `preferred_during_scheduling_ignored_during_execution`
+
+#### Arguments
 
 * `pod_affinity_term` - (Required) A pod affinity term, associated with the corresponding weight.
 * `weight` - (Required) Weight associated with matching the corresponding `pod_affinity_term`, in the range 1-100.

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -119,6 +119,7 @@ The following arguments are supported:
 
 #### Arguments
 
+* `affinity` - (Optional) A group of affinity scheduling rules. If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
 * `active_deadline_seconds` - (Optional) Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
 * `container` - (Optional) List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/containers)
 * `init_container` - (Optional) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers)/
@@ -138,6 +139,97 @@ The following arguments are supported:
 * `subdomain` - (Optional) If specified, the fully qualified Pod hostname will be "...svc.". If not specified, the pod will not have a domainname at all..
 * `termination_grace_period_seconds` - (Optional) Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.
 * `volume` - (Optional) List of volumes that can be mounted by containers belonging to the pod. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes)
+
+### `affinity`
+
+#### Arguments
+
+* `node_affinity` - (Optional) Node affinity scheduling rules for the pod. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature)
+* `pod_affinity` - (Optional) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature)
+* `pod_anti_affinity` - (Optional) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature)
+
+### `node_affinity`
+
+#### Arguments
+
+* `required_during_scheduling_ignored_during_execution` - (Optional) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+
+* `preferred_during_scheduling_ignored_during_execution` - (Optional) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.
+
+### `required_during_scheduling_ignored_during_execution`
+
+#### Arguments
+
+* `node_selector_term` - (Required) A list of node selector terms. The terms are ORed.
+
+## `node_selector_term`
+
+* `match_expressions` - (Optional) A list of node selector requirements by node's labels.
+
+* `match_fields` - (Optional) A list of node selector requirements by node's fields.
+
+### `match_expressions` / `match_fields`
+
+* `key` - (Required) The label key that the selector applies to.
+
+* `operator` - (Required) Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+* `values` - (Optional) An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer.
+
+### `preferred_during_scheduling_ignored_during_execution`
+
+#### Arguments
+
+* `preference` - (Required) A node selector term, associated with the corresponding weight.
+
+* `weight` - (Required) Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+
+### `preference`
+
+#### Arguments
+
+* `match_expressions` - (Optional) A list of node selector requirements by node's labels.
+
+* `match_fields` - (Optional) A list of node selector requirements by node's fields.
+
+## `match_expressions` / `match_fields`
+
+#### Arguments
+
+* `key` - (Required) The label key that the selector applies to.
+
+* `operator` - (Required) Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+* `values` - (Optional) An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer.
+
+### `pod_affinity`
+
+#### Arguments
+
+* `required_during_scheduling_ignored_during_execution` - (Optional) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node.
+
+* `preferred_during_scheduling_ignored_during_execution` - (Optional) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.
+
+### `pod_anti_affinity`
+
+#### Arguments
+
+* `required_during_scheduling_ignored_during_execution` - (Optional) If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. 
+
+* `preferred_during_scheduling_ignored_during_execution` - (Optional) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.
+
+### `required_during_scheduling_ignored_during_execution`
+
+#### Arguments (pod_affinity_term)
+
+* `label_selector` - (Optional) A label query over a set of resources, in this case pods.
+* `namespaces` - (Optional) Specifies which namespaces the `label_selector` applies to (matches against). Null or empty list means "this pod's namespace"
+* `topology_key` - (Optional) This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the `label_selector` in the specified namespaces, where co-located is defined as running on a node whose value of the label with key `topology_key` matches that of any node on which any of the selected pods is running. Empty `topology_key` is not allowed.
+
+### `preferred_during_scheduling_ignored_during_execution`
+
+* `pod_affinity_term` - (Required) A pod affinity term, associated with the corresponding weight.
+* `weight` - (Required) Weight associated with matching the corresponding `pod_affinity_term`, in the range 1-100.
 
 ### `container`
 

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -169,11 +169,15 @@ The following arguments are supported:
 
 ## `node_selector_term`
 
+#### Arguments
+
 * `match_expressions` - (Optional) A list of node selector requirements by node's labels.
 
 * `match_fields` - (Optional) A list of node selector requirements by node's fields.
 
 ### `match_expressions` / `match_fields`
+
+#### Arguments
 
 * `key` - (Required) The label key that the selector applies to.
 
@@ -223,15 +227,17 @@ The following arguments are supported:
 
 * `preferred_during_scheduling_ignored_during_execution` - (Optional) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.
 
-### `required_during_scheduling_ignored_during_execution`
+### `required_during_scheduling_ignored_during_execution` (pod_affinity_term)
 
-#### Arguments (pod_affinity_term)
+#### Arguments
 
 * `label_selector` - (Optional) A label query over a set of resources, in this case pods.
 * `namespaces` - (Optional) Specifies which namespaces the `label_selector` applies to (matches against). Null or empty list means "this pod's namespace"
 * `topology_key` - (Optional) This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the `label_selector` in the specified namespaces, where co-located is defined as running on a node whose value of the label with key `topology_key` matches that of any node on which any of the selected pods is running. Empty `topology_key` is not allowed.
 
 ### `preferred_during_scheduling_ignored_during_execution`
+
+#### Arguments
 
 * `pod_affinity_term` - (Required) A pod affinity term, associated with the corresponding weight.
 * `weight` - (Required) Weight associated with matching the corresponding `pod_affinity_term`, in the range 1-100.

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -124,6 +124,7 @@ The following arguments are supported:
 
 #### Arguments
 
+* `affinity` - (Optional) A group of affinity scheduling rules. If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
 * `active_deadline_seconds` - (Optional) Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
 * `container` - (Optional) List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/containers)
 * `init_container` - (Optional) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers)/
@@ -143,6 +144,97 @@ The following arguments are supported:
 * `subdomain` - (Optional) If specified, the fully qualified Pod hostname will be "...svc.". If not specified, the pod will not have a domainname at all..
 * `termination_grace_period_seconds` - (Optional) Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.
 * `volume` - (Optional) List of volumes that can be mounted by containers belonging to the pod. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes)
+
+### `affinity`
+
+#### Arguments
+
+* `node_affinity` - (Optional) Node affinity scheduling rules for the pod. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature)
+* `pod_affinity` - (Optional) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature)
+* `pod_anti_affinity` - (Optional) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature)
+
+### `node_affinity`
+
+#### Arguments
+
+* `required_during_scheduling_ignored_during_execution` - (Optional) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+
+* `preferred_during_scheduling_ignored_during_execution` - (Optional) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.
+
+### `required_during_scheduling_ignored_during_execution`
+
+#### Arguments
+
+* `node_selector_term` - (Required) A list of node selector terms. The terms are ORed.
+
+## `node_selector_term`
+
+* `match_expressions` - (Optional) A list of node selector requirements by node's labels.
+
+* `match_fields` - (Optional) A list of node selector requirements by node's fields.
+
+### `match_expressions` / `match_fields`
+
+* `key` - (Required) The label key that the selector applies to.
+
+* `operator` - (Required) Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+* `values` - (Optional) An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer.
+
+### `preferred_during_scheduling_ignored_during_execution`
+
+#### Arguments
+
+* `preference` - (Required) A node selector term, associated with the corresponding weight.
+
+* `weight` - (Required) Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+
+### `preference`
+
+#### Arguments
+
+* `match_expressions` - (Optional) A list of node selector requirements by node's labels.
+
+* `match_fields` - (Optional) A list of node selector requirements by node's fields.
+
+## `match_expressions` / `match_fields`
+
+#### Arguments
+
+* `key` - (Required) The label key that the selector applies to.
+
+* `operator` - (Required) Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+* `values` - (Optional) An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer.
+
+### `pod_affinity`
+
+#### Arguments
+
+* `required_during_scheduling_ignored_during_execution` - (Optional) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node.
+
+* `preferred_during_scheduling_ignored_during_execution` - (Optional) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.
+
+### `pod_anti_affinity`
+
+#### Arguments
+
+* `required_during_scheduling_ignored_during_execution` - (Optional) If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. 
+
+* `preferred_during_scheduling_ignored_during_execution` - (Optional) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.
+
+### `required_during_scheduling_ignored_during_execution`
+
+#### Arguments (pod_affinity_term)
+
+* `label_selector` - (Optional) A label query over a set of resources, in this case pods.
+* `namespaces` - (Optional) Specifies which namespaces the `label_selector` applies to (matches against). Null or empty list means "this pod's namespace"
+* `topology_key` - (Optional) This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the `label_selector` in the specified namespaces, where co-located is defined as running on a node whose value of the label with key `topology_key` matches that of any node on which any of the selected pods is running. Empty `topology_key` is not allowed.
+
+### `preferred_during_scheduling_ignored_during_execution`
+
+* `pod_affinity_term` - (Required) A pod affinity term, associated with the corresponding weight.
+* `weight` - (Required) Weight associated with matching the corresponding `pod_affinity_term`, in the range 1-100.
 
 ### `container`
 

--- a/website/docs/r/persistent_volume.html.markdown
+++ b/website/docs/r/persistent_volume.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 
 * `node_selector_terms` - (Required) A list of node selector terms. The terms are ORed.
 
-### `node_selector_terms`
+### `node_selector_term`
 
 #### Arguments
 

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -203,6 +203,89 @@ The following arguments are supported:
 * `pod_affinity` - (Optional) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature)
 * `pod_anti_affinity` - (Optional) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature)
 
+### `node_affinity`
+
+#### Arguments
+
+* `required_during_scheduling_ignored_during_execution` - (Optional) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+
+* `preferred_during_scheduling_ignored_during_execution` - (Optional) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.
+
+### `required_during_scheduling_ignored_during_execution`
+
+#### Arguments
+
+* `node_selector_term` - (Required) A list of node selector terms. The terms are ORed.
+
+## `node_selector_term`
+
+* `match_expressions` - (Optional) A list of node selector requirements by node's labels.
+
+* `match_fields` - (Optional) A list of node selector requirements by node's fields.
+
+### `match_expressions` / `match_fields`
+
+* `key` - (Required) The label key that the selector applies to.
+
+* `operator` - (Required) Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+* `values` - (Optional) An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer.
+
+### `preferred_during_scheduling_ignored_during_execution`
+
+#### Arguments
+
+* `preference` - (Required) A node selector term, associated with the corresponding weight.
+
+* `weight` - (Required) Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+
+### `preference`
+
+#### Arguments
+
+* `match_expressions` - (Optional) A list of node selector requirements by node's labels.
+
+* `match_fields` - (Optional) A list of node selector requirements by node's fields.
+
+## `match_expressions` / `match_fields`
+
+#### Arguments
+
+* `key` - (Required) The label key that the selector applies to.
+
+* `operator` - (Required)  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+* `values` - (Optional) An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer.
+
+### `pod_affinity`
+
+#### Arguments
+
+* `required_during_scheduling_ignored_during_execution` - (Optional) If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node.
+
+* `preferred_during_scheduling_ignored_during_execution` - (Optional) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.
+
+### `pod_anti_affinity`
+
+#### Arguments
+
+* `required_during_scheduling_ignored_during_execution` - (Optional) If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. 
+
+* `preferred_during_scheduling_ignored_during_execution` - (Optional) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.
+
+### `required_during_scheduling_ignored_during_execution`
+
+#### Arguments (pod_affinity_term)
+
+* `label_selector` - (Optional) A label query over a set of resources, in this case pods.
+* `namespaces` - (Optional) Specifies which namespaces the `label_selector` applies to (matches against). Null or empty list means "this pod's namespace"
+* `topology_key` - (Optional) This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the `label_selector` in the specified namespaces, where co-located is defined as running on a node whose value of the label with key `topology_key` matches that of any node on which any of the selected pods is running. Empty `topology_key` is not allowed.
+
+### `preferred_during_scheduling_ignored_during_execution`
+
+* `pod_affinity_term` - (Required) A pod affinity term, associated with the corresponding weight.
+* `weight` - (Required) Weight associated with matching the corresponding `pod_affinity_term`, in the range 1-100.
+
 ### `container`
 
 #### Arguments

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -195,6 +195,14 @@ The following arguments are supported:
 * `termination_grace_period_seconds` - (Optional) Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.
 * `volume` - (Optional) List of volumes that can be mounted by containers belonging to the pod. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/volumes)
 
+### `affinity`
+
+#### Arguments
+
+* `node_affinity` - (Optional) Node affinity scheduling rules for the pod. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature)
+* `pod_affinity` - (Optional) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature)
+* `pod_anti_affinity` - (Optional) Inter-pod topological affinity. rules that specify that certain pods should be placed in the same topological domain (e.g. same node, same rack, same zone, same power domain, etc.) For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature)
+
 ### `container`
 
 #### Arguments

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -219,11 +219,15 @@ The following arguments are supported:
 
 ## `node_selector_term`
 
+#### Arguments
+
 * `match_expressions` - (Optional) A list of node selector requirements by node's labels.
 
 * `match_fields` - (Optional) A list of node selector requirements by node's fields.
 
 ### `match_expressions` / `match_fields`
+
+#### Arguments
 
 * `key` - (Required) The label key that the selector applies to.
 
@@ -273,15 +277,17 @@ The following arguments are supported:
 
 * `preferred_during_scheduling_ignored_during_execution` - (Optional) The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.
 
-### `required_during_scheduling_ignored_during_execution`
+### `required_during_scheduling_ignored_during_execution` (pod_affinity_term)
 
-#### Arguments (pod_affinity_term)
+#### Arguments
 
 * `label_selector` - (Optional) A label query over a set of resources, in this case pods.
 * `namespaces` - (Optional) Specifies which namespaces the `label_selector` applies to (matches against). Null or empty list means "this pod's namespace"
 * `topology_key` - (Optional) This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the `label_selector` in the specified namespaces, where co-located is defined as running on a node whose value of the label with key `topology_key` matches that of any node on which any of the selected pods is running. Empty `topology_key` is not allowed.
 
 ### `preferred_during_scheduling_ignored_during_execution`
+
+#### Arguments
 
 * `pod_affinity_term` - (Required) A pod affinity term, associated with the corresponding weight.
 * `weight` - (Required) Weight associated with matching the corresponding `pod_affinity_term`, in the range 1-100.

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -80,6 +80,7 @@ The following arguments are supported:
 
 #### Arguments
 
+* `affinity` - (Optional) A group of affinity scheduling rules. If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
 * `active_deadline_seconds` - (Optional) Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
 * `container` - (Optional) List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/containers)
 * `init_container` - (Optional) List of init containers belonging to the pod. Init containers always run to completion and each must complete successfully before the next is started. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers)/

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -31,19 +31,19 @@ resource "kubernetes_pod" "test" {
       }
     }
 
-		dns_config {
-			nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
-			searches    = ["example.com"]
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
 
-			option {
-				name  = "ndots"
-				value = 1
-			}
+      option {
+        name  = "ndots"
+        value = 1
+      }
 
-			option {
-				name = "use-vc"
-			}
-		}
+      option {
+        name = "use-vc"
+      }
+    }
 
     dns_policy = "None"
   }

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -50,6 +50,100 @@ resource "kubernetes_pod" "test" {
 }
 ```
 
+terraform version of the [pods/pod-with-node-affinity.yaml](https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/pods/pod-with-node-affinity.yaml) example.
+
+```hcl
+resource "kubernetes_pod" "with_node_affinity" {
+  metadata {
+    name = "with-node-affinity"
+  }
+
+  spec {
+    affinity {
+      node_affinity {
+        required_during_scheduling_ignored_during_execution {
+          node_selector_term {
+            match_expressions {
+              key      = "kubernetes.io/e2e-az-name"
+              operator = "In"
+              values   = ["e2e-az1", "e2e-az2"]
+            }
+          }
+        }
+
+        preferred_during_scheduling_ignored_during_execution {
+          weight = 1
+
+          preference {
+            match_expressions {
+              key      = "another-node-label-key"
+              operator = "In"
+              values   = ["another-node-label-value"]
+            }
+          }
+        }
+      }
+    }
+
+    container {
+      name  = "with-node-affinity"
+      image = "k8s.gcr.io/pause:2.0"
+    }
+  }
+}
+```
+
+terraform version of the [pods/pod-with-pod-affinity.yaml](https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/pods/pod-with-pod-affinity.yaml) example.
+
+```hcl
+resource "kubernetes_pod" "with_pod_affinity" {
+  metadata {
+    name = "with-pod-affinity"
+  }
+
+  spec {
+    affinity {
+      pod_affinity {
+        required_during_scheduling_ignored_during_execution {
+          label_selector {
+            match_expressions {
+              key      = "security"
+              operator = "In"
+              values   = ["S1"]
+            }
+          }
+
+          topology_key = "failure-domain.beta.kubernetes.io/zone"
+        }
+      }
+
+      pod_anti_affinity {
+        preferred_during_scheduling_ignored_during_execution {
+          weight = 100
+
+          pod_affinity_term {
+            label_selector {
+              match_expressions {
+                key      = "security"
+                operator = "In"
+                values   = ["S2"]
+              }
+            }
+
+            topology_key = "failure-domain.beta.kubernetes.io/zone"
+          }
+        }
+      }
+    }
+
+    container {
+      name  = "with-pod-affinity"
+      image = "k8s.gcr.io/pause:2.0"
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
This branch adds support for Pod Affinity. It is mostly a cherry picking from the fork of @sl1pm4t of PRs https://github.com/sl1pm4t/terraform-provider-kubernetes/pull/68 and https://github.com/sl1pm4t/terraform-provider-kubernetes/pull/71 by @kolach. I updated the PR to match the APIs already existing in master, and to do mild refactoring to allow NodeSelectorTerm code to be reused in the 1 rare case where it is needed to be a single term instead of a list (PreferredDuringSchedulingIgnoredDuringExecution)

While here, I also updated the volume pod affinity to be able to take lists of node selector terms.