### PR TITLE
Add support for binary_data to kubernetes_config_map

### DIFF
--- a/kubernetes/resource_kubernetes_config_map.go
+++ b/kubernetes/resource_kubernetes_config_map.go
@@ -79,7 +79,7 @@ func resourceKubernetesConfigMapRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	d.Set("binary_data", byteMapToBase64Map(cfgMap.BinaryData))
+	d.Set("binary_data", flattenByteMapToBase64Map(cfgMap.BinaryData))
 	d.Set("data", cfgMap.Data)
 
 	return nil

--- a/kubernetes/resource_kubernetes_config_map.go
+++ b/kubernetes/resource_kubernetes_config_map.go
@@ -25,9 +25,15 @@ func resourceKubernetesConfigMap() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"metadata": namespacedMetadataSchema("config map", true),
+			"binary_data": {
+				Type:        schema.TypeMap,
+				Description: "BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet.",
+				Optional:    true,
+				Sensitive:   true, // Marked as sensitive as binary data most likely produces garbled output
+			},
 			"data": {
 				Type:        schema.TypeMap,
-				Description: "A map of the configuration data.",
+				Description: "Data contains the configuration data. Each key must consist of alphanumeric characters, '-', '_' or '.'. Values with non-UTF-8 byte sequences must use the BinaryData field. The keys stored in Data must not overlap with the keys in the BinaryData field, this is enforced during validation process.",
 				Optional:    true,
 			},
 		},
@@ -40,6 +46,7 @@ func resourceKubernetesConfigMapCreate(d *schema.ResourceData, meta interface{})
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	cfgMap := api.ConfigMap{
 		ObjectMeta: metadata,
+		BinaryData: expandStringMapToByteMap(d.Get("binary_data").(map[string]interface{})),
 		Data:       expandStringMap(d.Get("data").(map[string]interface{})),
 	}
 	log.Printf("[INFO] Creating new config map: %#v", cfgMap)
