### PR TITLE
Fix `api_group` attribute attribute of RBAC subjects.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/zclconf/go-cty v0.0.0-20181231001355-67e3da15e430 // indirect
 	golang.org/x/crypto v0.0.0-20190102171810-8d7daa0c54b3 // indirect
 	golang.org/x/net v0.0.0-20181220203305-927f97764cc3 // indirect
+	golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0 // indirect
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c // indirect
 	google.golang.org/api v0.1.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -230,6 +230,8 @@ golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e h1:o3PsSEY8E4eXWkXrIP9YJALUkVZqzHJT5DOasTyn8Vs=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0 h1:bzeyCHgoAyjZjAhvTpks+qM7sdlh4cCSitmXeCEO3B4=
+golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c h1:fqgJT0MGcGpPgpWU7VRdRjuArfcOvC4AoJmILihzhDg=

--- a/kubernetes/schema_rbac.go
+++ b/kubernetes/schema_rbac.go
@@ -2,15 +2,17 @@ package kubernetes
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func rbacRoleRefSchema(kind string) map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"api_group": {
-			Type:        schema.TypeString,
-			Description: "The API group of the user. Always `rbac.authorization.k8s.io`",
-			Required:    true,
-			Default:     "rbac.authorization.k8s.io",
+			Type:         schema.TypeString,
+			Description:  "The API group of the user. Always `rbac.authorization.k8s.io`",
+			Required:     true,
+			Default:      "rbac.authorization.k8s.io",
+			ValidateFunc: validation.StringInSlice([]string{"rbac.authorization.k8s.io"}, false),
 		},
 		"kind": {
 			Type:        schema.TypeString,
@@ -30,9 +32,9 @@ func rbacSubjectSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"api_group": {
 			Type:        schema.TypeString,
-			Description: "The API group of the user. Always `rbac.authorization.k8s.io`",
+			Description: "The API group of the subject resource.",
 			Optional:    true,
-			Default:     "rbac.authorization.k8s.io",
+			Computed:    true,
 		},
 		"kind": {
 			Type:        schema.TypeString,
@@ -46,7 +48,7 @@ func rbacSubjectSchema() map[string]*schema.Schema {
 		},
 		"namespace": {
 			Type:        schema.TypeString,
-			Description: "The Namespace of the ServiceAccount",
+			Description: "The Namespace of the subject resource.",
 			Optional:    true,
 			Default:     "default",
 		},

--- a/kubernetes/schema_rbac.go
+++ b/kubernetes/schema_rbac.go
@@ -9,9 +9,8 @@ func rbacRoleRefSchema(kind string) map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"api_group": {
 			Type:         schema.TypeString,
-			Description:  "The API group of the user. Always `rbac.authorization.k8s.io`",
+			Description:  "The API group of the user. The only value possible at the moment is `rbac.authorization.k8s.io`.",
 			Required:     true,
-			Default:      "rbac.authorization.k8s.io",
 			ValidateFunc: validation.StringInSlice([]string{"rbac.authorization.k8s.io"}, false),
 		},
 		"kind": {


### PR DESCRIPTION
This change aligns the schemas of RBAC role binding resources better to the Kubernetes specification.
With this, the provider tries harder to avoid user configuration errors that result in cryptic errors from the Kubernetes API.

According to [Kubernetes docs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding) the User and Group subject types belong to the `rbac.authorization.k8s.io`, so they need to be specified as such in subject entries. Unfortunately, Kubernetes silently "corrects" the value of `api_group` if an incorrect one is supplied, resulting in recurring Terraform diffs. Hence the change to make `api_group` computed in subjects.

On the the hand, in `role_ref` only `Role` and `ClusterRole` can be specified, both of which belong to the `rbac.authorization.k8s.io` API group. This being the only possible value is now reflected in validation.

There are three subject types possible in RBAC role bindings. This change also introduces acceptance tests to ensure all three subject types are supported as expected.

Fixes #204 #283

```
~/workspace/terraform-provider-kubernetes(fix-rbac) » TESTARGS="-run '^TestAccKubernetes(Cluster)?RoleBinding'" make testacc                                                                 alex@alexs-macbook
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run '^TestAccKubernetes(Cluster)?RoleBinding' -timeout 120m
?   	github.com/terraform-providers/terraform-provider-kubernetes	[no test files]
=== RUN   TestAccKubernetesClusterRoleBinding
--- PASS: TestAccKubernetesClusterRoleBinding (0.17s)
=== RUN   TestAccKubernetesClusterRoleBinding_serviceaccount_subject
--- PASS: TestAccKubernetesClusterRoleBinding_serviceaccount_subject (0.09s)
=== RUN   TestAccKubernetesClusterRoleBinding_group_subject
--- PASS: TestAccKubernetesClusterRoleBinding_group_subject (0.09s)
=== RUN   TestAccKubernetesClusterRoleBinding_importBasic
--- PASS: TestAccKubernetesClusterRoleBinding_importBasic (0.10s)
=== RUN   TestAccKubernetesRoleBinding_basic
--- PASS: TestAccKubernetesRoleBinding_basic (0.16s)
=== RUN   TestAccKubernetesRoleBinding_importBasic
--- PASS: TestAccKubernetesRoleBinding_importBasic (0.10s)
=== RUN   TestAccKubernetesRoleBinding_sa_subject
--- PASS: TestAccKubernetesRoleBinding_sa_subject (0.09s)
=== RUN   TestAccKubernetesRoleBinding_group_subject
--- PASS: TestAccKubernetesRoleBinding_group_subject (0.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	(cached)
------------------------------------------------------------
```