### PR TITLE
Add nil check for configmap volume mode

### DIFF
--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -266,7 +266,9 @@ func flattenConfigMapVolumeSource(in *v1.ConfigMapVolumeSource) []interface{} {
 		for i, v := range in.Items {
 			m := map[string]interface{}{}
 			m["key"] = v.Key
-			m["mode"] = *v.Mode
+			if v.Mode != nil {
+				m["mode"] = *v.Mode
+			}
 			m["path"] = v.Path
 			items[i] = m
 		}


### PR DESCRIPTION
I came across with this while importing existing deployment resource. It throws `panic: runtime error: invalid memory address or nil pointer dereference` when there is no mode definition on the resource.