### PR TITLE
Fix empty node_affinity / node_selector_term / match_expressions crash

### DIFF
--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -119,7 +119,7 @@ func resourceKubernetesPersistentVolume() *schema.Resource {
 											Schema: map[string]*schema.Schema{
 												"node_selector_term": {
 													Type:     schema.TypeList,
-													Optional: true,
+													Required: true,
 													Elem: &schema.Resource{
 														Schema: nodeSelectorTermFields(),
 													},

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -641,6 +641,14 @@ resource "kubernetes_persistent_volume" "test" {
         pd_name = "${google_compute_disk.test.name}"
       }
     }
+
+    node_affinity {
+      required {
+        node_selector_term {
+          match_expressions = [{}]
+        }
+      }
+    }
   }
 }
 

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -645,7 +645,12 @@ resource "kubernetes_persistent_volume" "test" {
     node_affinity {
       required {
         node_selector_term {
-          match_expressions = [{}]
+          match_expressions = [
+            {
+              key      = "test"
+              operator = "Exists"
+            }
+          ]
         }
       }
     }

--- a/kubernetes/schema_node_selector_term.go
+++ b/kubernetes/schema_node_selector_term.go
@@ -9,13 +9,13 @@ func nodeSelectorRequirementFields() map[string]*schema.Schema {
 		"key": {
 			Type:        schema.TypeString,
 			Description: "The label key that the selector applies to.",
-			Optional:    true,
+			Required:    true,
 			ForceNew:    true,
 		},
 		"operator": {
 			Type:        schema.TypeString,
-			Description: "A key's relationship to a set of values. Valid operators ard `In`, `NotIn`, `Exists` and `DoesNotExist`.",
-			Optional:    true,
+			Description: "A key's relationship to a set of values. Valid operators ard `In`, `NotIn`, `Exists`, `DoesNotExist`, `Gt`, and `Lt`.",
+			Required:    true,
 			ForceNew:    true,
 		},
 		"values": {

--- a/website/docs/r/persistent_volume.html.markdown
+++ b/website/docs/r/persistent_volume.html.markdown
@@ -48,9 +48,37 @@ The following arguments are supported:
 
 * `access_modes` - (Required) Contains all ways the volume can be mounted. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/persistent-volumes#access-modes)
 * `capacity` - (Required) A description of the persistent volume's resources and capacity. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/persistent-volumes#capacity)
+* `node_affinity` - (Optional) NodeAffinity defines constraints that limit what nodes this volume can be accessed from. This field influences the scheduling of pods that use this volume.
 * `persistent_volume_reclaim_policy` - (Optional) What happens to a persistent volume when released from its claim. Valid options are Retain (default) and Recycle. Recycling must be supported by the volume plugin underlying this persistent volume. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/persistent-volumes#recycling-policy)
 * `persistent_volume_source` - (Required) The specification of a persistent volume.
 * `storage_class_name` - (Optional) The name of the persistent volume's storage class. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class)
+
+### `node_affinity`
+
+#### Arguments
+
+* `required` - (Optional) Required specifies hard node constraints that must be met.
+
+### `required`
+
+#### Arguments
+
+* `node_selector_terms` - (Required) A list of node selector terms. The terms are ORed.
+
+### `node_selector_terms`
+
+#### Arguments
+
+* `match_expressions` - (Optional) A list of node selector requirements by node's labels.
+* `match_fields` - (Optional) A list of node selector requirements by node's fields.
+
+### `match_expressions` and `match_fields`
+
+#### Arguments
+
+* `key` - (Required) The label key that the selector applies to.
+* `operator` - (Required) Represents a key's relationship to a set of values. Valid operators are `In`, `NotIn`, `Exists`, `DoesNotExist`. `Gt`, and `Lt`.
+* `values` - (Optional) An array of string values. If the operator is `In` or `NotIn`, the values array must be non-empty. If the operator is `Exists` or `DoesNotExist`, the values array must be empty. If the operator is `Gt` or `Lt`, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
 
 ### `persistent_volume_source`
 


### PR DESCRIPTION
This PR adds a test case with a `node_affinity` containing an empty `node_selector_term` `match_expressions` list:

```
    node_affinity {
      required {
        node_selector_term {
          match_expressions = [{}]
        }
      }
    }
```

This configuration has real world usage but is accepted by the provider and demonstrates a crash of the provider:

```
# make testacc TEST=./kubernetes TESTARGS='-run=TestAccKubernetesPersistentVolume_googleCloud_basic -count=1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./kubernetes -v -run=TestAccKubernetesPersistentVolume_googleCloud_basic -count=1 -timeout 120m
=== RUN   TestAccKubernetesPersistentVolume_googleCloud_basic
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 367 [running]:
github.com/terraform-providers/terraform-provider-kubernetes/kubernetes.expandNodeSelectorRequirementList(0xc00110be30, 0x1, 0x1, 0x11, 0xc000a675e8, 0x10)
        /home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/kubernetes/structures.go:527 +0x328
github.com/terraform-providers/terraform-provider-kubernetes/kubernetes.expandNodeSelectorTerm(0xc00110be10, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/kubernetes/structures.go:553 +0x1e5
github.com/terraform-providers/terraform-provider-kubernetes/kubernetes.expandVolumeNodeAffinity(0xc00110bdd0, 0x1, 0x1, 0xd)
        /home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/kubernetes/structure_persistent_volume_spec.go:1532 +0x191
github.com/terraform-providers/terraform-provider-kubernetes/kubernetes.expandPersistentVolumeSpec(0xc00110bce0, 0x1, 0x1, 0x4769ae0, 0xc000e14c60, 0x1)
        /home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/kubernetes/structure_persistent_volume_spec.go:948 +0x348
github.com/terraform-providers/terraform-provider-kubernetes/kubernetes.resourceKubernetesPersistentVolumeCreate(0xc000a305b0, 0x57187a0, 0xc000a62d80, 0xc000a305b0, 0x0)
        /home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/kubernetes/resource_kubernetes_persistent_volume.go:144 +0x15e
github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).Apply(0xc0006675e0, 0xc000302820, 0xc000ea1ce0, 0x57187a0, 0xc000a62d80, 0xc0000dc001, 0x2, 0xc000d80000)
        /home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:225 +0x3a2
github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).Apply(0xc00023e850, 0xc00003c410, 0xc000302820, 0xc000ea1ce0, 0x1, 0x55a39b, 0xc0000dc080)
        /home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/helper/schema/provider.go:283 +0x18f
github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/terraform.(*EvalApply).Eval(0xc000943bc0, 0x6192200, 0xc000a228f0, 0x2, 0x2, 0x5758374, 0x4)
        /home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/terraform/eval_apply.go:57 +0x244
github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/terraform.EvalRaw(0x607a000, 0xc000943bc0, 0x6192200, 0xc000a228f0, 0x0, 0x0, 0x0, 0x0)
        /home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/terraform/eval.go:53 +0x11a
github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/terraform.(*EvalSequence).Eval(0xc000a03b20, 0x6192200, 0xc000a228f0, 0x2, 0x2, 0x5758374, 0x4)
        /home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/terraform/eval_sequence.go:14 +0x9c
github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/terraform.EvalRaw(0x607a540, 0xc000a03b20, 0x6192200, 0xc000a228f0, 0x4c18960, 0xa578ce2, 0x47ff320, 0xc000e47b50)
        /home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/terraform/eval.go:53 +0x11a
github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/terraform.Eval(0x607a540, 0xc000a03b20, 0x6192200, 0xc000a228f0, 0xc000a03b20, 0x607a540, 0xc000a03b20, 0xc000089db0)
        /home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/terraform/eval.go:34 +0x4d
github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/terraform.(*Graph).walk.func1(0x56178a0, 0xc0005fd0e8, 0x0, 0x0)
        /home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/terraform/graph.go:126 +0xbc2
github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/dag.(*Walker).walkVertex(0xc00078f570, 0x56178a0, 0xc0005fd0e8, 0xc000a04680)
        /home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/dag/walk.go:387 +0x33b
created by github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/dag.(*Walker).Update
        /home/patrick/go/src/github.com/terraform-providers/terraform-provider-kubernetes/vendor/github.com/hashicorp/terraform/dag/walk.go:310 +0xa4f
FAIL    github.com/terraform-providers/terraform-provider-kubernetes/kubernetes 18.350s
make: *** [GNUmakefile:17: testacc] Error 1

```

I see at least two options to fix that:
- check the content of the map before converting it
- make the `key` and `operator` fields required as I believe they should be: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#nodeselectorrequirement-v1-core

Note: this issue was discovered when tinkering with #393 