### PR TITLE
Test infra GKE: auto-detect available cluster versions

### DIFF
--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -16,18 +16,25 @@ resource "random_id" "password" {
   byte_length = 16
 }
 
-# See https://cloud.google.com/container-engine/supported-versions
-variable "kubernetes_version" {}
+variable "kubernetes_version" {
+  default = ""
+}
+
 variable "workers_count" {
   default = "3"
+}
+
+data "google_container_engine_versions" "supported" {
+  zone           = "${data.google_compute_zones.available.names[0]}"
+  version_prefix = "${var.kubernetes_version}"
 }
 
 resource "google_container_cluster" "primary" {
   name               = "tf-acc-test-${random_id.cluster_name.hex}"
   zone               = "${data.google_compute_zones.available.names[0]}"
   initial_node_count = "${var.workers_count}"
-  node_version       = "${var.kubernetes_version}"
-  min_master_version = "${var.kubernetes_version}"
+  node_version       = "${data.google_container_engine_versions.supported.latest_node_version}"
+  min_master_version = "${data.google_container_engine_versions.supported.latest_master_version}"
 
   additional_zones = [
     "${data.google_compute_zones.available.names[1]}",


### PR DESCRIPTION
This change allows the GKE test infra template to query and pick the latest available Kubernetes version in that specific region.
By setting the `kubernetes_version` Terraform variable to a partial or specific GKE version the selected version can be controlled precisely.
This allows the templates to more robustly function in CI environments where daily runs have to keep up with the rolling releases of GKE.
