### PR TITLE
Add support for reading service account tokens

### DIFF
--- a/kubernetes/data_source_kubernetes_service_account_token.go
+++ b/kubernetes/data_source_kubernetes_service_account_token.go
@@ -1,0 +1,88 @@
+package kubernetes
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"log"
+)
+
+func dataSourceKubernetesServiceAccountToken() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceKubernetesServiceAccountTokenRead,
+
+		Schema: map[string]*schema.Schema{
+			"metadata": namespacedMetadataSchema("service account token", false),
+
+			"data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ca_crt": {
+							Type:        schema.TypeString,
+							Description: "CA certificate for the apiserver - this is 'ca.crt' in the underlying secret",
+							Computed:    true,
+						},
+						"namespace": {
+							Type:        schema.TypeString,
+							Description: "Namespace that the service account token is application for.",
+							Computed:    true,
+						},
+						"token": {
+							Type:        schema.TypeString,
+							Description: "Bearer token used to authenticate against the apiserver.",
+							Computed:    true,
+							Sensitive:   true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceKubernetesServiceAccountTokenRead(d *schema.ResourceData, meta interface{}) error {
+	om := meta_v1.ObjectMeta{
+		Namespace: d.Get("metadata.0.namespace").(string),
+		Name:      d.Get("metadata.0.name").(string),
+	}
+	d.SetId(buildId(om))
+
+	conn := meta.(*kubernetes.Clientset)
+
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Reading service account token %s", name)
+	secret, err := conn.CoreV1().Secrets(namespace).Get(name, meta_v1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if secret.Type != core_v1.SecretTypeServiceAccountToken {
+		return fmt.Errorf("Incorrect secret type: %v", secret.Type)
+	}
+
+	log.Printf("[INFO] Received service account token: %#v", secret)
+	err = d.Set("metadata", flattenMetadata(secret.ObjectMeta))
+	if err != nil {
+		return err
+	}
+
+	data := byteMapToStringMap(secret.Data)
+
+	att := make(map[string]interface{})
+
+	att["ca_crt"] = data[core_v1.ServiceAccountRootCAKey]
+	att["namespace"] = data[core_v1.ServiceAccountNamespaceKey]
+	att["token"] = data[core_v1.ServiceAccountTokenKey]
+	d.Set("data", []interface{}{att})
+
+	return err
+}

--- a/kubernetes/data_source_kubernetes_service_account_token_test.go
+++ b/kubernetes/data_source_kubernetes_service_account_token_test.go
@@ -1,0 +1,45 @@
+package kubernetes
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccKubernetesDataSourceServiceAccountToken_basic(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesDataSourceServiceAccountTokenConfig_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+
+					resource.TestMatchResourceAttr("data.kubernetes_service_account_token.test", "metadata.0.name", regexp.MustCompile(fmt.Sprintf("%s-token.*", name))),
+					resource.TestCheckResourceAttrSet("data.kubernetes_service_account_token.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_service_account_token.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_service_account_token.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_service_account_token.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_service_account_token.test", "data.0.ca_crt"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_service_account_token.test", "data.0.namespace"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_service_account_token.test", "data.0.token"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKubernetesDataSourceServiceAccountTokenConfig_basic(name string) string {
+	return testAccKubernetesServiceAccountConfig_basic(name) + `
+data "kubernetes_service_account_token" "test" {
+	metadata {
+		name = "${kubernetes_service_account.test.default_secret_name}"
+	}
+}
+`
+}

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -104,9 +104,10 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"kubernetes_secret":        dataSourceKubernetesSecret(),
-			"kubernetes_service":       dataSourceKubernetesService(),
-			"kubernetes_storage_class": dataSourceKubernetesStorageClass(),
+			"kubernetes_secret":                dataSourceKubernetesSecret(),
+			"kubernetes_service":               dataSourceKubernetesService(),
+			"kubernetes_service_account_token": dataSourceKubernetesServiceAccountToken(),
+			"kubernetes_storage_class":         dataSourceKubernetesStorageClass(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/docs/d/service_account_token.html.markdown
+++ b/website/docs/d/service_account_token.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "kubernetes"
+page_title: "Kubernetes: kubernetes_service_account_token"
+sidebar_current: "docs-kubernetes-data-source-service-account-token"
+description: |-
+  Use to read service account token secrets.
+---
+
+# kubernetes_service_account_token
+
+Use this data source to read service account token secrets.
+
+While `kubernetes_secret` data resource can read the service account token secrets, this tends to run into problems such as
+being unable to access the `ca.crt` value.  
+
+## Example Usage
+
+```hcl
+data "kubernetes_service_account_token" "test" {
+  metadata {
+    name = "example-service-bemorq6tot"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `metadata` - (Required) Standard secret's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#metadata)
+
+## Attributes
+
+* `data` - Data defines the attributes for this service account token.
+
+## Nested Blocks
+
+### `metadata`
+
+#### Arguments
+
+* `name` - (Required) Name of the secret, must be unique. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+* `namespace` - (Optional) Namespace defines the space within which name of the secret must be unique.
+
+#### Attributes
+
+* `generation` - A sequence number representing a specific generation of the desired state.
+* `resource_version` - An opaque value that represents the internal version of this secret that can be used by clients to determine when secret has changed. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#concurrency-control-and-consistency)
+* `self_link` - A URL representing this secret.
+* `uid` - The unique in time and space value for this secret. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#uids)
+
+### `data`
+
+#### Attributes
+
+* `ca_crt` - CA certificate for the apiserver - this is 'ca.crt' in the underlying secret
+* `namespace` - Namespace that the service account token is application for.
+* `token` -  Bearer token used to authenticate against the apiserver.

--- a/website/kubernetes.erb
+++ b/website/kubernetes.erb
@@ -24,6 +24,9 @@
             <li<%= sidebar_current("docs-kubernetes-data-source-service") %>>
               <a href="/docs/providers/kubernetes/d/service.html">kubernetes_service</a>
             </li>
+            <li<%= sidebar_current("docs-kubernetes-data-source-service-account-token") %>>
+              <a href="/docs/providers/kubernetes/d/service_account_token.html">kubernetes_service_account_token</a>
+            </li>
             <li<%= sidebar_current("docs-kubernetes-data-source-storage-class") %>>
               <a href="/docs/providers/kubernetes/d/storage_class.html">kubernetes_storage_class</a>
             </li>


### PR DESCRIPTION
Although the kubernetes_secret data resource is capable reading service account tokens, this tends to run into problems such as being unable to reference the `ca.crt` value or having Terraform plan which both creates a service account and attempts to read the associated service account token.