### PR TITLE
Make persistent_volume's node_affinity computed to support server side populated default values

### DIFF
--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -11,7 +11,6 @@ import (
 	api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgApi "k8s.io/apimachinery/pkg/types"
 	kubernetes "k8s.io/client-go/kubernetes"
 )
@@ -247,7 +246,7 @@ func resourceKubernetesPersistentVolumeDelete(d *schema.ResourceData, meta inter
 	}
 
 	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-		out, err := conn.CoreV1().PersistentVolumes().Get(name, metav1.GetOptions{})
+		out, err := conn.CoreV1().PersistentVolumes().Get(name, meta_v1.GetOptions{})
 		if err != nil {
 			if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 				return nil

--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -108,6 +108,7 @@ func resourceKubernetesPersistentVolume() *schema.Resource {
 							Type:        schema.TypeList,
 							Description: "A description of the persistent volume's node affinity. More info: https://kubernetes.io/docs/concepts/storage/volumes/#local",
 							Optional:    true,
+							Computed:    true,
 							MaxItems:    1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -248,7 +248,7 @@ func resourceKubernetesPersistentVolumeDelete(d *schema.ResourceData, meta inter
 	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		out, err := conn.CoreV1().PersistentVolumes().Get(name, meta_v1.GetOptions{})
 		if err != nil {
-			if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
+			if errors.IsNotFound(err) {
 				return nil
 			}
 			return resource.NonRetryableError(err)
@@ -275,7 +275,7 @@ func resourceKubernetesPersistentVolumeExists(d *schema.ResourceData, meta inter
 	log.Printf("[INFO] Checking persistent volume %s", name)
 	_, err := conn.CoreV1().PersistentVolumes().Get(name, meta_v1.GetOptions{})
 	if err != nil {
-		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
+		if errors.IsNotFound(err) {
 			return false, nil
 		}
 		log.Printf("[DEBUG] Received error: %#v", err)

--- a/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
@@ -598,6 +598,10 @@ resource "kubernetes_persistent_volume_claim" "test" {
 func testAccKubernetesPersistentVolumeClaimConfig_import(volumeName, claimName, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
+  lifecycle {
+    ignore_changes = ["spec.0.node_affinity"]
+  }
+
   metadata {
     name = "%s"
   }
@@ -650,6 +654,10 @@ resource "kubernetes_persistent_volume_claim" "test" {
 func testAccKubernetesPersistentVolumeClaimConfig_volumeMatch(volumeName, claimName, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
+  lifecycle {
+    ignore_changes = ["spec.0.node_affinity"]
+  }
+
   metadata {
     name = "%s"
   }
@@ -702,6 +710,10 @@ resource "kubernetes_persistent_volume_claim" "test" {
 func testAccKubernetesPersistentVolumeClaimConfig_volumeMatch_modified(volumeName, claimName, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test2" {
+  lifecycle {
+    ignore_changes = ["spec.0.node_affinity"]
+  }
+
   metadata {
     name = "%s"
   }
@@ -842,6 +854,10 @@ resource "kubernetes_persistent_volume_claim" "test" {
 func testAccKubernetesPersistentVolumeClaimConfig_volumeUpdate(volumeName, claimName, storage, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
+  lifecycle {
+    ignore_changes = ["spec.0.node_affinity"]
+  }
+
   metadata {
     name = "%s"
   }

--- a/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
@@ -598,10 +598,6 @@ resource "kubernetes_persistent_volume_claim" "test" {
 func testAccKubernetesPersistentVolumeClaimConfig_import(volumeName, claimName, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
-  lifecycle {
-    ignore_changes = ["spec.0.node_affinity"]
-  }
-
   metadata {
     name = "%s"
   }
@@ -654,10 +650,6 @@ resource "kubernetes_persistent_volume_claim" "test" {
 func testAccKubernetesPersistentVolumeClaimConfig_volumeMatch(volumeName, claimName, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
-  lifecycle {
-    ignore_changes = ["spec.0.node_affinity"]
-  }
-
   metadata {
     name = "%s"
   }
@@ -710,10 +702,6 @@ resource "kubernetes_persistent_volume_claim" "test" {
 func testAccKubernetesPersistentVolumeClaimConfig_volumeMatch_modified(volumeName, claimName, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test2" {
-  lifecycle {
-    ignore_changes = ["spec.0.node_affinity"]
-  }
-
   metadata {
     name = "%s"
   }
@@ -854,10 +842,6 @@ resource "kubernetes_persistent_volume_claim" "test" {
 func testAccKubernetesPersistentVolumeClaimConfig_volumeUpdate(volumeName, claimName, storage, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
-  lifecycle {
-    ignore_changes = ["spec.0.node_affinity"]
-  }
-
   metadata {
     name = "%s"
   }

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -614,6 +614,10 @@ func testAccCheckKubernetesPersistentVolumeExists(n string, obj *api.PersistentV
 func testAccKubernetesPersistentVolumeConfig_googleCloud_basic(name, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
+  lifecycle {
+    ignore_changes = ["spec.0.node_affinity"]
+  }
+
   metadata {
     annotations {
       TestAnnotationOne = "one"
@@ -657,6 +661,10 @@ resource "google_compute_disk" "test" {
 func testAccKubernetesPersistentVolumeConfig_googleCloud_modified(name, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
+  lifecycle {
+    ignore_changes = ["spec.0.node_affinity"]
+  }
+
   metadata {
     annotations {
       TestAnnotationOne = "one"
@@ -702,6 +710,10 @@ resource "google_compute_disk" "test" {
 func testAccKubernetesPersistentVolumeConfig_googleCloud_volumeSource(name, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
+  lifecycle {
+    ignore_changes = ["spec.0.node_affinity"]
+  }
+
   metadata {
     name = "%s"
   }
@@ -864,8 +876,8 @@ resource "kubernetes_persistent_volume" "test" {
       local {
         path = "%s"
       }
-		}
-		node_affinity {
+    }
+    node_affinity {
       required {
         node_selector_term {
           match_expressions = [{
@@ -912,6 +924,10 @@ resource "kubernetes_persistent_volume" "test" {
 func testAccKubernetesPersistentVolumeConfig_storageClass(name, diskName, storageClassName, storageClassName2, zone, refName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
+  lifecycle {
+    ignore_changes = ["spec.0.node_affinity"]
+  }
+
   metadata {
     name = "%s"
   }

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -614,10 +614,6 @@ func testAccCheckKubernetesPersistentVolumeExists(n string, obj *api.PersistentV
 func testAccKubernetesPersistentVolumeConfig_googleCloud_basic(name, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
-  lifecycle {
-    ignore_changes = ["spec.0.node_affinity"]
-  }
-
   metadata {
     annotations {
       TestAnnotationOne = "one"
@@ -661,10 +657,6 @@ resource "google_compute_disk" "test" {
 func testAccKubernetesPersistentVolumeConfig_googleCloud_modified(name, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
-  lifecycle {
-    ignore_changes = ["spec.0.node_affinity"]
-  }
-
   metadata {
     annotations {
       TestAnnotationOne = "one"
@@ -710,10 +702,6 @@ resource "google_compute_disk" "test" {
 func testAccKubernetesPersistentVolumeConfig_googleCloud_volumeSource(name, diskName, zone string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
-  lifecycle {
-    ignore_changes = ["spec.0.node_affinity"]
-  }
-
   metadata {
     name = "%s"
   }
@@ -924,10 +912,6 @@ resource "kubernetes_persistent_volume" "test" {
 func testAccKubernetesPersistentVolumeConfig_storageClass(name, diskName, storageClassName, storageClassName2, zone, refName string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_persistent_volume" "test" {
-  lifecycle {
-    ignore_changes = ["spec.0.node_affinity"]
-  }
-
   metadata {
     name = "%s"
   }


### PR DESCRIPTION
This PR intends to fix the currently failing GKE PV & PVC acceptance when testing `master` against a `test-infra/gke` provisioned cluster.

The first strategy here was to ignore server side populated `spec.0.node_affinity` default values.
`failure-domain.beta.kubernetes.io/region` and `failure-domain.beta.kubernetes.io/zone`
However, it triggered strange terraform 0.11 behavior which made it fail in some but not all tests.

The retained solution is to make this field computed to the server side populated default values when no configuration for this block is provided.

An alternative may have been to try and replicate the default AKS/EKS/GKE/Minikube behavior on the terraform provider side but that seem overly complicated and hard to maintain in time.

The issue does not trigger when `spec.0.node_affinity` is [explicitly set in configuration](https://github.com/terraform-providers/terraform-provider-kubernetes/blob/cfb0ab9b36a44c69a6c13a4eb1e997f16d9754c7/kubernetes/resource_kubernetes_persistent_volume_test.go#L880).

Without this change :

```
# make testacc TEST=./kubernetes
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./kubernetes -v  -timeout 120m
=== RUN   TestAccKubernetesDataSourceSecret_basic
--- PASS: TestAccKubernetesDataSourceSecret_basic (1.61s)
=== RUN   TestAccKubernetesDataSourceService_basic
--- PASS: TestAccKubernetesDataSourceService_basic (1.27s)
=== RUN   TestAccKubernetesDataSourceStorageClass_basic
--- PASS: TestAccKubernetesDataSourceStorageClass_basic (1.29s)
=== RUN   TestDiffStringMap
=== RUN   TestDiffStringMap/0
=== RUN   TestDiffStringMap/1
=== RUN   TestDiffStringMap/2
=== RUN   TestDiffStringMap/3
=== RUN   TestDiffStringMap/4
=== RUN   TestDiffStringMap/5
=== RUN   TestDiffStringMap/6
--- PASS: TestDiffStringMap (0.00s)
    --- PASS: TestDiffStringMap/0 (0.00s)
    --- PASS: TestDiffStringMap/1 (0.00s)
    --- PASS: TestDiffStringMap/2 (0.00s)
    --- PASS: TestDiffStringMap/3 (0.00s)
    --- PASS: TestDiffStringMap/4 (0.00s)
    --- PASS: TestDiffStringMap/5 (0.00s)
    --- PASS: TestDiffStringMap/6 (0.00s)
=== RUN   TestEscapeJsonPointer
--- PASS: TestEscapeJsonPointer (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.02s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestProvider_configure
--- SKIP: TestProvider_configure (0.00s)
    provider_test.go:43: The environment variable TF_ACC is set, and this test prevents acceptance tests from running as it alters environment variables - skipping
=== RUN   TestAccKubernetesClusterRoleBinding
--- PASS: TestAccKubernetesClusterRoleBinding (1.98s)
=== RUN   TestAccKubernetesClusterRoleBinding_serviceaccount_subject
--- PASS: TestAccKubernetesClusterRoleBinding_serviceaccount_subject (1.13s)
=== RUN   TestAccKubernetesClusterRoleBinding_group_subject
--- PASS: TestAccKubernetesClusterRoleBinding_group_subject (1.12s)
=== RUN   TestAccKubernetesClusterRoleBinding_importBasic
--- PASS: TestAccKubernetesClusterRoleBinding_importBasic (1.23s)
=== RUN   TestAccKubernetesClusterRole_basic
--- PASS: TestAccKubernetesClusterRole_basic (1.99s)
=== RUN   TestAccKubernetesClusterRole_importBasic
--- PASS: TestAccKubernetesClusterRole_importBasic (1.26s)
=== RUN   TestAccKubernetesConfigMap_basic
--- PASS: TestAccKubernetesConfigMap_basic (3.74s)
=== RUN   TestAccKubernetesConfigMap_importBasic
--- PASS: TestAccKubernetesConfigMap_importBasic (1.26s)
=== RUN   TestAccKubernetesConfigMap_generatedName
--- PASS: TestAccKubernetesConfigMap_generatedName (1.12s)
=== RUN   TestAccKubernetesConfigMap_importGeneratedName
--- PASS: TestAccKubernetesConfigMap_importGeneratedName (1.24s)
=== RUN   TestAccKubernetesDaemonSet_minimal
--- PASS: TestAccKubernetesDaemonSet_minimal (1.18s)
=== RUN   TestAccKubernetesDaemonSet_basic
--- PASS: TestAccKubernetesDaemonSet_basic (2.23s)
=== RUN   TestAccKubernetesDaemonSet_importBasic
--- PASS: TestAccKubernetesDaemonSet_importBasic (1.33s)
=== RUN   TestAccKubernetesDaemonSet_with_template_metadata
--- PASS: TestAccKubernetesDaemonSet_with_template_metadata (2.21s)
=== RUN   TestAccKubernetesDaemonSet_initContainer
--- PASS: TestAccKubernetesDaemonSet_initContainer (1.19s)
=== RUN   TestAccKubernetesDaemonSet_noTopLevelLabels
--- PASS: TestAccKubernetesDaemonSet_noTopLevelLabels (1.17s)
=== RUN   TestAccKubernetesDeployment_basic
--- PASS: TestAccKubernetesDeployment_basic (27.54s)
=== RUN   TestAccKubernetesDeployment_initContainer
--- PASS: TestAccKubernetesDeployment_initContainer (37.76s)
=== RUN   TestAccKubernetesDeployment_importBasic
--- PASS: TestAccKubernetesDeployment_importBasic (37.89s)
=== RUN   TestAccKubernetesDeployment_generatedName
--- PASS: TestAccKubernetesDeployment_generatedName (17.37s)
=== RUN   TestAccKubernetesDeployment_importGeneratedName
--- PASS: TestAccKubernetesDeployment_importGeneratedName (9.41s)
=== RUN   TestAccKubernetesDeployment_with_security_context
--- PASS: TestAccKubernetesDeployment_with_security_context (9.33s)
=== RUN   TestAccKubernetesDeployment_with_container_liveness_probe_using_exec
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_exec (5.17s)
=== RUN   TestAccKubernetesDeployment_with_container_liveness_probe_using_http_get
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_http_get (5.18s)
=== RUN   TestAccKubernetesDeployment_with_container_liveness_probe_using_tcp
--- PASS: TestAccKubernetesDeployment_with_container_liveness_probe_using_tcp (5.15s)
=== RUN   TestAccKubernetesDeployment_with_container_lifecycle
--- PASS: TestAccKubernetesDeployment_with_container_lifecycle (3.02s)
=== RUN   TestAccKubernetesDeployment_with_container_security_context
--- PASS: TestAccKubernetesDeployment_with_container_security_context (5.18s)
=== RUN   TestAccKubernetesDeployment_with_volume_mount
--- PASS: TestAccKubernetesDeployment_with_volume_mount (6.07s)
=== RUN   TestAccKubernetesDeployment_with_resource_requirements
--- PASS: TestAccKubernetesDeployment_with_resource_requirements (3.04s)
=== RUN   TestAccKubernetesDeployment_with_empty_dir_volume
--- PASS: TestAccKubernetesDeployment_with_empty_dir_volume (3.05s)
=== RUN   TestAccKubernetesDeploymentUpdate_basic
--- PASS: TestAccKubernetesDeploymentUpdate_basic (34.57s)
=== RUN   TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate (9.28s)
=== RUN   TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_30perc_max_unavailable_40perc
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_30perc_max_unavailable_40perc (6.74s)
=== RUN   TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_1_max_unavailable_2
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_rollingupdate_max_surge_1_max_unavailable_2 (3.03s)
=== RUN   TestAccKubernetesDeployment_with_deployment_strategy_recreate
--- PASS: TestAccKubernetesDeployment_with_deployment_strategy_recreate (5.17s)
=== RUN   TestAccKubernetesDeployment_with_host_aliases
--- PASS: TestAccKubernetesDeployment_with_host_aliases (3.04s)
=== RUN   TestAccKubernetesEndpoint_basic
--- PASS: TestAccKubernetesEndpoint_basic (2.87s)
=== RUN   TestAccKubernetesEndpoint_importBasic
--- PASS: TestAccKubernetesEndpoint_importBasic (1.25s)
=== RUN   TestAccKubernetesEndpoint_generatedName
--- PASS: TestAccKubernetesEndpoint_generatedName (1.12s)
=== RUN   TestAccKubernetesEndpoint_importGeneratedName
--- PASS: TestAccKubernetesEndpoint_importGeneratedName (1.24s)
=== RUN   TestAccKubernetesHorizontalPodAutoscaler_basic
--- PASS: TestAccKubernetesHorizontalPodAutoscaler_basic (2.85s)
=== RUN   TestAccKubernetesHorizontalPodAutoscaler_generatedName
--- PASS: TestAccKubernetesHorizontalPodAutoscaler_generatedName (1.17s)
=== RUN   TestAccKubernetesHorizontalPodAutoscaler_importBasic
--- PASS: TestAccKubernetesHorizontalPodAutoscaler_importBasic (1.24s)
=== RUN   TestAccKubernetesLimitRange_basic
--- PASS: TestAccKubernetesLimitRange_basic (2.87s)
=== RUN   TestAccKubernetesLimitRange_empty
--- PASS: TestAccKubernetesLimitRange_empty (1.11s)
=== RUN   TestAccKubernetesLimitRange_generatedName
--- PASS: TestAccKubernetesLimitRange_generatedName (1.13s)
=== RUN   TestAccKubernetesLimitRange_typeChange
--- PASS: TestAccKubernetesLimitRange_typeChange (1.99s)
=== RUN   TestAccKubernetesLimitRange_multipleLimits
--- PASS: TestAccKubernetesLimitRange_multipleLimits (1.13s)
=== RUN   TestAccKubernetesLimitRange_importBasic
--- PASS: TestAccKubernetesLimitRange_importBasic (1.24s)
=== RUN   TestAccKubernetesNamespace_basic
--- PASS: TestAccKubernetesNamespace_basic (11.43s)
=== RUN   TestAccKubernetesNamespace_invalidLabelValueType
--- PASS: TestAccKubernetesNamespace_invalidLabelValueType (0.03s)
=== RUN   TestAccKubernetesNamespace_importBasic
--- PASS: TestAccKubernetesNamespace_importBasic (8.12s)
=== RUN   TestAccKubernetesNamespace_generatedName
--- PASS: TestAccKubernetesNamespace_generatedName (8.04s)
=== RUN   TestAccKubernetesNamespace_withSpecialCharacters
--- PASS: TestAccKubernetesNamespace_withSpecialCharacters (8.01s)
=== RUN   TestAccKubernetesNamespace_importGeneratedName
--- PASS: TestAccKubernetesNamespace_importGeneratedName (8.13s)
=== RUN   TestAccKubernetesNetworkPolicy_basic
--- PASS: TestAccKubernetesNetworkPolicy_basic (4.65s)
=== RUN   TestAccKubernetesNetworkPolicy_withEgressAtCreation
--- PASS: TestAccKubernetesNetworkPolicy_withEgressAtCreation (1.27s)
=== RUN   TestAccKubernetesNetworkPolicy_importBasic
--- PASS: TestAccKubernetesNetworkPolicy_importBasic (1.25s)
=== RUN   TestAccKubernetesPersistentVolumeClaim_basic
--- PASS: TestAccKubernetesPersistentVolumeClaim_basic (4.10s)
=== RUN   TestAccKubernetesPersistentVolumeClaim_googleCloud_importBasic
--- FAIL: TestAccKubernetesPersistentVolumeClaim_googleCloud_importBasic (72.51s)
    testing.go:538: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        DESTROY/CREATE: kubernetes_persistent_volume.test
          metadata.#:                                                                                   "1" => "1"
          metadata.0.generation:                                                                        "0" => "<computed>"
          metadata.0.name:                                                                              "tf-acc-test-b3w2ztw7pn" => "tf-acc-test-b3w2ztw7pn"
          metadata.0.resource_version:                                                                  "345719" => "<computed>"
          metadata.0.self_link:                                                                         "/api/v1/persistentvolumes/tf-acc-test-b3w2ztw7pn" => "<computed>"
          metadata.0.uid:                                                                               "a4a4b042-5b9d-11e9-a958-42010a8e0064" => "<computed>"
          spec.#:                                                                                       "1" => "1"
          spec.0.access_modes.#:                                                                        "1" => "1"
          spec.0.access_modes.1245328686:                                                               "ReadWriteOnce" => "ReadWriteOnce"
          spec.0.capacity.%:                                                                            "1" => "1"
          spec.0.capacity.storage:                                                                      "10Gi" => "10Gi"
          spec.0.node_affinity.#:                                                                       "1" => "0"
          spec.0.node_affinity.0.required.#:                                                            "1" => "0"
          spec.0.node_affinity.0.required.0.node_selector_term.#:                                       "1" => "0"
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.#:                   "2" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.key:               "failure-domain.beta.kubernetes.io/zone" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.operator:          "In" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.#:          "1" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.3196152168: "us-east1-b" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.key:               "failure-domain.beta.kubernetes.io/region" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.operator:          "In" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.#:          "1" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.2035457625: "us-east1" => "" (forces new resource)
          spec.0.persistent_volume_reclaim_policy:                                                      "Retain" => "Retain"
          spec.0.persistent_volume_source.#:                                                            "1" => "1"
          spec.0.persistent_volume_source.0.gce_persistent_disk.#:                                      "1" => "1"
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.pd_name:                              "tf-acc-test-disk-obe9l93u1f" => "tf-acc-test-disk-obe9l93u1f"
          spec.0.storage_class_name:                                                                    "standard" => "standard"

        STATE:

        google_compute_disk.test:
          ID = tf-acc-test-disk-obe9l93u1f
          provider = provider.google
          creation_timestamp = 2019-04-10T07:32:46.856-07:00
          description =
          disk_encryption_key.# = 0
          image = https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20170523
          label_fingerprint = 42WmSpB8rSM=
          labels.% = 0
          last_attach_timestamp =
          last_detach_timestamp =
          name = tf-acc-test-disk-obe9l93u1f
          project = myproject-sandbox
          self_link = https://www.googleapis.com/compute/v1/projects/myproject-sandbox/zones/us-east1-b/disks/tf-acc-test-disk-obe9l93u1f
          size = 10
          snapshot =
          source_image_encryption_key.# = 0
          source_image_id = 2405673006522696145
          source_snapshot_encryption_key.# = 0
          source_snapshot_id =
          type = pd-ssd
          users.# = 0
          zone = us-east1-b
        kubernetes_persistent_volume.test:
          ID = tf-acc-test-b3w2ztw7pn
          provider = provider.kubernetes
          metadata.# = 1
          metadata.0.annotations.% = 0
          metadata.0.generation = 0
          metadata.0.labels.% = 0
          metadata.0.name = tf-acc-test-b3w2ztw7pn
          metadata.0.resource_version = 345719
          metadata.0.self_link = /api/v1/persistentvolumes/tf-acc-test-b3w2ztw7pn
          metadata.0.uid = a4a4b042-5b9d-11e9-a958-42010a8e0064
          spec.# = 1
          spec.0.access_modes.# = 1
          spec.0.access_modes.1245328686 = ReadWriteOnce
          spec.0.capacity.% = 1
          spec.0.capacity.storage = 10Gi
          spec.0.node_affinity.# = 1
          spec.0.node_affinity.0.required.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.# = 2
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.key = failure-domain.beta.kubernetes.io/zone
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.operator = In
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.3196152168 = us-east1-b
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.key = failure-domain.beta.kubernetes.io/region
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.operator = In
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.2035457625 = us-east1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_fields.# = 0
          spec.0.persistent_volume_reclaim_policy = Retain
          spec.0.persistent_volume_source.# = 1
          spec.0.persistent_volume_source.0.aws_elastic_block_store.# = 0
          spec.0.persistent_volume_source.0.azure_disk.# = 0
          spec.0.persistent_volume_source.0.azure_file.# = 0
          spec.0.persistent_volume_source.0.ceph_fs.# = 0
          spec.0.persistent_volume_source.0.cinder.# = 0
          spec.0.persistent_volume_source.0.fc.# = 0
          spec.0.persistent_volume_source.0.flex_volume.# = 0
          spec.0.persistent_volume_source.0.flocker.# = 0
          spec.0.persistent_volume_source.0.gce_persistent_disk.# = 1
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.fs_type =
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.partition = 0
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.pd_name = tf-acc-test-disk-obe9l93u1f
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.read_only = false
          spec.0.persistent_volume_source.0.glusterfs.# = 0
          spec.0.persistent_volume_source.0.host_path.# = 0
          spec.0.persistent_volume_source.0.iscsi.# = 0
          spec.0.persistent_volume_source.0.local.# = 0
          spec.0.persistent_volume_source.0.nfs.# = 0
          spec.0.persistent_volume_source.0.photon_persistent_disk.# = 0
          spec.0.persistent_volume_source.0.quobyte.# = 0
          spec.0.persistent_volume_source.0.rbd.# = 0
          spec.0.persistent_volume_source.0.vsphere_volume.# = 0
          spec.0.storage_class_name = standard

          Dependencies:
            google_compute_disk.test
        kubernetes_persistent_volume_claim.test:
          ID = default/tf-acc-test-01v2y48zmh
          provider = provider.kubernetes
          metadata.# = 1
          metadata.0.annotations.% = 0
          metadata.0.generate_name =
          metadata.0.generation = 0
          metadata.0.labels.% = 0
          metadata.0.name = tf-acc-test-01v2y48zmh
          metadata.0.namespace = default
          metadata.0.resource_version = 345725
          metadata.0.self_link = /api/v1/namespaces/default/persistentvolumeclaims/tf-acc-test-01v2y48zmh
          metadata.0.uid = a4db579c-5b9d-11e9-a958-42010a8e0064
          spec.# = 1
          spec.0.access_modes.# = 1
          spec.0.access_modes.1245328686 = ReadWriteOnce
          spec.0.resources.# = 1
          spec.0.resources.0.limits.% = 0
          spec.0.resources.0.requests.% = 1
          spec.0.resources.0.requests.storage = 5Gi
          spec.0.selector.# = 0
          spec.0.storage_class_name = standard
          spec.0.volume_name = tf-acc-test-b3w2ztw7pn
          wait_until_bound = true

          Dependencies:
            kubernetes_persistent_volume.test
=== RUN   TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch
--- FAIL: TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeMatch (27.04s)
    testing.go:538: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        DESTROY/CREATE: kubernetes_persistent_volume.test
          metadata.#:                                                                                   "1" => "1"
          metadata.0.generation:                                                                        "0" => "<computed>"
          metadata.0.name:                                                                              "tf-acc-test-lvyanl6f40" => "tf-acc-test-lvyanl6f40"
          metadata.0.resource_version:                                                                  "345809" => "<computed>"
          metadata.0.self_link:                                                                         "/api/v1/persistentvolumes/tf-acc-test-lvyanl6f40" => "<computed>"
          metadata.0.uid:                                                                               "b4937ef8-5b9d-11e9-a958-42010a8e0064" => "<computed>"
          spec.#:                                                                                       "1" => "1"
          spec.0.access_modes.#:                                                                        "1" => "1"
          spec.0.access_modes.1245328686:                                                               "ReadWriteOnce" => "ReadWriteOnce"
          spec.0.capacity.%:                                                                            "1" => "1"
          spec.0.capacity.storage:                                                                      "10Gi" => "10Gi"
          spec.0.node_affinity.#:                                                                       "1" => "0"
          spec.0.node_affinity.0.required.#:                                                            "1" => "0"
          spec.0.node_affinity.0.required.0.node_selector_term.#:                                       "1" => "0"
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.#:                   "2" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.key:               "failure-domain.beta.kubernetes.io/zone" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.operator:          "In" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.#:          "1" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.3196152168: "us-east1-b" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.key:               "failure-domain.beta.kubernetes.io/region" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.operator:          "In" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.#:          "1" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.2035457625: "us-east1" => "" (forces new resource)
          spec.0.persistent_volume_reclaim_policy:                                                      "Retain" => "Retain"
          spec.0.persistent_volume_source.#:                                                            "1" => "1"
          spec.0.persistent_volume_source.0.gce_persistent_disk.#:                                      "1" => "1"
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.pd_name:                              "tf-acc-test-disk-jumw4w8ktx" => "tf-acc-test-disk-jumw4w8ktx"
          spec.0.storage_class_name:                                                                    "standard" => "standard"

        STATE:

        google_compute_disk.test:
          ID = tf-acc-test-disk-jumw4w8ktx
          provider = provider.google
          creation_timestamp = 2019-04-10T07:33:59.208-07:00
          description =
          disk_encryption_key.# = 0
          image = https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20170523
          label_fingerprint = 42WmSpB8rSM=
          labels.% = 0
          last_attach_timestamp =
          last_detach_timestamp =
          name = tf-acc-test-disk-jumw4w8ktx
          project = myproject-sandbox
          self_link = https://www.googleapis.com/compute/v1/projects/myproject-sandbox/zones/us-east1-b/disks/tf-acc-test-disk-jumw4w8ktx
          size = 10
          snapshot =
          source_image_encryption_key.# = 0
          source_image_id = 2405673006522696145
          source_snapshot_encryption_key.# = 0
          source_snapshot_id =
          type = pd-ssd
          users.# = 0
          zone = us-east1-b
        kubernetes_persistent_volume.test:
          ID = tf-acc-test-lvyanl6f40
          provider = provider.kubernetes
          metadata.# = 1
          metadata.0.annotations.% = 0
          metadata.0.generation = 0
          metadata.0.labels.% = 0
          metadata.0.name = tf-acc-test-lvyanl6f40
          metadata.0.resource_version = 345809
          metadata.0.self_link = /api/v1/persistentvolumes/tf-acc-test-lvyanl6f40
          metadata.0.uid = b4937ef8-5b9d-11e9-a958-42010a8e0064
          spec.# = 1
          spec.0.access_modes.# = 1
          spec.0.access_modes.1245328686 = ReadWriteOnce
          spec.0.capacity.% = 1
          spec.0.capacity.storage = 10Gi
          spec.0.node_affinity.# = 1
          spec.0.node_affinity.0.required.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.# = 2
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.key = failure-domain.beta.kubernetes.io/zone
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.operator = In
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.3196152168 = us-east1-b
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.key = failure-domain.beta.kubernetes.io/region
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.operator = In
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.2035457625 = us-east1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_fields.# = 0
          spec.0.persistent_volume_reclaim_policy = Retain
          spec.0.persistent_volume_source.# = 1
          spec.0.persistent_volume_source.0.aws_elastic_block_store.# = 0
          spec.0.persistent_volume_source.0.azure_disk.# = 0
          spec.0.persistent_volume_source.0.azure_file.# = 0
          spec.0.persistent_volume_source.0.ceph_fs.# = 0
          spec.0.persistent_volume_source.0.cinder.# = 0
          spec.0.persistent_volume_source.0.fc.# = 0
          spec.0.persistent_volume_source.0.flex_volume.# = 0
          spec.0.persistent_volume_source.0.flocker.# = 0
          spec.0.persistent_volume_source.0.gce_persistent_disk.# = 1
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.fs_type =
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.partition = 0
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.pd_name = tf-acc-test-disk-jumw4w8ktx
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.read_only = false
          spec.0.persistent_volume_source.0.glusterfs.# = 0
          spec.0.persistent_volume_source.0.host_path.# = 0
          spec.0.persistent_volume_source.0.iscsi.# = 0
          spec.0.persistent_volume_source.0.local.# = 0
          spec.0.persistent_volume_source.0.nfs.# = 0
          spec.0.persistent_volume_source.0.photon_persistent_disk.# = 0
          spec.0.persistent_volume_source.0.quobyte.# = 0
          spec.0.persistent_volume_source.0.rbd.# = 0
          spec.0.persistent_volume_source.0.vsphere_volume.# = 0
          spec.0.storage_class_name = standard

          Dependencies:
            google_compute_disk.test
        kubernetes_persistent_volume_claim.test:
          ID = default/tf-acc-test-rvdlpf7pot
          provider = provider.kubernetes
          metadata.# = 1
          metadata.0.annotations.% = 0
          metadata.0.generate_name =
          metadata.0.generation = 0
          metadata.0.labels.% = 0
          metadata.0.name = tf-acc-test-rvdlpf7pot
          metadata.0.namespace = default
          metadata.0.resource_version = 345814
          metadata.0.self_link = /api/v1/namespaces/default/persistentvolumeclaims/tf-acc-test-rvdlpf7pot
          metadata.0.uid = b4c97592-5b9d-11e9-a958-42010a8e0064
          spec.# = 1
          spec.0.access_modes.# = 1
          spec.0.access_modes.1245328686 = ReadWriteOnce
          spec.0.resources.# = 1
          spec.0.resources.0.limits.% = 0
          spec.0.resources.0.requests.% = 1
          spec.0.resources.0.requests.storage = 5Gi
          spec.0.selector.# = 0
          spec.0.storage_class_name = standard
          spec.0.volume_name = tf-acc-test-lvyanl6f40
          wait_until_bound = true

          Dependencies:
            kubernetes_persistent_volume.test
=== RUN   TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeUpdate
--- FAIL: TestAccKubernetesPersistentVolumeClaim_googleCloud_volumeUpdate (30.48s)
    testing.go:538: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        DESTROY/CREATE: kubernetes_persistent_volume.test
          metadata.#:                                                                                   "1" => "1"
          metadata.0.generation:                                                                        "0" => "<computed>"
          metadata.0.name:                                                                              "tf-acc-test-6qng9lakce" => "tf-acc-test-6qng9lakce"
          metadata.0.resource_version:                                                                  "345893" => "<computed>"
          metadata.0.self_link:                                                                         "/api/v1/persistentvolumes/tf-acc-test-6qng9lakce" => "<computed>"
          metadata.0.uid:                                                                               "c4aabcda-5b9d-11e9-a958-42010a8e0064" => "<computed>"
          spec.#:                                                                                       "1" => "1"
          spec.0.access_modes.#:                                                                        "1" => "1"
          spec.0.access_modes.1245328686:                                                               "ReadWriteOnce" => "ReadWriteOnce"
          spec.0.capacity.%:                                                                            "1" => "1"
          spec.0.capacity.storage:                                                                      "5Gi" => "5Gi"
          spec.0.node_affinity.#:                                                                       "1" => "0"
          spec.0.node_affinity.0.required.#:                                                            "1" => "0"
          spec.0.node_affinity.0.required.0.node_selector_term.#:                                       "1" => "0"
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.#:                   "2" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.key:               "failure-domain.beta.kubernetes.io/zone" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.operator:          "In" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.#:          "1" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.3196152168: "us-east1-b" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.key:               "failure-domain.beta.kubernetes.io/region" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.operator:          "In" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.#:          "1" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.2035457625: "us-east1" => "" (forces new resource)
          spec.0.persistent_volume_reclaim_policy:                                                      "Retain" => "Retain"
          spec.0.persistent_volume_source.#:                                                            "1" => "1"
          spec.0.persistent_volume_source.0.gce_persistent_disk.#:                                      "1" => "1"
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.pd_name:                              "tf-acc-test-disk-gmek7s1uz2" => "tf-acc-test-disk-gmek7s1uz2"
          spec.0.storage_class_name:                                                                    "standard" => "standard"

        STATE:

        google_compute_disk.test:
          ID = tf-acc-test-disk-gmek7s1uz2
          provider = provider.google
          creation_timestamp = 2019-04-10T07:34:26.157-07:00
          description =
          disk_encryption_key.# = 0
          image = https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20170523
          label_fingerprint = 42WmSpB8rSM=
          labels.% = 0
          last_attach_timestamp =
          last_detach_timestamp =
          name = tf-acc-test-disk-gmek7s1uz2
          project = myproject-sandbox
          self_link = https://www.googleapis.com/compute/v1/projects/myproject-sandbox/zones/us-east1-b/disks/tf-acc-test-disk-gmek7s1uz2
          size = 10
          snapshot =
          source_image_encryption_key.# = 0
          source_image_id = 2405673006522696145
          source_snapshot_encryption_key.# = 0
          source_snapshot_id =
          type = pd-ssd
          users.# = 0
          zone = us-east1-b
        kubernetes_persistent_volume.test:
          ID = tf-acc-test-6qng9lakce
          provider = provider.kubernetes
          metadata.# = 1
          metadata.0.annotations.% = 0
          metadata.0.generation = 0
          metadata.0.labels.% = 0
          metadata.0.name = tf-acc-test-6qng9lakce
          metadata.0.resource_version = 345893
          metadata.0.self_link = /api/v1/persistentvolumes/tf-acc-test-6qng9lakce
          metadata.0.uid = c4aabcda-5b9d-11e9-a958-42010a8e0064
          spec.# = 1
          spec.0.access_modes.# = 1
          spec.0.access_modes.1245328686 = ReadWriteOnce
          spec.0.capacity.% = 1
          spec.0.capacity.storage = 5Gi
          spec.0.node_affinity.# = 1
          spec.0.node_affinity.0.required.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.# = 2
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.key = failure-domain.beta.kubernetes.io/zone
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.operator = In
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.3196152168 = us-east1-b
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.key = failure-domain.beta.kubernetes.io/region
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.operator = In
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.2035457625 = us-east1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_fields.# = 0
          spec.0.persistent_volume_reclaim_policy = Retain
          spec.0.persistent_volume_source.# = 1
          spec.0.persistent_volume_source.0.aws_elastic_block_store.# = 0
          spec.0.persistent_volume_source.0.azure_disk.# = 0
          spec.0.persistent_volume_source.0.azure_file.# = 0
          spec.0.persistent_volume_source.0.ceph_fs.# = 0
          spec.0.persistent_volume_source.0.cinder.# = 0
          spec.0.persistent_volume_source.0.fc.# = 0
          spec.0.persistent_volume_source.0.flex_volume.# = 0
          spec.0.persistent_volume_source.0.flocker.# = 0
          spec.0.persistent_volume_source.0.gce_persistent_disk.# = 1
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.fs_type =
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.partition = 0
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.pd_name = tf-acc-test-disk-gmek7s1uz2
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.read_only = false
          spec.0.persistent_volume_source.0.glusterfs.# = 0
          spec.0.persistent_volume_source.0.host_path.# = 0
          spec.0.persistent_volume_source.0.iscsi.# = 0
          spec.0.persistent_volume_source.0.local.# = 0
          spec.0.persistent_volume_source.0.nfs.# = 0
          spec.0.persistent_volume_source.0.photon_persistent_disk.# = 0
          spec.0.persistent_volume_source.0.quobyte.# = 0
          spec.0.persistent_volume_source.0.rbd.# = 0
          spec.0.persistent_volume_source.0.vsphere_volume.# = 0
          spec.0.storage_class_name = standard

          Dependencies:
            google_compute_disk.test
        kubernetes_persistent_volume_claim.test:
          ID = default/tf-acc-test-goatsafd42
          provider = provider.kubernetes
          metadata.# = 1
          metadata.0.annotations.% = 0
          metadata.0.generate_name =
          metadata.0.generation = 0
          metadata.0.labels.% = 0
          metadata.0.name = tf-acc-test-goatsafd42
          metadata.0.namespace = default
          metadata.0.resource_version = 345908
          metadata.0.self_link = /api/v1/namespaces/default/persistentvolumeclaims/tf-acc-test-goatsafd42
          metadata.0.uid = c4e10ff7-5b9d-11e9-a958-42010a8e0064
          spec.# = 1
          spec.0.access_modes.# = 1
          spec.0.access_modes.1245328686 = ReadWriteOnce
          spec.0.resources.# = 1
          spec.0.resources.0.limits.% = 0
          spec.0.resources.0.requests.% = 1
          spec.0.resources.0.requests.storage = 5Gi
          spec.0.selector.# = 0
          spec.0.storage_class_name = standard
          spec.0.volume_name = tf-acc-test-6qng9lakce
          wait_until_bound = true

          Dependencies:
            kubernetes_persistent_volume.test
=== RUN   TestAccKubernetesPersistentVolumeClaim_googleCloud_storageClass
--- PASS: TestAccKubernetesPersistentVolumeClaim_googleCloud_storageClass (10.82s)
=== RUN   TestAccKubernetesPersistentVolume_googleCloud_basic
--- FAIL: TestAccKubernetesPersistentVolume_googleCloud_basic (25.96s)
    testing.go:538: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        DESTROY/CREATE: kubernetes_persistent_volume.test
          metadata.#:                                                                                   "1" => "1"
          metadata.0.annotations.%:                                                                     "2" => "2"
          metadata.0.annotations.TestAnnotationOne:                                                     "one" => "one"
          metadata.0.annotations.TestAnnotationTwo:                                                     "two" => "two"
          metadata.0.generation:                                                                        "0" => "<computed>"
          metadata.0.labels.%:                                                                          "3" => "3"
          metadata.0.labels.TestLabelOne:                                                               "one" => "one"
          metadata.0.labels.TestLabelThree:                                                             "three" => "three"
          metadata.0.labels.TestLabelTwo:                                                               "two" => "two"
          metadata.0.name:                                                                              "tf-acc-test-b2gwgxrslt" => "tf-acc-test-b2gwgxrslt"
          metadata.0.resource_version:                                                                  "346049" => "<computed>"
          metadata.0.self_link:                                                                         "/api/v1/persistentvolumes/tf-acc-test-b2gwgxrslt" => "<computed>"
          metadata.0.uid:                                                                               "dd3d624d-5b9d-11e9-a958-42010a8e0064" => "<computed>"
          spec.#:                                                                                       "1" => "1"
          spec.0.access_modes.#:                                                                        "1" => "1"
          spec.0.access_modes.1245328686:                                                               "ReadWriteOnce" => "ReadWriteOnce"
          spec.0.capacity.%:                                                                            "1" => "1"
          spec.0.capacity.storage:                                                                      "123Gi" => "123Gi"
          spec.0.node_affinity.#:                                                                       "1" => "0"
          spec.0.node_affinity.0.required.#:                                                            "1" => "0"
          spec.0.node_affinity.0.required.0.node_selector_term.#:                                       "1" => "0"
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.#:                   "2" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.key:               "failure-domain.beta.kubernetes.io/zone" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.operator:          "In" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.#:          "1" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.3196152168: "us-east1-b" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.key:               "failure-domain.beta.kubernetes.io/region" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.operator:          "In" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.#:          "1" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.2035457625: "us-east1" => "" (forces new resource)
          spec.0.persistent_volume_reclaim_policy:                                                      "Retain" => "Retain"
          spec.0.persistent_volume_source.#:                                                            "1" => "1"
          spec.0.persistent_volume_source.0.gce_persistent_disk.#:                                      "1" => "1"
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.pd_name:                              "tf-acc-test-disk-b2gwgxrslt" => "tf-acc-test-disk-b2gwgxrslt"

        STATE:

        google_compute_disk.test:
          ID = tf-acc-test-disk-b2gwgxrslt
          provider = provider.google
          creation_timestamp = 2019-04-10T07:35:07.465-07:00
          description =
          disk_encryption_key.# = 0
          image = https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20170523
          label_fingerprint = 42WmSpB8rSM=
          labels.% = 0
          last_attach_timestamp =
          last_detach_timestamp =
          name = tf-acc-test-disk-b2gwgxrslt
          project = myproject-sandbox
          self_link = https://www.googleapis.com/compute/v1/projects/myproject-sandbox/zones/us-east1-b/disks/tf-acc-test-disk-b2gwgxrslt
          size = 10
          snapshot =
          source_image_encryption_key.# = 0
          source_image_id = 2405673006522696145
          source_snapshot_encryption_key.# = 0
          source_snapshot_id =
          type = pd-ssd
          users.# = 0
          zone = us-east1-b
        kubernetes_persistent_volume.test:
          ID = tf-acc-test-b2gwgxrslt
          provider = provider.kubernetes
          metadata.# = 1
          metadata.0.annotations.% = 2
          metadata.0.annotations.TestAnnotationOne = one
          metadata.0.annotations.TestAnnotationTwo = two
          metadata.0.generation = 0
          metadata.0.labels.% = 3
          metadata.0.labels.TestLabelOne = one
          metadata.0.labels.TestLabelThree = three
          metadata.0.labels.TestLabelTwo = two
          metadata.0.name = tf-acc-test-b2gwgxrslt
          metadata.0.resource_version = 346049
          metadata.0.self_link = /api/v1/persistentvolumes/tf-acc-test-b2gwgxrslt
          metadata.0.uid = dd3d624d-5b9d-11e9-a958-42010a8e0064
          spec.# = 1
          spec.0.access_modes.# = 1
          spec.0.access_modes.1245328686 = ReadWriteOnce
          spec.0.capacity.% = 1
          spec.0.capacity.storage = 123Gi
          spec.0.node_affinity.# = 1
          spec.0.node_affinity.0.required.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.# = 2
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.key = failure-domain.beta.kubernetes.io/zone
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.operator = In
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.3196152168 = us-east1-b
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.key = failure-domain.beta.kubernetes.io/region
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.operator = In
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.2035457625 = us-east1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_fields.# = 0
          spec.0.persistent_volume_reclaim_policy = Retain
          spec.0.persistent_volume_source.# = 1
          spec.0.persistent_volume_source.0.aws_elastic_block_store.# = 0
          spec.0.persistent_volume_source.0.azure_disk.# = 0
          spec.0.persistent_volume_source.0.azure_file.# = 0
          spec.0.persistent_volume_source.0.ceph_fs.# = 0
          spec.0.persistent_volume_source.0.cinder.# = 0
          spec.0.persistent_volume_source.0.fc.# = 0
          spec.0.persistent_volume_source.0.flex_volume.# = 0
          spec.0.persistent_volume_source.0.flocker.# = 0
          spec.0.persistent_volume_source.0.gce_persistent_disk.# = 1
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.fs_type =
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.partition = 0
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.pd_name = tf-acc-test-disk-b2gwgxrslt
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.read_only = false
          spec.0.persistent_volume_source.0.glusterfs.# = 0
          spec.0.persistent_volume_source.0.host_path.# = 0
          spec.0.persistent_volume_source.0.iscsi.# = 0
          spec.0.persistent_volume_source.0.local.# = 0
          spec.0.persistent_volume_source.0.nfs.# = 0
          spec.0.persistent_volume_source.0.photon_persistent_disk.# = 0
          spec.0.persistent_volume_source.0.quobyte.# = 0
          spec.0.persistent_volume_source.0.rbd.# = 0
          spec.0.persistent_volume_source.0.vsphere_volume.# = 0
          spec.0.storage_class_name =

          Dependencies:
            google_compute_disk.test
=== RUN   TestAccKubernetesPersistentVolume_aws_basic
--- SKIP: TestAccKubernetesPersistentVolume_aws_basic (0.00s)
    provider_test.go:200: The environment variables AWS_DEFAULT_REGION, AWS_ZONE, AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set to run AWS tests - skipping
=== RUN   TestAccKubernetesPersistentVolume_googleCloud_importBasic
--- FAIL: TestAccKubernetesPersistentVolume_googleCloud_importBasic (26.04s)
    testing.go:538: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        DESTROY/CREATE: kubernetes_persistent_volume.test
          metadata.#:                                                                                   "1" => "1"
          metadata.0.annotations.%:                                                                     "2" => "2"
          metadata.0.annotations.TestAnnotationOne:                                                     "one" => "one"
          metadata.0.annotations.TestAnnotationTwo:                                                     "two" => "two"
          metadata.0.generation:                                                                        "0" => "<computed>"
          metadata.0.labels.%:                                                                          "3" => "3"
          metadata.0.labels.TestLabelOne:                                                               "one" => "one"
          metadata.0.labels.TestLabelThree:                                                             "three" => "three"
          metadata.0.labels.TestLabelTwo:                                                               "two" => "two"
          metadata.0.name:                                                                              "tf-acc-test-import-ijwtxl9i7m" => "tf-acc-test-import-ijwtxl9i7m"
          metadata.0.resource_version:                                                                  "346123" => "<computed>"
          metadata.0.self_link:                                                                         "/api/v1/persistentvolumes/tf-acc-test-import-ijwtxl9i7m" => "<computed>"
          metadata.0.uid:                                                                               "ecc1d89d-5b9d-11e9-a958-42010a8e0064" => "<computed>"
          spec.#:                                                                                       "1" => "1"
          spec.0.access_modes.#:                                                                        "1" => "1"
          spec.0.access_modes.1245328686:                                                               "ReadWriteOnce" => "ReadWriteOnce"
          spec.0.capacity.%:                                                                            "1" => "1"
          spec.0.capacity.storage:                                                                      "123Gi" => "123Gi"
          spec.0.node_affinity.#:                                                                       "1" => "0"
          spec.0.node_affinity.0.required.#:                                                            "1" => "0"
          spec.0.node_affinity.0.required.0.node_selector_term.#:                                       "1" => "0"
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.#:                   "2" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.key:               "failure-domain.beta.kubernetes.io/zone" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.operator:          "In" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.#:          "1" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.3196152168: "us-east1-b" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.key:               "failure-domain.beta.kubernetes.io/region" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.operator:          "In" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.#:          "1" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.2035457625: "us-east1" => "" (forces new resource)
          spec.0.persistent_volume_reclaim_policy:                                                      "Retain" => "Retain"
          spec.0.persistent_volume_source.#:                                                            "1" => "1"
          spec.0.persistent_volume_source.0.gce_persistent_disk.#:                                      "1" => "1"
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.pd_name:                              "tf-acc-test-disk-ijwtxl9i7m" => "tf-acc-test-disk-ijwtxl9i7m"

        STATE:

        google_compute_disk.test:
          ID = tf-acc-test-disk-ijwtxl9i7m
          provider = provider.google
          creation_timestamp = 2019-04-10T07:35:33.463-07:00
          description =
          disk_encryption_key.# = 0
          image = https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20170523
          label_fingerprint = 42WmSpB8rSM=
          labels.% = 0
          last_attach_timestamp =
          last_detach_timestamp =
          name = tf-acc-test-disk-ijwtxl9i7m
          project = myproject-sandbox
          self_link = https://www.googleapis.com/compute/v1/projects/myproject-sandbox/zones/us-east1-b/disks/tf-acc-test-disk-ijwtxl9i7m
          size = 10
          snapshot =
          source_image_encryption_key.# = 0
          source_image_id = 2405673006522696145
          source_snapshot_encryption_key.# = 0
          source_snapshot_id =
          type = pd-ssd
          users.# = 0
          zone = us-east1-b
        kubernetes_persistent_volume.test:
          ID = tf-acc-test-import-ijwtxl9i7m
          provider = provider.kubernetes
          metadata.# = 1
          metadata.0.annotations.% = 2
          metadata.0.annotations.TestAnnotationOne = one
          metadata.0.annotations.TestAnnotationTwo = two
          metadata.0.generation = 0
          metadata.0.labels.% = 3
          metadata.0.labels.TestLabelOne = one
          metadata.0.labels.TestLabelThree = three
          metadata.0.labels.TestLabelTwo = two
          metadata.0.name = tf-acc-test-import-ijwtxl9i7m
          metadata.0.resource_version = 346123
          metadata.0.self_link = /api/v1/persistentvolumes/tf-acc-test-import-ijwtxl9i7m
          metadata.0.uid = ecc1d89d-5b9d-11e9-a958-42010a8e0064
          spec.# = 1
          spec.0.access_modes.# = 1
          spec.0.access_modes.1245328686 = ReadWriteOnce
          spec.0.capacity.% = 1
          spec.0.capacity.storage = 123Gi
          spec.0.node_affinity.# = 1
          spec.0.node_affinity.0.required.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.# = 2
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.key = failure-domain.beta.kubernetes.io/zone
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.operator = In
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.3196152168 = us-east1-b
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.key = failure-domain.beta.kubernetes.io/region
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.operator = In
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.2035457625 = us-east1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_fields.# = 0
          spec.0.persistent_volume_reclaim_policy = Retain
          spec.0.persistent_volume_source.# = 1
          spec.0.persistent_volume_source.0.aws_elastic_block_store.# = 0
          spec.0.persistent_volume_source.0.azure_disk.# = 0
          spec.0.persistent_volume_source.0.azure_file.# = 0
          spec.0.persistent_volume_source.0.ceph_fs.# = 0
          spec.0.persistent_volume_source.0.cinder.# = 0
          spec.0.persistent_volume_source.0.fc.# = 0
          spec.0.persistent_volume_source.0.flex_volume.# = 0
          spec.0.persistent_volume_source.0.flocker.# = 0
          spec.0.persistent_volume_source.0.gce_persistent_disk.# = 1
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.fs_type =
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.partition = 0
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.pd_name = tf-acc-test-disk-ijwtxl9i7m
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.read_only = false
          spec.0.persistent_volume_source.0.glusterfs.# = 0
          spec.0.persistent_volume_source.0.host_path.# = 0
          spec.0.persistent_volume_source.0.iscsi.# = 0
          spec.0.persistent_volume_source.0.local.# = 0
          spec.0.persistent_volume_source.0.nfs.# = 0
          spec.0.persistent_volume_source.0.photon_persistent_disk.# = 0
          spec.0.persistent_volume_source.0.quobyte.# = 0
          spec.0.persistent_volume_source.0.rbd.# = 0
          spec.0.persistent_volume_source.0.vsphere_volume.# = 0
          spec.0.storage_class_name =

          Dependencies:
            google_compute_disk.test
=== RUN   TestAccKubernetesPersistentVolume_googleCloud_volumeSource
--- FAIL: TestAccKubernetesPersistentVolume_googleCloud_volumeSource (25.54s)
    testing.go:538: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        DESTROY/CREATE: kubernetes_persistent_volume.test
          metadata.#:                                                                                   "1" => "1"
          metadata.0.generation:                                                                        "0" => "<computed>"
          metadata.0.name:                                                                              "tf-acc-test-427ghxeu0j" => "tf-acc-test-427ghxeu0j"
          metadata.0.resource_version:                                                                  "346203" => "<computed>"
          metadata.0.self_link:                                                                         "/api/v1/persistentvolumes/tf-acc-test-427ghxeu0j" => "<computed>"
          metadata.0.uid:                                                                               "fc2f878a-5b9d-11e9-a958-42010a8e0064" => "<computed>"
          spec.#:                                                                                       "1" => "1"
          spec.0.access_modes.#:                                                                        "1" => "1"
          spec.0.access_modes.1245328686:                                                               "ReadWriteOnce" => "ReadWriteOnce"
          spec.0.capacity.%:                                                                            "1" => "1"
          spec.0.capacity.storage:                                                                      "123Gi" => "123Gi"
          spec.0.node_affinity.#:                                                                       "1" => "0"
          spec.0.node_affinity.0.required.#:                                                            "1" => "0"
          spec.0.node_affinity.0.required.0.node_selector_term.#:                                       "1" => "0"
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.#:                   "2" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.key:               "failure-domain.beta.kubernetes.io/zone" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.operator:          "In" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.#:          "1" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.3196152168: "us-east1-b" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.key:               "failure-domain.beta.kubernetes.io/region" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.operator:          "In" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.#:          "1" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.2035457625: "us-east1" => "" (forces new resource)
          spec.0.persistent_volume_reclaim_policy:                                                      "Retain" => "Retain"
          spec.0.persistent_volume_source.#:                                                            "1" => "1"
          spec.0.persistent_volume_source.0.gce_persistent_disk.#:                                      "1" => "1"
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.pd_name:                              "tf-acc-test-disk-427ghxeu0j" => "tf-acc-test-disk-427ghxeu0j"

        STATE:

        google_compute_disk.test:
          ID = tf-acc-test-disk-427ghxeu0j
          provider = provider.google
          creation_timestamp = 2019-04-10T07:35:59.452-07:00
          description =
          disk_encryption_key.# = 0
          image = https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20170523
          label_fingerprint = 42WmSpB8rSM=
          labels.% = 0
          last_attach_timestamp =
          last_detach_timestamp =
          name = tf-acc-test-disk-427ghxeu0j
          project = myproject-sandbox
          self_link = https://www.googleapis.com/compute/v1/projects/myproject-sandbox/zones/us-east1-b/disks/tf-acc-test-disk-427ghxeu0j
          size = 12
          snapshot =
          source_image_encryption_key.# = 0
          source_image_id = 2405673006522696145
          source_snapshot_encryption_key.# = 0
          source_snapshot_id =
          type = pd-ssd
          users.# = 0
          zone = us-east1-b
        kubernetes_persistent_volume.test:
          ID = tf-acc-test-427ghxeu0j
          provider = provider.kubernetes
          metadata.# = 1
          metadata.0.annotations.% = 0
          metadata.0.generation = 0
          metadata.0.labels.% = 0
          metadata.0.name = tf-acc-test-427ghxeu0j
          metadata.0.resource_version = 346203
          metadata.0.self_link = /api/v1/persistentvolumes/tf-acc-test-427ghxeu0j
          metadata.0.uid = fc2f878a-5b9d-11e9-a958-42010a8e0064
          spec.# = 1
          spec.0.access_modes.# = 1
          spec.0.access_modes.1245328686 = ReadWriteOnce
          spec.0.capacity.% = 1
          spec.0.capacity.storage = 123Gi
          spec.0.node_affinity.# = 1
          spec.0.node_affinity.0.required.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.# = 2
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.key = failure-domain.beta.kubernetes.io/zone
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.operator = In
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.3196152168 = us-east1-b
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.key = failure-domain.beta.kubernetes.io/region
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.operator = In
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.2035457625 = us-east1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_fields.# = 0
          spec.0.persistent_volume_reclaim_policy = Retain
          spec.0.persistent_volume_source.# = 1
          spec.0.persistent_volume_source.0.aws_elastic_block_store.# = 0
          spec.0.persistent_volume_source.0.azure_disk.# = 0
          spec.0.persistent_volume_source.0.azure_file.# = 0
          spec.0.persistent_volume_source.0.ceph_fs.# = 0
          spec.0.persistent_volume_source.0.cinder.# = 0
          spec.0.persistent_volume_source.0.fc.# = 0
          spec.0.persistent_volume_source.0.flex_volume.# = 0
          spec.0.persistent_volume_source.0.flocker.# = 0
          spec.0.persistent_volume_source.0.gce_persistent_disk.# = 1
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.fs_type =
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.partition = 0
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.pd_name = tf-acc-test-disk-427ghxeu0j
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.read_only = false
          spec.0.persistent_volume_source.0.glusterfs.# = 0
          spec.0.persistent_volume_source.0.host_path.# = 0
          spec.0.persistent_volume_source.0.iscsi.# = 0
          spec.0.persistent_volume_source.0.local.# = 0
          spec.0.persistent_volume_source.0.nfs.# = 0
          spec.0.persistent_volume_source.0.photon_persistent_disk.# = 0
          spec.0.persistent_volume_source.0.quobyte.# = 0
          spec.0.persistent_volume_source.0.rbd.# = 0
          spec.0.persistent_volume_source.0.vsphere_volume.# = 0
          spec.0.storage_class_name =

          Dependencies:
            google_compute_disk.test
=== RUN   TestAccKubernetesPersistentVolume_hostPath_volumeSource
--- PASS: TestAccKubernetesPersistentVolume_hostPath_volumeSource (2.99s)
=== RUN   TestAccKubernetesPersistentVolume_local_volumeSource
--- PASS: TestAccKubernetesPersistentVolume_local_volumeSource (3.05s)
=== RUN   TestAccKubernetesPersistentVolume_cephFsSecretRef
--- PASS: TestAccKubernetesPersistentVolume_cephFsSecretRef (1.51s)
=== RUN   TestAccKubernetesPersistentVolume_storageClass
--- FAIL: TestAccKubernetesPersistentVolume_storageClass (26.16s)
    testing.go:538: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        DESTROY/CREATE: kubernetes_persistent_volume.test
          metadata.#:                                                                                   "1" => "1"
          metadata.0.generation:                                                                        "0" => "<computed>"
          metadata.0.name:                                                                              "tf-acc-test-yik9p88wsv" => "tf-acc-test-yik9p88wsv"
          metadata.0.resource_version:                                                                  "346318" => "<computed>"
          metadata.0.self_link:                                                                         "/api/v1/persistentvolumes/tf-acc-test-yik9p88wsv" => "<computed>"
          metadata.0.uid:                                                                               "1004d677-5b9e-11e9-a958-42010a8e0064" => "<computed>"
          spec.#:                                                                                       "1" => "1"
          spec.0.access_modes.#:                                                                        "1" => "1"
          spec.0.access_modes.1254135962:                                                               "ReadWriteMany" => "ReadWriteMany"
          spec.0.capacity.%:                                                                            "1" => "1"
          spec.0.capacity.storage:                                                                      "123Gi" => "123Gi"
          spec.0.node_affinity.#:                                                                       "1" => "0"
          spec.0.node_affinity.0.required.#:                                                            "1" => "0"
          spec.0.node_affinity.0.required.0.node_selector_term.#:                                       "1" => "0"
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.#:                   "2" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.key:               "failure-domain.beta.kubernetes.io/zone" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.operator:          "In" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.#:          "1" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.3196152168: "us-east1-b" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.key:               "failure-domain.beta.kubernetes.io/region" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.operator:          "In" => "" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.#:          "1" => "0" (forces new resource)
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.2035457625: "us-east1" => "" (forces new resource)
          spec.0.persistent_volume_reclaim_policy:                                                      "Retain" => "Retain"
          spec.0.persistent_volume_source.#:                                                            "1" => "1"
          spec.0.persistent_volume_source.0.gce_persistent_disk.#:                                      "1" => "1"
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.pd_name:                              "tf-acc-test-disk-yik9p88wsv" => "tf-acc-test-disk-yik9p88wsv"
          spec.0.storage_class_name:                                                                    "tf-acc-test-sc-yik9p88wsv" => "tf-acc-test-sc-yik9p88wsv"

        STATE:

        google_compute_disk.test:
          ID = tf-acc-test-disk-yik9p88wsv
          provider = provider.google
          creation_timestamp = 2019-04-10T07:36:32.554-07:00
          description =
          disk_encryption_key.# = 0
          image = https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20170523
          label_fingerprint = 42WmSpB8rSM=
          labels.% = 0
          last_attach_timestamp =
          last_detach_timestamp =
          name = tf-acc-test-disk-yik9p88wsv
          project = myproject-sandbox
          self_link = https://www.googleapis.com/compute/v1/projects/myproject-sandbox/zones/us-east1-b/disks/tf-acc-test-disk-yik9p88wsv
          size = 12
          snapshot =
          source_image_encryption_key.# = 0
          source_image_id = 2405673006522696145
          source_snapshot_encryption_key.# = 0
          source_snapshot_id =
          type = pd-ssd
          users.# = 0
          zone = us-east1-b
        kubernetes_persistent_volume.test:
          ID = tf-acc-test-yik9p88wsv
          provider = provider.kubernetes
          metadata.# = 1
          metadata.0.annotations.% = 0
          metadata.0.generation = 0
          metadata.0.labels.% = 0
          metadata.0.name = tf-acc-test-yik9p88wsv
          metadata.0.resource_version = 346318
          metadata.0.self_link = /api/v1/persistentvolumes/tf-acc-test-yik9p88wsv
          metadata.0.uid = 1004d677-5b9e-11e9-a958-42010a8e0064
          spec.# = 1
          spec.0.access_modes.# = 1
          spec.0.access_modes.1254135962 = ReadWriteMany
          spec.0.capacity.% = 1
          spec.0.capacity.storage = 123Gi
          spec.0.node_affinity.# = 1
          spec.0.node_affinity.0.required.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.# = 2
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.key = failure-domain.beta.kubernetes.io/zone
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.operator = In
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.0.values.3196152168 = us-east1-b
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.key = failure-domain.beta.kubernetes.io/region
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.operator = In
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.# = 1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_expressions.1.values.2035457625 = us-east1
          spec.0.node_affinity.0.required.0.node_selector_term.0.match_fields.# = 0
          spec.0.persistent_volume_reclaim_policy = Retain
          spec.0.persistent_volume_source.# = 1
          spec.0.persistent_volume_source.0.aws_elastic_block_store.# = 0
          spec.0.persistent_volume_source.0.azure_disk.# = 0
          spec.0.persistent_volume_source.0.azure_file.# = 0
          spec.0.persistent_volume_source.0.ceph_fs.# = 0
          spec.0.persistent_volume_source.0.cinder.# = 0
          spec.0.persistent_volume_source.0.fc.# = 0
          spec.0.persistent_volume_source.0.flex_volume.# = 0
          spec.0.persistent_volume_source.0.flocker.# = 0
          spec.0.persistent_volume_source.0.gce_persistent_disk.# = 1
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.fs_type =
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.partition = 0
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.pd_name = tf-acc-test-disk-yik9p88wsv
          spec.0.persistent_volume_source.0.gce_persistent_disk.0.read_only = false
          spec.0.persistent_volume_source.0.glusterfs.# = 0
          spec.0.persistent_volume_source.0.host_path.# = 0
          spec.0.persistent_volume_source.0.iscsi.# = 0
          spec.0.persistent_volume_source.0.local.# = 0
          spec.0.persistent_volume_source.0.nfs.# = 0
          spec.0.persistent_volume_source.0.photon_persistent_disk.# = 0
          spec.0.persistent_volume_source.0.quobyte.# = 0
          spec.0.persistent_volume_source.0.rbd.# = 0
          spec.0.persistent_volume_source.0.vsphere_volume.# = 0
          spec.0.storage_class_name = tf-acc-test-sc-yik9p88wsv

          Dependencies:
            google_compute_disk.test
            kubernetes_storage_class.test
        kubernetes_storage_class.test:
          ID = tf-acc-test-sc-yik9p88wsv
          provider = provider.kubernetes
          allow_volume_expansion = true
          metadata.# = 1
          metadata.0.annotations.% = 0
          metadata.0.generate_name =
          metadata.0.generation = 0
          metadata.0.labels.% = 0
          metadata.0.name = tf-acc-test-sc-yik9p88wsv
          metadata.0.resource_version = 346280
          metadata.0.self_link = /apis/storage.k8s.io/v1/storageclasses/tf-acc-test-sc-yik9p88wsv
          metadata.0.uid = 07e652ea-5b9e-11e9-a958-42010a8e0064
          parameters.% = 1
          parameters.type = pd-ssd
          reclaim_policy = Delete
          storage_provisioner = kubernetes.io/gce-pd
          volume_binding_mode = Immediate
        kubernetes_storage_class.test2:
          ID = tf-acc-test-sc2-yik9p88wsv
          provider = provider.kubernetes
          allow_volume_expansion = true
          metadata.# = 1
          metadata.0.annotations.% = 0
          metadata.0.generate_name =
          metadata.0.generation = 0
          metadata.0.labels.% = 0
          metadata.0.name = tf-acc-test-sc2-yik9p88wsv
          metadata.0.resource_version = 346281
          metadata.0.self_link = /apis/storage.k8s.io/v1/storageclasses/tf-acc-test-sc2-yik9p88wsv
          metadata.0.uid = 07e77361-5b9e-11e9-a958-42010a8e0064
          parameters.% = 1
          parameters.type = pd-standard
          reclaim_policy = Delete
          storage_provisioner = kubernetes.io/gce-pd
          volume_binding_mode = Immediate
=== RUN   TestAccKubernetesPersistentVolume_hostPath_nodeAffinity
--- PASS: TestAccKubernetesPersistentVolume_hostPath_nodeAffinity (5.94s)
=== RUN   TestAccKubernetesPod_basic
--- PASS: TestAccKubernetesPod_basic (23.33s)
=== RUN   TestAccKubernetesPod_initContainer_updateForcesNew
--- PASS: TestAccKubernetesPod_initContainer_updateForcesNew (21.83s)
=== RUN   TestAccKubernetesPod_updateArgsForceNew
--- PASS: TestAccKubernetesPod_updateArgsForceNew (90.72s)
=== RUN   TestAccKubernetesPod_updateEnvForceNew
--- PASS: TestAccKubernetesPod_updateEnvForceNew (12.15s)
=== RUN   TestAccKubernetesPod_importBasic
--- PASS: TestAccKubernetesPod_importBasic (8.84s)
=== RUN   TestAccKubernetesPod_with_pod_security_context
--- PASS: TestAccKubernetesPod_with_pod_security_context (11.10s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_exec
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_exec (41.20s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_http_get
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_http_get (19.26s)
=== RUN   TestAccKubernetesPod_with_container_liveness_probe_using_tcp
--- PASS: TestAccKubernetesPod_with_container_liveness_probe_using_tcp (19.20s)
=== RUN   TestAccKubernetesPod_with_container_lifecycle
--- PASS: TestAccKubernetesPod_with_container_lifecycle (20.94s)
=== RUN   TestAccKubernetesPod_with_container_security_context
--- PASS: TestAccKubernetesPod_with_container_security_context (6.98s)
=== RUN   TestAccKubernetesPod_with_volume_mount
--- PASS: TestAccKubernetesPod_with_volume_mount (11.05s)
=== RUN   TestAccKubernetesPod_with_cfg_map_volume_mount
--- PASS: TestAccKubernetesPod_with_cfg_map_volume_mount (9.54s)
=== RUN   TestAccKubernetesPod_with_resource_requirements
--- PASS: TestAccKubernetesPod_with_resource_requirements (6.98s)
=== RUN   TestAccKubernetesPod_with_empty_dir_volume
--- PASS: TestAccKubernetesPod_with_empty_dir_volume (6.98s)
=== RUN   TestAccKubernetesPod_with_secret_vol_items
--- PASS: TestAccKubernetesPod_with_secret_vol_items (9.69s)
=== RUN   TestAccKubernetesPod_gke_with_nodeSelector
--- PASS: TestAccKubernetesPod_gke_with_nodeSelector (19.36s)
=== RUN   TestAccKubernetesReplicationController_deprecated_basic
--- PASS: TestAccKubernetesReplicationController_deprecated_basic (115.62s)
=== RUN   TestAccKubernetesReplicationController_deprecated_initContainer
--- PASS: TestAccKubernetesReplicationController_deprecated_initContainer (114.68s)
=== RUN   TestAccKubernetesReplicationController_deprecated_importBasic
--- PASS: TestAccKubernetesReplicationController_deprecated_importBasic (114.85s)
=== RUN   TestAccKubernetesReplicationController_deprecated_generatedName
--- PASS: TestAccKubernetesReplicationController_deprecated_generatedName (1.50s)
=== RUN   TestAccKubernetesReplicationController_deprecated_importGeneratedName
--- PASS: TestAccKubernetesReplicationController_deprecated_importGeneratedName (1.60s)
=== RUN   TestAccKubernetesReplicationController_deprecated_with_security_context
--- PASS: TestAccKubernetesReplicationController_deprecated_with_security_context (1.49s)
=== RUN   TestAccKubernetesReplicationController_deprecated_with_container_liveness_probe_using_exec
--- PASS: TestAccKubernetesReplicationController_deprecated_with_container_liveness_probe_using_exec (1.51s)
=== RUN   TestAccKubernetesReplicationController_deprecated_with_container_liveness_probe_using_http_get
--- PASS: TestAccKubernetesReplicationController_deprecated_with_container_liveness_probe_using_http_get (1.52s)
=== RUN   TestAccKubernetesReplicationController_deprecated_with_container_liveness_probe_using_tcp
--- PASS: TestAccKubernetesReplicationController_deprecated_with_container_liveness_probe_using_tcp (1.52s)
=== RUN   TestAccKubernetesReplicationController_deprecated_with_container_lifecycle
--- PASS: TestAccKubernetesReplicationController_deprecated_with_container_lifecycle (1.52s)
=== RUN   TestAccKubernetesReplicationController_deprecated_with_container_security_context
--- PASS: TestAccKubernetesReplicationController_deprecated_with_container_security_context (1.48s)
=== RUN   TestAccKubernetesReplicationController_deprecated_with_volume_mount
--- PASS: TestAccKubernetesReplicationController_deprecated_with_volume_mount (2.34s)
=== RUN   TestAccKubernetesReplicationController_deprecated_with_resource_requirements
--- PASS: TestAccKubernetesReplicationController_deprecated_with_resource_requirements (1.52s)
=== RUN   TestAccKubernetesReplicationController_deprecated_with_empty_dir_volume
--- PASS: TestAccKubernetesReplicationController_deprecated_with_empty_dir_volume (1.52s)
=== RUN   TestAccKubernetesReplicationController_basic
--- PASS: TestAccKubernetesReplicationController_basic (115.68s)
=== RUN   TestAccKubernetesReplicationController_initContainer
--- PASS: TestAccKubernetesReplicationController_initContainer (114.80s)
=== RUN   TestAccKubernetesReplicationController_importBasic
--- PASS: TestAccKubernetesReplicationController_importBasic (114.80s)
=== RUN   TestAccKubernetesReplicationController_generatedName
--- PASS: TestAccKubernetesReplicationController_generatedName (1.49s)
=== RUN   TestAccKubernetesReplicationController_importGeneratedName
--- PASS: TestAccKubernetesReplicationController_importGeneratedName (1.62s)
=== RUN   TestAccKubernetesReplicationController_with_security_context
--- PASS: TestAccKubernetesReplicationController_with_security_context (1.50s)
=== RUN   TestAccKubernetesReplicationController_with_container_liveness_probe_using_exec
--- PASS: TestAccKubernetesReplicationController_with_container_liveness_probe_using_exec (1.52s)
=== RUN   TestAccKubernetesReplicationController_with_container_liveness_probe_using_http_get
--- PASS: TestAccKubernetesReplicationController_with_container_liveness_probe_using_http_get (1.53s)
=== RUN   TestAccKubernetesReplicationController_with_container_liveness_probe_using_tcp
--- PASS: TestAccKubernetesReplicationController_with_container_liveness_probe_using_tcp (1.50s)
=== RUN   TestAccKubernetesReplicationController_with_container_lifecycle
--- PASS: TestAccKubernetesReplicationController_with_container_lifecycle (1.52s)
=== RUN   TestAccKubernetesReplicationController_with_container_security_context
--- PASS: TestAccKubernetesReplicationController_with_container_security_context (1.52s)
=== RUN   TestAccKubernetesReplicationController_with_volume_mount
--- PASS: TestAccKubernetesReplicationController_with_volume_mount (2.37s)
=== RUN   TestAccKubernetesReplicationController_with_resource_requirements
--- PASS: TestAccKubernetesReplicationController_with_resource_requirements (1.54s)
=== RUN   TestAccKubernetesReplicationController_with_empty_dir_volume
--- PASS: TestAccKubernetesReplicationController_with_empty_dir_volume (1.54s)
=== RUN   TestAccKubernetesResourceQuota_basic
--- PASS: TestAccKubernetesResourceQuota_basic (3.20s)
=== RUN   TestAccKubernetesResourceQuota_generatedName
--- PASS: TestAccKubernetesResourceQuota_generatedName (1.23s)
=== RUN   TestAccKubernetesResourceQuota_withScopes
--- PASS: TestAccKubernetesResourceQuota_withScopes (2.32s)
=== RUN   TestAccKubernetesResourceQuota_importBasic
--- PASS: TestAccKubernetesResourceQuota_importBasic (1.36s)
=== RUN   TestAccKubernetesRoleBinding_basic
--- PASS: TestAccKubernetesRoleBinding_basic (1.98s)
=== RUN   TestAccKubernetesRoleBinding_importBasic
--- PASS: TestAccKubernetesRoleBinding_importBasic (1.26s)
=== RUN   TestAccKubernetesRoleBinding_sa_subject
--- PASS: TestAccKubernetesRoleBinding_sa_subject (1.10s)
=== RUN   TestAccKubernetesRoleBinding_group_subject
--- PASS: TestAccKubernetesRoleBinding_group_subject (1.12s)
=== RUN   TestAccKubernetesRole_basic
--- PASS: TestAccKubernetesRole_basic (2.21s)
=== RUN   TestAccKubernetesRole_importBasic
--- PASS: TestAccKubernetesRole_importBasic (1.46s)
=== RUN   TestAccKubernetesRole_generatedName
--- PASS: TestAccKubernetesRole_generatedName (1.15s)
=== RUN   TestAccKubernetesSecret_basic
--- PASS: TestAccKubernetesSecret_basic (4.67s)
=== RUN   TestAccKuberNetesSecret_dotInName
--- PASS: TestAccKuberNetesSecret_dotInName (1.12s)
=== RUN   TestAccKubernetesSecret_importBasic
--- PASS: TestAccKubernetesSecret_importBasic (1.24s)
=== RUN   TestAccKubernetesSecret_generatedName
--- PASS: TestAccKubernetesSecret_generatedName (1.11s)
=== RUN   TestAccKubernetesSecret_importGeneratedName
--- PASS: TestAccKubernetesSecret_importGeneratedName (1.24s)
=== RUN   TestAccKubernetesSecret_binaryData
--- PASS: TestAccKubernetesSecret_binaryData (2.22s)
=== RUN   TestAccKubernetesServiceAccount_basic
--- PASS: TestAccKubernetesServiceAccount_basic (2.25s)
=== RUN   TestAccKubernetesServiceAccount_automount
--- PASS: TestAccKubernetesServiceAccount_automount (2.25s)
=== RUN   TestAccKubernetesServiceAccount_update
--- PASS: TestAccKubernetesServiceAccount_update (4.11s)
=== RUN   TestAccKubernetesServiceAccount_generatedName
--- PASS: TestAccKubernetesServiceAccount_generatedName (1.35s)
=== RUN   TestAccKubernetesServiceAccount_importBasic
--- PASS: TestAccKubernetesServiceAccount_importBasic (2.57s)
=== RUN   TestAccKubernetesService_basic
--- PASS: TestAccKubernetesService_basic (3.08s)
=== RUN   TestAccKubernetesService_loadBalancer
--- PASS: TestAccKubernetesService_loadBalancer (58.95s)
=== RUN   TestAccKubernetesService_nodePort
--- PASS: TestAccKubernetesService_nodePort (1.14s)
=== RUN   TestAccKubernetesService_noTargetPort
--- PASS: TestAccKubernetesService_noTargetPort (98.41s)
=== RUN   TestAccKubernetesService_stringTargetPort
--- PASS: TestAccKubernetesService_stringTargetPort (108.53s)
=== RUN   TestAccKubernetesService_externalName
--- PASS: TestAccKubernetesService_externalName (1.13s)
=== RUN   TestAccKubernetesService_importBasic
--- PASS: TestAccKubernetesService_importBasic (1.90s)
=== RUN   TestAccKubernetesService_generatedName
--- PASS: TestAccKubernetesService_generatedName (1.30s)
=== RUN   TestAccKubernetesService_importGeneratedName
--- PASS: TestAccKubernetesService_importGeneratedName (1.26s)
=== RUN   TestAccKubernetesStatefulSet_basic
--- PASS: TestAccKubernetesStatefulSet_basic (1.33s)
=== RUN   TestAccKubernetesStatefulSet_basic_idempotency
--- PASS: TestAccKubernetesStatefulSet_basic_idempotency (1.83s)
=== RUN   TestAccKubernetesStatefulSet_update_image
--- PASS: TestAccKubernetesStatefulSet_update_image (2.22s)
=== RUN   TestAccKubernetesStatefulSet_update_template_selector_labels
--- PASS: TestAccKubernetesStatefulSet_update_template_selector_labels (2.47s)
=== RUN   TestAccKubernetesStatefulSet_update_replicas
--- PASS: TestAccKubernetesStatefulSet_update_replicas (2.22s)
=== RUN   TestAccKubernetesStatefulSet_update_rolling_update_partition
--- PASS: TestAccKubernetesStatefulSet_update_rolling_update_partition (2.20s)
=== RUN   TestAccKubernetesStatefulSet_update_update_strategy_on_delete
--- PASS: TestAccKubernetesStatefulSet_update_update_strategy_on_delete (2.22s)
=== RUN   TestAccKubernetesStatefulSet_update_update_strategy_rolling_update
--- PASS: TestAccKubernetesStatefulSet_update_update_strategy_rolling_update (2.22s)
=== RUN   TestAccKubernetesStatefulSet_update_pod_template_container_port
--- PASS: TestAccKubernetesStatefulSet_update_pod_template_container_port (2.48s)
=== RUN   TestAccKubernetesStorageClass_basic
--- PASS: TestAccKubernetesStorageClass_basic (3.09s)
=== RUN   TestAccKubernetesStorageClass_importBasic
--- PASS: TestAccKubernetesStorageClass_importBasic (1.23s)
=== RUN   TestAccKubernetesStorageClass_generatedName
--- PASS: TestAccKubernetesStorageClass_generatedName (1.09s)
=== RUN   TestAccKubernetesStorageClass_importGeneratedName
--- PASS: TestAccKubernetesStorageClass_importGeneratedName (1.21s)
=== RUN   TestFlattenEndpointAddresses
--- PASS: TestFlattenEndpointAddresses (0.00s)
=== RUN   TestFlattenEndpointPorts
--- PASS: TestFlattenEndpointPorts (0.00s)
=== RUN   TestFlattenEndpointSubsets
--- PASS: TestFlattenEndpointSubsets (0.00s)
=== RUN   TestExpandEndpointAddresses
--- PASS: TestExpandEndpointAddresses (0.00s)
=== RUN   TestExpandEndpointPorts
--- PASS: TestExpandEndpointPorts (0.00s)
=== RUN   TestExpandEndpointSubsets
--- PASS: TestExpandEndpointSubsets (0.00s)
=== RUN   TestFlattenLabelSelector
--- PASS: TestFlattenLabelSelector (0.00s)
=== RUN   TestFlattenNetworkPolicyIngressPorts
--- PASS: TestFlattenNetworkPolicyIngressPorts (0.00s)
=== RUN   TestExpandNetworkPolicyIngressPorts
--- PASS: TestExpandNetworkPolicyIngressPorts (0.00s)
=== RUN   TestIsInternalKey
=== RUN   TestIsInternalKey/0
=== RUN   TestIsInternalKey/1
=== RUN   TestIsInternalKey/2
=== RUN   TestIsInternalKey/3
=== RUN   TestIsInternalKey/4
=== RUN   TestIsInternalKey/5
=== RUN   TestIsInternalKey/6
--- PASS: TestIsInternalKey (0.00s)
    --- PASS: TestIsInternalKey/0 (0.00s)
    --- PASS: TestIsInternalKey/1 (0.00s)
    --- PASS: TestIsInternalKey/2 (0.00s)
    --- PASS: TestIsInternalKey/3 (0.00s)
    --- PASS: TestIsInternalKey/4 (0.00s)
    --- PASS: TestIsInternalKey/5 (0.00s)
    --- PASS: TestIsInternalKey/6 (0.00s)
=== RUN   TestValidateModeBits
--- PASS: TestValidateModeBits (0.00s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-kubernetes/kubernetes 2009.662s
make: *** [GNUmakefile:17: testacc] Error 1
```