@@ -71,6 +78,8 @@ func resourceKubernetesConfigMapRead(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
+
+	d.Set("binary_data", byteMapToStringMap(cfgMap.BinaryData))
 	d.Set("data", cfgMap.Data)
 
 	return nil
@@ -85,15 +94,27 @@ func resourceKubernetesConfigMapUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
+	if d.HasChange("binary_data") {
+		oldV, newV := d.GetChange("binary_data")
+
+		oldV = base64EncodeStringMap(oldV.(map[string]interface{}))
+		newV = base64EncodeStringMap(newV.(map[string]interface{}))
+
+		diffOps := diffStringMap("/binaryData/", oldV.(map[string]interface{}), newV.(map[string]interface{}))
+		ops = append(ops, diffOps...)
+	}
+
 	if d.HasChange("data") {
 		oldV, newV := d.GetChange("data")
 		diffOps := diffStringMap("/data/", oldV.(map[string]interface{}), newV.(map[string]interface{}))
 		ops = append(ops, diffOps...)
 	}
+
 	data, err := ops.MarshalJSON()
 	if err != nil {
 		return fmt.Errorf("Failed to marshal update operations: %s", err)
 	}
+
 	log.Printf("[INFO] Updating config map %q: %v", name, string(data))
 	out, err := conn.CoreV1().ConfigMaps(namespace).Patch(name, pkgApi.JSONPatchType, data)
 	if err != nil {

--- a/kubernetes/resource_kubernetes_config_map.go
+++ b/kubernetes/resource_kubernetes_config_map.go
@@ -26,10 +26,10 @@ func resourceKubernetesConfigMap() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"metadata": namespacedMetadataSchema("config map", true),
 			"binary_data": {
-				Type:        schema.TypeMap,
-				Description: "BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet.",
-				Optional:    true,
-				Sensitive:   true, // Marked as sensitive as binary data most likely produces garbled output
+				Type:         schema.TypeMap,
+				Description:  "BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet.",
+				Optional:     true,
+				ValidateFunc: validateBase64EncodedMap,
 			},
 			"data": {
 				Type:        schema.TypeMap,

--- a/kubernetes/resource_kubernetes_config_map_test.go
+++ b/kubernetes/resource_kubernetes_config_map_test.go
@@ -406,8 +406,8 @@ resource "kubernetes_config_map" "test" {
 
   binary_data = {
     one = "${filebase64("./test-fixtures/binary2.data")}"
-		two = "${filebase64("./test-fixtures/binary.data")}"
-		raw = "${base64encode("Raw data should come back as is in the pod")}"
+    two = "${filebase64("./test-fixtures/binary.data")}"
+    raw = "${base64encode("Raw data should come back as is in the pod")}"
   }
 
   data = {

--- a/kubernetes/resource_kubernetes_config_map_test.go
+++ b/kubernetes/resource_kubernetes_config_map_test.go
@@ -137,6 +137,34 @@ func TestAccKubernetesConfigMap_importBasic(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesConfigMap_binaryData(t *testing.T) {
+	var conf api.ConfigMap
+	prefix := "tf-acc-test-gen-"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "kubernetes_config_map.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesConfigMapDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesConfigMapConfig_binaryData(prefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesConfigMapExists("kubernetes_config_map.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_config_map.test", "data.%", "1"),
+				),
+			},
+			{
+				Config: testAccKubernetesConfigMapConfig_binaryData2(prefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesConfigMapExists("kubernetes_config_map.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_config_map.test", "data.%", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKubernetesConfigMap_generatedName(t *testing.T) {
 	var conf api.ConfigMap
 	prefix := "tf-acc-test-gen-"
@@ -341,6 +369,35 @@ resource "kubernetes_config_map" "test" {
   data = {
     one = "first"
     two = "second"
+  }
+}
+`, prefix)
+}
+
+func testAccKubernetesConfigMapConfig_binaryData(prefix string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_config_map" "test" {
+  metadata {
+    generate_name = "%s"
+  }
+
+  data {
+    one = "${file("./test-fixtures/binary.data")}"
+  }
+}
+`, prefix)
+}
+
+func testAccKubernetesConfigMapConfig_binaryData2(prefix string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_config_map" "test" {
+  metadata {
+    generate_name = "%s"
+  }
+
+  data {
+    one = "${file("./test-fixtures/binary2.data")}"
+    two = "${file("./test-fixtures/binary.data")}"
   }
 }
 `, prefix)

--- a/kubernetes/resource_kubernetes_config_map_test.go
+++ b/kubernetes/resource_kubernetes_config_map_test.go
@@ -151,14 +151,18 @@ func TestAccKubernetesConfigMap_binaryData(t *testing.T) {
 				Config: testAccKubernetesConfigMapConfig_binaryData(prefix),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesConfigMapExists("kubernetes_config_map.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_config_map.test", "binary_data.%", "1"),
 					resource.TestCheckResourceAttr("kubernetes_config_map.test", "data.%", "1"),
+					resource.TestCheckResourceAttr("kubernetes_config_map.test", "data.two", "second"),
 				),
 			},
 			{
 				Config: testAccKubernetesConfigMapConfig_binaryData2(prefix),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesConfigMapExists("kubernetes_config_map.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_config_map.test", "data.%", "2"),
+					resource.TestCheckResourceAttr("kubernetes_config_map.test", "binary_data.%", "2"),
+					resource.TestCheckResourceAttr("kubernetes_config_map.test", "data.%", "1"),
+					resource.TestCheckResourceAttr("kubernetes_config_map.test", "data.three", "third"),
 				),
 			},
 		},
@@ -381,8 +385,12 @@ resource "kubernetes_config_map" "test" {
     generate_name = "%s"
   }
 
-  data {
+  binary_data {
     one = "${file("./test-fixtures/binary.data")}"
+  }
+
+  data {
+    two = "second"
   }
 }
 `, prefix)
@@ -395,9 +403,13 @@ resource "kubernetes_config_map" "test" {
     generate_name = "%s"
   }
 
-  data {
+  binary_data {
     one = "${file("./test-fixtures/binary2.data")}"
     two = "${file("./test-fixtures/binary.data")}"
+  }
+
+  data {
+    three = "third"
   }
 }
 `, prefix)

--- a/kubernetes/resource_kubernetes_config_map_test.go
+++ b/kubernetes/resource_kubernetes_config_map_test.go
@@ -385,11 +385,11 @@ resource "kubernetes_config_map" "test" {
     generate_name = "%s"
   }
 
-  binary_data {
-    one = "${file("./test-fixtures/binary.data")}"
+  binary_data = {
+    one = "${filebase64("./test-fixtures/binary.data")}"
   }
 
-  data {
+  data = {
     two = "second"
   }
 }
@@ -403,12 +403,12 @@ resource "kubernetes_config_map" "test" {
     generate_name = "%s"
   }
 
-  binary_data {
-    one = "${file("./test-fixtures/binary2.data")}"
-    two = "${file("./test-fixtures/binary.data")}"
+  binary_data = {
+    one = "${filebase64("./test-fixtures/binary2.data")}"
+    two = "${filebase64("./test-fixtures/binary.data")}"
   }
 
-  data {
+  data = {
     three = "third"
   }
 }

--- a/kubernetes/resource_kubernetes_config_map_test.go
+++ b/kubernetes/resource_kubernetes_config_map_test.go
@@ -160,7 +160,8 @@ func TestAccKubernetesConfigMap_binaryData(t *testing.T) {
 				Config: testAccKubernetesConfigMapConfig_binaryData2(prefix),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesConfigMapExists("kubernetes_config_map.test", &conf),
-					resource.TestCheckResourceAttr("kubernetes_config_map.test", "binary_data.%", "2"),
+					resource.TestCheckResourceAttr("kubernetes_config_map.test", "binary_data.%", "3"),
+					resource.TestCheckResourceAttr("kubernetes_config_map.test", "binary_data.raw", "UmF3IGRhdGEgc2hvdWxkIGNvbWUgYmFjayBhcyBpcyBpbiB0aGUgcG9k"),
 					resource.TestCheckResourceAttr("kubernetes_config_map.test", "data.%", "1"),
 					resource.TestCheckResourceAttr("kubernetes_config_map.test", "data.three", "third"),
 				),
@@ -405,7 +406,8 @@ resource "kubernetes_config_map" "test" {
 
   binary_data = {
     one = "${filebase64("./test-fixtures/binary2.data")}"
-    two = "${filebase64("./test-fixtures/binary.data")}"
+		two = "${filebase64("./test-fixtures/binary.data")}"
+		raw = "${base64encode("Raw data should come back as is in the pod")}"
   }
 
   data = {

--- a/kubernetes/resource_kubernetes_config_map_test.go
+++ b/kubernetes/resource_kubernetes_config_map_test.go
@@ -405,8 +405,8 @@ resource "kubernetes_config_map" "test" {
   }
 
   binary_data = {
-    one = "${filebase64("./test-fixtures/binary2.data")}"
-    two = "${filebase64("./test-fixtures/binary.data")}"
+    one = "${filebase64("./test-fixtures/binary.data")}"
+    two = "${filebase64("./test-fixtures/binary2.data")}"
     raw = "${base64encode("Raw data should come back as is in the pod")}"
   }
 

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -472,7 +472,7 @@ func TestAccKubernetesPod_with_cfg_map_volume_mount(t *testing.T) {
 	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	cfgMap := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
-	imageName := "nginx:1.7.9"
+	imageName := "busybox:1.30.1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -484,11 +484,15 @@ func TestAccKubernetesPod_with_cfg_map_volume_mount(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesPodExists("kubernetes_pod.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.image", imageName),
-					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.#", "2"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.0.mount_path", "/tmp/my_path"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.0.name", "cfg"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.0.read_only", "false"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.0.sub_path", ""),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.1.mount_path", "/tmp/my_raw_path"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.1.name", "cfg-binary"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.1.read_only", "false"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.1.sub_path", ""),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.name", "cfg"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.config_map.0.name", cfgMap),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.config_map.0.default_mode", "0777")),
@@ -1128,6 +1132,10 @@ resource "kubernetes_config_map" "test" {
     name = "%s"
   }
 
+  binary_data = {
+    raw = "${base64encode("Raw data should come back as is in the pod")}"
+  }
+
   data = {
     one = "first"
   }
@@ -1143,13 +1151,30 @@ resource "kubernetes_pod" "test" {
   }
 
   spec {
+    restart_policy = "Never"
+
     container {
       image = "%s"
       name  = "containername"
 
+      args = ["/bin/sh", "-xc", "ls -l /tmp/my_raw_path ; cat /tmp/my_raw_path/raw.txt ; sleep 10"]
+
+      lifecycle {
+        post_start {
+          exec {
+            command = ["/bin/sh", "-xc", "grep 'Raw data should come back as is in the pod' /tmp/my_raw_path/raw.txt"]
+          }
+        }
+      }
+
       volume_mount {
         mount_path = "/tmp/my_path"
         name       = "cfg"
+      }
+
+      volume_mount {
+        mount_path = "/tmp/my_raw_path"
+        name       = "cfg-binary"
       }
     }
 
@@ -1185,6 +1210,19 @@ resource "kubernetes_pod" "test" {
           key  = "one"
           path = "one-with-mode.txt"
           mode = "0444"
+        }
+      }
+    }
+
+    volume {
+      name = "cfg-binary"
+
+      config_map {
+        name = "${kubernetes_config_map.test.metadata.0.name}"
+
+        items {
+          key  = "raw"
+          path = "raw.txt"
         }
       }
     }

--- a/kubernetes/resource_kubernetes_secret.go
+++ b/kubernetes/resource_kubernetes_secret.go
@@ -88,7 +88,7 @@ func resourceKubernetesSecretRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	d.Set("data", byteMapToStringMap(secret.Data))
+	d.Set("data", flattenByteMapToStringMap(secret.Data))
 	d.Set("type", secret.Type)
 
 	return nil

--- a/kubernetes/resource_kubernetes_secret_test.go
+++ b/kubernetes/resource_kubernetes_secret_test.go
@@ -270,7 +270,7 @@ func testAccCheckSecretData(m *api.Secret, expected map[string]string) resource.
 		if len(expected) == 0 && len(m.Data) == 0 {
 			return nil
 		}
-		if !reflect.DeepEqual(byteMapToStringMap(m.Data), expected) {
+		if !reflect.DeepEqual(flattenByteMapToStringMap(m.Data), expected) {
 			return fmt.Errorf("%s data don't match.\nExpected: %q\nGiven: %q",
 				m.Name, expected, m.Data)
 		}

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -152,7 +152,7 @@ func isInternalKey(annotationKey string) bool {
 	return false
 }
 
-func byteMapToBase64Map(m map[string][]byte) map[string]string {
+func flattenByteMapToBase64Map(m map[string][]byte) map[string]string {
 	result := make(map[string]string)
 	for k, v := range m {
 		result[k] = base64.StdEncoding.EncodeToString([]byte(v))
@@ -160,7 +160,7 @@ func byteMapToBase64Map(m map[string][]byte) map[string]string {
 	return result
 }
 
-func byteMapToStringMap(m map[string][]byte) map[string]string {
+func flattenByteMapToStringMap(m map[string][]byte) map[string]string {
 	result := make(map[string]string)
 	for k, v := range m {
 		result[k] = string(v)

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -77,6 +77,17 @@ func expandStringMap(m map[string]interface{}) map[string]string {
 	return result
 }
 
+func expandBase64MapToByteMap(m map[string]interface{}) map[string][]byte {
+	result := make(map[string][]byte)
+	for k, v := range m {
+		b, err := base64.StdEncoding.DecodeString(v.(string))
+		if err == nil {
+			result[k] = b
+		}
+	}
+	return result
+}
+
 func expandStringMapToByteMap(m map[string]interface{}) map[string][]byte {
 	result := make(map[string][]byte)
 	for k, v := range m {
@@ -139,6 +150,14 @@ func isInternalKey(annotationKey string) bool {
 	}
 
 	return false
+}
+
+func byteMapToBase64Map(m map[string][]byte) map[string]string {
+	result := make(map[string]string)
+	for k, v := range m {
+		result[k] = base64.StdEncoding.EncodeToString([]byte(v))
+	}
+	return result
 }
 
 func byteMapToStringMap(m map[string][]byte) map[string]string {

--- a/kubernetes/validators.go
+++ b/kubernetes/validators.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strconv"
 	"strings"
@@ -24,6 +25,21 @@ func validateAnnotations(value interface{}, key string) (ws []string, es []error
 		if isInternalKey(k) {
 			es = append(es, fmt.Errorf("%s: %q is internal Kubernetes annotation", key, k))
 		}
+	}
+	return
+}
+
+func validateBase64Encoded(v interface{}, key string) (ws []string, es []error) {
+	s, ok := v.(string)
+	if !ok {
+		es = []error{fmt.Errorf("%s: must be a non-nil base64-encoded string", key)}
+		return
+	}
+
+	_, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		es = []error{fmt.Errorf("%s: must be a base64-encoded string", key)}
+		return
 	}
 	return
 }

--- a/kubernetes/validators.go
+++ b/kubernetes/validators.go
@@ -44,6 +44,23 @@ func validateBase64Encoded(v interface{}, key string) (ws []string, es []error) 
 	return
 }
 
+func validateBase64EncodedMap(value interface{}, key string) (ws []string, es []error) {
+	m, ok := value.(map[string]interface{})
+	if !ok {
+		es = []error{fmt.Errorf("%s: must be a map of strings to base64 encoded strings", key)}
+		return
+	}
+
+	for k, v := range m {
+		_, errs := validateBase64Encoded(v, k)
+		for _, e := range errs {
+			es = append(es, fmt.Errorf("%s (%q) %s", k, v, e))
+		}
+	}
+
+	return
+}
+
 func validateName(value interface{}, key string) (ws []string, es []error) {
 	v := value.(string)
 	errors := apiValidation.NameIsDNSSubdomain(v, false)

--- a/kubernetes/validators_test.go
+++ b/kubernetes/validators_test.go
@@ -54,3 +54,55 @@ func TestValidateBase64Encoded(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateBase64EncodedMap(t *testing.T) {
+	validCases := []interface{}{
+		map[string]interface{}{
+			"key_empty": "", // the plain empty string
+		},
+		map[string]interface{}{
+			"key_encoded_empty": "Cg==", // the encoded empty string
+		},
+		map[string]interface{}{
+			"key_blah": "blah", // "nV"
+		},
+		map[string]interface{}{
+			"key_Test": "VGVzdAo=", // "Test"
+		},
+	}
+	for _, data := range validCases {
+		_, es := validateBase64EncodedMap(data, "binary_data")
+		if len(es) > 0 {
+			t.Fatalf("Expected %#o to be valid: %#v", data, es)
+		}
+	}
+
+	invalidCases := []interface{}{
+		nil,
+		"bl ah",
+		"blahd",
+		"C=",
+		map[string]interface{}{
+			"invalid_nil": nil,
+		},
+		map[string]string{
+			"key_ok":         "VGVzdAo=",
+			"invalid_string": "blahd",
+		},
+		map[string]int{
+			"invalid_int": 10,
+		},
+		map[int]int{
+			10: 10,
+		},
+		map[string]byte{
+			"invalid_byte": 10,
+		},
+	}
+	for _, data := range invalidCases {
+		_, es := validateBase64EncodedMap(data, "binary_data")
+		if len(es) == 0 {
+			t.Fatalf("Expected %#o to be invalid", data)
+		}
+	}
+}

--- a/kubernetes/validators_test.go
+++ b/kubernetes/validators_test.go
@@ -25,3 +25,32 @@ func TestValidateModeBits(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateBase64Encoded(t *testing.T) {
+	validCases := []interface{}{
+		"",         // the plain empty string
+		"Cg==",     // the encoded empty string
+		"blah",     // "nV"
+		"VGVzdAo=", // "Test"
+		"f0VMRgIBAQAAAAAAAAAAAAMAPgABAAAAMGEAAAAAAABAAAAAAAAAAKATAgAAAAAAAAAAAEAAOAALAEAAHAAbAAYAAAAEAAAAQAAAAAAAAABAAAAAAAAAAEAAAAAAAAAAaAIAAA==", // `head /bin/ls -c 100 | base64`
+	}
+	for _, data := range validCases {
+		_, es := validateBase64Encoded(data, "binary_data")
+		if len(es) > 0 {
+			t.Fatalf("Expected %#o to be valid: %#v", data, es)
+		}
+	}
+
+	invalidCases := []interface{}{
+		nil,
+		"bl ah",
+		"blahd",
+		"C=",
+	}
+	for _, data := range invalidCases {
+		_, es := validateBase64Encoded(data, "binary_data")
+		if len(es) == 0 {
+			t.Fatalf("Expected %#o to be invalid", data)
+		}
+	}
+}

--- a/website/docs/r/config_map.html.markdown
+++ b/website/docs/r/config_map.html.markdown
@@ -33,7 +33,8 @@ resource "kubernetes_config_map" "example" {
 
 The following arguments are supported:
 
-* `data` - (Optional) A map of the configuration data.
+* `binary_data` - (Optional) BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet.
+* `data` - (Optional) Data contains the configuration data. Each key must consist of alphanumeric characters, '-', '_' or '.'. Values with non-UTF-8 byte sequences must use the BinaryData field. The keys stored in Data must not overlap with the keys in the BinaryData field, this is enforced during validation process.
 * `metadata` - (Required) Standard config map's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#metadata)
 
 ## Nested Blocks

--- a/website/docs/r/config_map.html.markdown
+++ b/website/docs/r/config_map.html.markdown
@@ -26,6 +26,10 @@ resource "kubernetes_config_map" "example" {
   data {
     my_config_file.yml = "${file("${path.module}/my_config_file.yml")}"
   }
+
+  binary_data {
+    my_payload.bin = "${filebase64("${path.module}/my_payload.bin")}"
+  }
 }
 ```
 
@@ -33,7 +37,7 @@ resource "kubernetes_config_map" "example" {
 
 The following arguments are supported:
 
-* `binary_data` - (Optional) BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet.
+* `binary_data` - (Optional) BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet. This field only accepts base64-encoded payloads that will be decoded/received before being sent/received to the apiserver.
 * `data` - (Optional) Data contains the configuration data. Each key must consist of alphanumeric characters, '-', '_' or '.'. Values with non-UTF-8 byte sequences must use the BinaryData field. The keys stored in Data must not overlap with the keys in the BinaryData field, this is enforced during validation process.
 * `metadata` - (Required) Standard config map's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/e59e666e3464c7d4851136baa8835a311efdfb8e/contributors/devel/api-conventions.md#metadata)
 


### PR DESCRIPTION
This PR adds support for the [`binaryData` field of config maps](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#configmap-v1-core).

This is largely based on the existing secret data implementation.

```
resource "kubernetes_config_map" "test" {
  metadata {
    name = "test"
  }

  data {
    text = "Some text"
  }

  binary_data {
   file1 = "${file(/mydir/binary1.data)"
   file2 = "${file(/mydir/binary2.data)"
  }
}
```

Partly resolves #399 regarding binary data support Does not address the folder support part of the issue.