### PR TITLE
GKE test infra: base template path on module location

### DIFF
--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -48,7 +48,7 @@ resource "google_container_cluster" "primary" {
 }
 
 data "template_file" "kubeconfig" {
-  template = "${file("kubeconfig-template.yaml")}"
+  template = "${file("${path.module}/kubeconfig-template.yaml")}"
 
   vars {
     cluster_name    = "${google_container_cluster.primary.name}"


### PR DESCRIPTION
This change is needed to allow building these templates "out-of-tree".