### PR TITLE
Add support for importing service accounts

### DIFF
--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -60,7 +60,6 @@ func resourceKubernetesServiceAccount() *schema.Resource {
 				Type:        schema.TypeBool,
 				Description: "True to enable automatic mounting of the service account token",
 				Optional:    true,
-				Default:     false,
 			},
 			"default_secret_name": {
 				Type:     schema.TypeString,

--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -21,10 +22,9 @@ func resourceKubernetesServiceAccount() *schema.Resource {
 		Exists: resourceKubernetesServiceAccountExists,
 		Update: resourceKubernetesServiceAccountUpdate,
 		Delete: resourceKubernetesServiceAccountDelete,
-
-		// This resource is not importable because the API doesn't offer
-		// any way to differentiate between default & user-defined secret
-		// after the account was created.
+		Importer: &schema.ResourceImporter{
+			State: resourceKubernetesServiceAccountImportState,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"metadata": namespacedMetadataSchema("service account", true),
@@ -169,6 +169,10 @@ func resourceKubernetesServiceAccountRead(d *schema.ResourceData, meta interface
 	if err != nil {
 		return err
 	}
+	err = d.Set("automount_service_account_token", *svcAcc.AutomountServiceAccountToken)
+	if err != nil {
+		return err
+	}
 	d.Set("image_pull_secret", flattenLocalObjectReferenceArray(svcAcc.ImagePullSecrets))
 
 	defaultSecretName := d.Get("default_secret_name").(string)
@@ -203,6 +207,13 @@ func resourceKubernetesServiceAccountUpdate(d *schema.ResourceData, meta interfa
 		ops = append(ops, &ReplaceOperation{
 			Path:  "/secrets",
 			Value: expandServiceAccountSecrets(v, defaultSecretName),
+		})
+	}
+	if d.HasChange("automount_service_account_token") {
+		v := d.Get("automount_service_account_token").(bool)
+		ops = append(ops, &ReplaceOperation{
+			Path:  "/automountServiceAccountToken",
+			Value: v,
 		})
 	}
 	data, err := ops.MarshalJSON()
@@ -257,4 +268,81 @@ func resourceKubernetesServiceAccountExists(d *schema.ResourceData, meta interfa
 		log.Printf("[DEBUG] Received error: %#v", err)
 	}
 	return true, err
+}
+
+func resourceKubernetesServiceAccountImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	conn := meta.(*kubernetes.Clientset)
+
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	sa, err := conn.CoreV1().ServiceAccounts(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	defaultSecret, err := findDefaultServiceAccount(sa, conn)
+	if err != nil {
+		return nil, err
+	}
+
+	err = d.Set("default_secret_name", defaultSecret)
+	if err != nil {
+		return nil, err
+	}
+	d.SetId(buildId(sa.ObjectMeta))
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func findDefaultServiceAccount(sa *api.ServiceAccount, conn *kubernetes.Clientset) (string, error) {
+	/*
+		The default service account token secret would have:
+		- been created either at the same moment as the service account or _just_ after (Kubernetes controllers appears to work off a queue)
+		- have a name starting with "[service account name]-token-"
+
+		See this for where the default token is created in Kubernetes
+		https://github.com/kubernetes/kubernetes/blob/release-1.13/pkg/controller/serviceaccount/tokens_controller.go#L384
+	*/
+	var serviceAccountTokens []string
+	for _, saSecret := range sa.Secrets {
+		if !strings.HasPrefix(saSecret.Name, fmt.Sprintf("%s-token-", sa.Name)) {
+			log.Printf("[DEBUG] Skipping %s as it doesn't have the right name", saSecret.Name)
+			continue
+		}
+
+		secret, err := conn.CoreV1().Secrets(sa.Namespace).Get(saSecret.Name, metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+
+		if secret.Type != api.SecretTypeServiceAccountToken {
+			log.Printf("[DEBUG] Skipping %s as it is of the wrong type", saSecret.Name)
+			continue
+		}
+
+		if secret.CreationTimestamp.Before(&sa.CreationTimestamp) {
+			log.Printf("[DEBUG] Skipping %s as it existed before the service account", saSecret.Name)
+			continue
+		}
+
+		if secret.CreationTimestamp.Sub(sa.CreationTimestamp.Time) > (1 * time.Second) {
+			log.Printf("[DEBUG] Skipping %s as it wasn't created at the same time as the service account", saSecret.Name)
+			continue
+		}
+
+		log.Printf("[DEBUG] Found %s as a candidate for the default service account token", saSecret.Name)
+		serviceAccountTokens = append(serviceAccountTokens, secret.Name)
+	}
+
+	if len(serviceAccountTokens) == 0 {
+		return "", fmt.Errorf("Unable to find any service accounts tokens which could have been the default one")
+	}
+
+	if len(serviceAccountTokens) > 1 {
+		return "", fmt.Errorf("Found too many service accounts tokens which could have been the default one")
+	}
+
+	return serviceAccountTokens[0], nil
 }

--- a/website/docs/r/service_account.html.markdown
+++ b/website/docs/r/service_account.html.markdown
@@ -77,3 +77,11 @@ In addition to the arguments listed above, the following computed attributes are
 exported:
 
 * `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service.
+
+## Import
+
+Service account can be imported using the namespace and name, e.g.
+
+```
+$ terraform import kubernetes_service_account.example default/terraform-example
+```


### PR DESCRIPTION
This implements importing of service accounts using the behaviour implemented in source code of the Kubernetes service account controller to discover the default service account token. This PR also adds support for updating the `automount_service_account_token` attribute when it changes.