### PR TITLE
Feature/add hostaliases

### DIFF
--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -563,6 +563,34 @@ func TestAccKubernetesDeployment_with_deployment_strategy_recreate(t *testing.T)
 	})
 }
 
+func TestAccKubernetesDeployment_with_host_aliases(t *testing.T) {
+	var conf api.Deployment
+
+	rcName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := "nginx:1.7.8"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesDeploymentConfigHostAliases(rcName, imageName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.host_aliases.0.hostnames.#", "2"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.host_aliases.0.hostnames.0", "abc.com"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.host_aliases.0.hostnames.0", "contoso.com"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.host_aliases.0.ip", "127.0.0.5"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.host_aliases.1.hostnames.#", "1"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.host_aliases.1.hostnames.0", "xyz.com"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.host_aliases.1.ip", "127.0.0.6"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckKubernetesDeploymentDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*kubernetes.Clientset)
 
@@ -1367,35 +1395,29 @@ func testAccKubernetesDeploymentConfigWithDeploymentStrategyRollingUpdate(rcName
 resource "kubernetes_deployment" "test" {
   metadata {
     name = "%s"
-
     labels {
       Test = "TfAcceptanceTest"
     }
   }
-
   spec {
     selector {
       match_labels {
         Test = "TfAcceptanceTest"
       }
     }
-
     strategy {
       type = "RollingUpdate"
-
       rolling_update {
         max_surge       = "%s"
         max_unavailable = "%s"
       }
     }
-
     template {
       metadata {
         labels {
           Test = "TfAcceptanceTest"
         }
       }
-
       spec {
         container {
           image = "%s"
@@ -1406,4 +1428,62 @@ resource "kubernetes_deployment" "test" {
   }
 }
 `, rcName, maxSurge, maxUnavailable, imageName)
+}
+
+func testAccKubernetesDeploymentConfigHostAliases(name string, imageName string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_deployment" "test" {
+  metadata {
+    annotations {
+      TestAnnotationOne = "one"
+      TestAnnotationTwo = "two"
+    }
+    labels {
+      TestLabelOne   = "one"
+      TestLabelTwo   = "two"
+      TestLabelThree = "three"
+    }
+    name = "%s"
+  }
+  spec {
+    replicas = 1 
+    selector {
+      match_labels {
+        TestLabelOne   = "one"
+        TestLabelTwo   = "two"
+        TestLabelThree = "three"
+      }
+    }
+    template {
+      metadata {
+        labels {
+          TestLabelOne   = "one"
+          TestLabelTwo   = "two"
+          TestLabelThree = "three"
+        }
+      }
+      spec {
+        container {
+          image = "%s"
+          name  = "tf-acc-test"
+          resources {
+            requests {
+              memory = "64Mi"
+              cpu    = "50m"
+            }
+          }
+        }
+        host_aliases {
+          ip = "127.0.0.5"
+          hostnames = ["abc.com","contoso.com"]
+        }
+        host_aliases {
+          ip = "127.0.0.6"
+          hostnames = ["xyz.com"]
+        }
+      }
+    }
+  }
+}
+`, name, imageName)
 }

--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -580,7 +580,7 @@ func TestAccKubernetesDeployment_with_host_aliases(t *testing.T) {
 					testAccCheckKubernetesDeploymentExists(deploymentTestResourceName, &conf),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.host_aliases.0.hostnames.#", "2"),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.host_aliases.0.hostnames.0", "abc.com"),
-					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.host_aliases.0.hostnames.0", "contoso.com"),
+					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.host_aliases.0.hostnames.1", "contoso.com"),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.host_aliases.0.ip", "127.0.0.5"),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.host_aliases.1.hostnames.#", "1"),
 					resource.TestCheckResourceAttr(deploymentTestResourceName, "spec.0.template.0.spec.0.host_aliases.1.hostnames.0", "xyz.com"),

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -47,6 +47,29 @@ func podSpecFields(isUpdatable, isDeprecated, isComputed bool) map[string]*schem
 			Description: "Set DNS policy for containers within the pod. One of 'ClusterFirst' or 'Default'. Defaults to 'ClusterFirst'.",
 			Deprecated:  deprecatedMessage,
 		},
+		"host_aliases": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			ForceNew:    true,
+			Computed:    isComputed,
+			Description: "List of hosts and IPs that will be injected into the pod's hosts file if specified. Optional: Default to false.",
+			Deprecated:  deprecatedMessage,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"hostnames": {
+						Type:        schema.TypeList,
+						Required:    true,
+						Description: "Hostnames for the above IP address.",
+						Elem:        &schema.Schema{Type: schema.TypeString},
+					},
+					"ip": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "IP address of the host file entry.",
+					},
+				},
+			},
+		},
 		"host_ipc": {
 			Type:        schema.TypeBool,
 			Optional:    true,

--- a/kubernetes/structure_hostalias.go
+++ b/kubernetes/structure_hostalias.go
@@ -1,0 +1,35 @@
+package kubernetes
+
+import "k8s.io/api/core/v1"
+
+func flattenHostaliases(in []v1.HostAlias) []interface{} {
+	att := make([]interface{}, len(in))
+	for i, v := range in {
+		ha := make(map[string]interface{})
+		ha["ip"] = v.IP
+		if len(v.Hostnames) > 0 {
+			ha["hostnames"] = v.Hostnames
+		}
+		att[i] = ha
+	}
+	return att
+}
+func expandHostaliases(hostalias []interface{}) ([]v1.HostAlias, error) {
+	if len(hostalias) == 0 {
+		return []v1.HostAlias{}, nil
+	}
+
+	hs := make([]v1.HostAlias, len(hostalias))
+	for i, ha := range hostalias {
+		hoas := ha.(map[string]interface{})
+
+		if ip, ok := hoas["ip"]; ok {
+			hs[i].IP = ip.(string)
+		}
+
+		if hostnames, ok := hoas["hostnames"].([]interface{}); ok {
+			hs[i].Hostnames = expandStringSlice(hostnames)
+		}
+	}
+	return hs, nil
+}

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -29,6 +29,8 @@ func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
 
 	att["dns_policy"] = in.DNSPolicy
 
+	att["host_aliases"] = flattenHostaliases(in.HostAliases)
+
 	att["host_ipc"] = in.HostIPC
 	att["host_network"] = in.HostNetwork
 	att["host_pid"] = in.HostPID
@@ -342,6 +344,14 @@ func expandPodSpec(p []interface{}) (*v1.PodSpec, error) {
 
 	if v, ok := in["dns_policy"].(string); ok {
 		obj.DNSPolicy = v1.DNSPolicy(v)
+	}
+
+	if v, ok := in["host_aliases"].([]interface{}); ok && len(v) > 0 {
+		hs, err := expandHostaliases(v)
+		if err != nil {
+			return obj, err
+		}
+		obj.HostAliases = hs
 	}
 
 	if v, ok := in["host_ipc"]; ok {


### PR DESCRIPTION
Since the /etc/hosts of a pod is shared with its node you cannot add entries so Kubernetes Pod definition has the HostAlias, which holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.

With this addition you can define a block to add your entries

```
      host_aliases {
        ip = "127.0.0.5"
        hostnames = ["pepito.com","pepito"]
      }
      host_aliases {
        ip = "127.0.0.6"
        hostnames = ["xyz.com","xyz"]
```