### PR TITLE
test-infra: Fix test environment setup

### DIFF
--- a/kubernetes/test-infra/kops-on-gce/kops-create.sh
+++ b/kubernetes/test-infra/kops-on-gce/kops-create.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 export NODE_SIZE=n1-standard-1
 export MASTER_SIZE=n1-standard-2
 export KOPS_STATE_STORE="gs://${BUCKET_NAME}"
@@ -27,9 +29,4 @@ kops create cluster --cloud=gce \
   --admin-access=${IP_ADDRESS}/32 \
   --yes
 
-EXIT_CODE=$?
-if [ $EXIT_CODE == 0 ]; then
-  ../kops-waiter.sh 120
-else
-  exit $EXIT_CODE
-fi
+../kops-waiter.sh 120

--- a/kubernetes/test-infra/kops-waiter.sh
+++ b/kubernetes/test-infra/kops-waiter.sh
@@ -1,8 +1,10 @@
+#!/bin/bash
+echo "KOPS_STATE_STORE=$KOPS_STATE_STORE"
 MAX_RETRIES=$1
 
 RETRIES=1
 while [ 1 ]; do
-  kops validate cluster --state=s3://${BUCKET_NAME}
+  kops validate cluster
   if [ $? == 0 ]; then
     break
   fi
@@ -12,24 +14,7 @@ while [ 1 ]; do
   ((RETRIES++))
   if [ $RETRIES -gt $MAX_RETRIES ]; then
     echo "Bailing out after $MAX_RETRIES retries"
-    break
-  fi
-done
-
-RETRIES=1
-KUBE_HOST=$(kubectl config view -o jsonpath="{.clusters[?(@.name == \"${CLUSTER_NAME}\")].cluster.server}")
-while [ 1 ]; do
-  echo "Trying to resolve $KUBE_HOST"
-  host $KUBE_HOST
-  if [ $? == 0 ]; then
-    break
-  fi
-
-  sleep 5
-  echo "Retrying DNS query... ($RETRIES)"
-  ((RETRIES++))
-  if [ $RETRIES -gt $MAX_RETRIES ]; then
-    echo "Bailing out after $MAX_RETRIES retries"
+    exit 1
     break
   fi
 done

--- a/kubernetes/test-infra/minikube-on-packet/10-install-kvm.sh
+++ b/kubernetes/test-infra/minikube-on-packet/10-install-kvm.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+set -e
 
 yum install -y curl yum-utils libvirt qemu-kvm virt-install libguestfs-tools libvirt-client qemu-kvm-tools
 

--- a/kubernetes/test-infra/minikube-on-packet/20-install-minikube.sh
+++ b/kubernetes/test-infra/minikube-on-packet/20-install-minikube.sh
@@ -19,5 +19,7 @@ minikube config set vm-driver kvm2
 
 # These settings allocate half of the host's CPU cores and memory to the minikube virtual machine.
 # The proportion can be adjusted by chaning the '/ 2' factor in the expressions below.
-minikube config set cpus $(($(lscpu -p | grep -cv '#') / 2))
-minikube config set memory $(($(free --mega -tw | grep Mem: | cut -d' ' -f12) / 2))
+CPU_CORES=$(lscpu -p | grep -cv '#')
+FREE_MEMORY=$(free --mega -tw | grep Mem: | cut -d' ' -f12)
+minikube config set cpus $((CPU_CORES / 2))
+minikube config set memory $((FREE_MEMORY / 2))

--- a/kubernetes/test-infra/minikube-on-packet/20-install-minikube.sh
+++ b/kubernetes/test-infra/minikube-on-packet/20-install-minikube.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
+set -e
 
 # Install kubectl
-
 KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
   && chmod a+x kubectl && mv kubectl /usr/local/bin/

--- a/kubernetes/test-infra/minikube-on-packet/20-install-minikube.sh
+++ b/kubernetes/test-infra/minikube-on-packet/20-install-minikube.sh
@@ -8,7 +8,7 @@ curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VER
 kubectl version
 
 # Install minikube
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 \
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64 \
   && chmod a+x minikube && mv minikube /usr/local/bin/
 minikube version
 

--- a/kubernetes/test-infra/minikube-on-packet/20-install-minikube.sh
+++ b/kubernetes/test-infra/minikube-on-packet/20-install-minikube.sh
@@ -5,7 +5,7 @@ set -e
 KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
   && chmod a+x kubectl && mv kubectl /usr/local/bin/
-kubectl version
+kubectl version --client
 
 # Install minikube
 curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64 \

--- a/kubernetes/test-infra/minikube-on-packet/main.tf
+++ b/kubernetes/test-infra/minikube-on-packet/main.tf
@@ -69,7 +69,7 @@ resource "packet_ssh_key" "default" {
 resource "packet_device" "minikube" {
   hostname         = "minikube"
   plan             = "${var.packet_plan}"
-  facility         = "${var.packet_facility}"
+  facilities       = ["${var.packet_facility}"]
   operating_system = "centos_7"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.main.id}"

--- a/kubernetes/test-infra/minikube-on-packet/main.tf
+++ b/kubernetes/test-infra/minikube-on-packet/main.tf
@@ -5,6 +5,11 @@ variable "kubernetes_version" {
   description = "See 'minikube get-k8s-versions' for all available versions"
 }
 
+variable "minikube_version" {
+  type = "string"
+  description = "See https://github.com/kubernetes/minikube/releases"
+}
+
 variable "packet_facility" {
   type = "string"
   description = "See https://www.packet.net/developers/api/facilities/ for all available facilities"
@@ -97,7 +102,7 @@ resource "packet_device" "minikube" {
     inline = [
       "chmod a+x /tmp/10-install-kvm.sh && chmod a+x /tmp/20-install-minikube.sh",
       "/tmp/10-install-kvm.sh | tee /var/log/provisioning-11-kvm.log",
-      "/tmp/20-install-minikube.sh | tee /var/log/provisioning-20-minikube.log",
+      "MINIKUBE_VERSION=${var.minikube_version} /tmp/20-install-minikube.sh | tee /var/log/provisioning-20-minikube.log",
       "/usr/local/bin/minikube start --kubernetes-version=v${var.kubernetes_version}",
       # Extract certs so they can be transfered back to client
       "mkdir -p /tmp/${var.dotminikube_path}",


### PR DESCRIPTION
This fixes kops acceptance tests which were failing previously due to incorrect state store location.

minikube is still failing, because of https://github.com/kubernetes/minikube/issues/3546 - we might want to look into either removing it entirely or upgrading CentOS.