### PR TITLE
EKS test infra: wait for API to be ready

### DIFF
--- a/kubernetes/test-infra/eks/main.tf
+++ b/kubernetes/test-infra/eks/main.tf
@@ -1,4 +1,3 @@
-
 module "vpc" {
   source = "./vpc"
 }
@@ -34,5 +33,7 @@ module "node-config" {
   source = "./node-config"
 
   k8s_node_role_arn = ["${list(module.cluster.worker_iam_role_arn)}"]
+  cluster_ca        = "${module.cluster.cluster_certificate_authority_data}"
+  cluster_endpoint  = "${module.cluster.cluster_endpoint}"
   kubeconfig        = "${module.cluster.kubeconfig}"
 }

--- a/kubernetes/test-infra/eks/node-config/variables.tf
+++ b/kubernetes/test-infra/eks/node-config/variables.tf
@@ -5,3 +5,11 @@ variable "k8s_node_role_arn" {
 variable "kubeconfig" {
   type = "string"
 }
+
+variable "cluster_ca" {
+  type = "string"
+}
+
+variable "cluster_endpoint" {
+  type = "string"
+}


### PR DESCRIPTION
This change introduces a loop-check for the K8s API to become ready before proceeding to apply the node auth ConfigMap. 
This ensures reliable builds within the same Terraform run which is nice to have in CI.
