### PR TITLE
Make worker count configurable in GKE test infra

### DIFF
--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -18,11 +18,14 @@ resource "random_id" "password" {
 
 # See https://cloud.google.com/container-engine/supported-versions
 variable "kubernetes_version" {}
+variable "workers_count" {
+  default = "4"
+}
 
 resource "google_container_cluster" "primary" {
   name               = "tf-acc-test-${random_id.cluster_name.hex}"
   zone               = "${data.google_compute_zones.available.names[0]}"
-  initial_node_count = 3
+  initial_node_count = "${var.workers_count}"
   node_version       = "${var.kubernetes_version}"
   min_master_version = "${var.kubernetes_version}"
 

--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -19,7 +19,7 @@ resource "random_id" "password" {
 # See https://cloud.google.com/container-engine/supported-versions
 variable "kubernetes_version" {}
 variable "workers_count" {
-  default = "4"
+  default = "3"
 }
 
 resource "google_container_cluster" "primary" {


### PR DESCRIPTION
An equivalent setting is already present in the EKS and AKS environments.
This change just aligns GKE to those.