### PR TITLE
Add support for Job and CronJob (closes #86 and #212)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
 language: go
 go:
   - "1.11.x"
+go_import_path: github.com/terraform-providers/terraform-provider-kubernetes
 
 install:
   # This script is used by the Travis build to install a cookie for

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
 language: go
 go:
   - "1.11.x"
-go_import_path: github.com/terraform-providers/terraform-provider-kubernetes
 
 install:
   # This script is used by the Travis build to install a cookie for

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
+	github.com/robfig/cron v1.2.0
 	github.com/stoewer/go-strcase v1.0.2 // indirect
 	github.com/terraform-providers/terraform-provider-aws v0.0.0-20190510001811-4b894dbf13f6
 	github.com/terraform-providers/terraform-provider-google v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -436,6 +436,8 @@ github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
+github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -141,6 +141,7 @@ func Provider() terraform.ResourceProvider {
 			"kubernetes_cluster_role":              resourceKubernetesClusterRole(),
 			"kubernetes_cluster_role_binding":      resourceKubernetesClusterRoleBinding(),
 			"kubernetes_config_map":                resourceKubernetesConfigMap(),
+			"kubernetes_cron_job":                  resourceKubernetesCronJob(),
 			"kubernetes_daemonset":                 resourceKubernetesDaemonSet(),
 			"kubernetes_deployment":                resourceKubernetesDeployment(),
 			"kubernetes_endpoints":                 resourceKubernetesEndpoints(),

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -146,6 +146,7 @@ func Provider() terraform.ResourceProvider {
 			"kubernetes_endpoints":                 resourceKubernetesEndpoints(),
 			"kubernetes_horizontal_pod_autoscaler": resourceKubernetesHorizontalPodAutoscaler(),
 			"kubernetes_ingress":                   resourceKubernetesIngress(),
+			"kubernetes_job":                       resourceKubernetesJob(),
 			"kubernetes_limit_range":               resourceKubernetesLimitRange(),
 			"kubernetes_namespace":                 resourceKubernetesNamespace(),
 			"kubernetes_network_policy":            resourceKubernetesNetworkPolicy(),

--- a/kubernetes/resource_kubernetes_cron_job.go
+++ b/kubernetes/resource_kubernetes_cron_job.go
@@ -1,0 +1,210 @@
+package kubernetes
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"k8s.io/api/batch/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgApi "k8s.io/apimachinery/pkg/types"
+	kubernetes "k8s.io/client-go/kubernetes"
+)
+
+func resourceKubernetesCronJob() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceKubernetesCronJobCreate,
+		Read:   resourceKubernetesCronJobRead,
+		Update: resourceKubernetesCronJobUpdate,
+		Delete: resourceKubernetesCronJobDelete,
+		Exists: resourceKubernetesCronJobExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"metadata": namespacedMetadataSchema("cronjob", true),
+			"spec": {
+				Type:        schema.TypeList,
+				Description: "Spec of the cron job owned by the cluster",
+				Required:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: cronJobSpecFields(),
+				},
+			},
+		},
+	}
+}
+
+func resourceKubernetesCronJobCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*kubernetes.Clientset)
+
+	metadata := expandMetadata(d.Get("metadata").([]interface{}))
+	spec, err := expandCronJobSpec(d.Get("spec").([]interface{}))
+	if err != nil {
+		return err
+	}
+
+	job := v1beta1.CronJob{
+		ObjectMeta: metadata,
+		Spec:       spec,
+	}
+
+	log.Printf("[INFO] Creating new cron job: %#v", job)
+
+	out, err := conn.BatchV1beta1().CronJobs(metadata.Namespace).Create(&job)
+	if err != nil {
+		return err
+	}
+	log.Printf("[INFO] Submitted new cron job: %#v", out)
+
+	d.SetId(buildId(out.ObjectMeta))
+
+	return resourceKubernetesCronJobRead(d, meta)
+}
+
+func resourceKubernetesCronJobUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*kubernetes.Clientset)
+
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
+	ops := patchMetadata("metadata.0.", "/metadata/", d)
+
+	if d.HasChange("spec") {
+		specOps, err := patchCronJobSpec("/spec", "spec.0.", d)
+		if err != nil {
+			return err
+		}
+		ops = append(ops, specOps...)
+	}
+
+	data, err := ops.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("Failed to marshal update operations: %s", err)
+	}
+
+	log.Printf("[INFO] Updating cron job %s: %s", d.Id(), ops)
+
+	out, err := conn.BatchV1beta1().CronJobs(namespace).Patch(name, pkgApi.JSONPatchType, data)
+	if err != nil {
+		return err
+	}
+	log.Printf("[INFO] Submitted updated cron job: %#v", out)
+
+	d.SetId(buildId(out.ObjectMeta))
+	return resourceKubernetesCronJobRead(d, meta)
+}
+
+func resourceKubernetesCronJobRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*kubernetes.Clientset)
+
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Reading cron job %s", name)
+	job, err := conn.BatchV1beta1().CronJobs(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		log.Printf("[DEBUG] Received error: %#v", err)
+		return err
+	}
+	log.Printf("[INFO] Received cron job: %#v", job)
+
+	// Remove server-generated labels unless using manual selector
+	if _, ok := d.GetOk("spec.0.manual_selector"); !ok {
+		labels := job.ObjectMeta.Labels
+
+		if _, ok := labels["controller-uid"]; ok {
+			delete(labels, "controller-uid")
+		}
+
+		if _, ok := labels["cron-job-name"]; ok {
+			delete(labels, "cron-job-name")
+		}
+
+		labels = job.Spec.JobTemplate.Spec.Selector.MatchLabels
+
+		if _, ok := labels["controller-uid"]; ok {
+			delete(labels, "controller-uid")
+		}
+	}
+
+	err = d.Set("metadata", flattenMetadata(job.ObjectMeta))
+	if err != nil {
+		return err
+	}
+
+	jobSpec, err := flattenCronJobSpec(job.Spec)
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("spec", jobSpec)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceKubernetesCronJobDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*kubernetes.Clientset)
+
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Deleting cron job: %#v", name)
+	err = conn.BatchV1beta1().CronJobs(namespace).Delete(name, nil)
+	if err != nil {
+		return err
+	}
+
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		_, err := conn.BatchV1beta1().CronJobs(namespace).Get(name, metav1.GetOptions{})
+		if err != nil {
+			if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
+				return nil
+			}
+			return resource.NonRetryableError(err)
+		}
+
+		e := fmt.Errorf("Cron Job %s still exists", name)
+		return resource.RetryableError(e)
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Cron Job %s deleted", name)
+
+	d.SetId("")
+	return nil
+}
+
+func resourceKubernetesCronJobExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	conn := meta.(*kubernetes.Clientset)
+
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return false, err
+	}
+
+	log.Printf("[INFO] Checking cron job %s", name)
+	_, err = conn.BatchV1beta1().CronJobs(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
+			return false, nil
+		}
+		log.Printf("[DEBUG] Received error: %#v", err)
+	}
+	return true, err
+}

--- a/kubernetes/resource_kubernetes_cron_job.go
+++ b/kubernetes/resource_kubernetes_cron_job.go
@@ -129,7 +129,10 @@ func resourceKubernetesCronJobRead(d *schema.ResourceData, meta interface{}) err
 			delete(labels, "cron-job-name")
 		}
 
-		labels = job.Spec.JobTemplate.Spec.Selector.MatchLabels
+		if job.Spec.JobTemplate.Spec.Selector != nil &&
+			job.Spec.JobTemplate.Spec.Selector.MatchLabels != nil {
+			labels = job.Spec.JobTemplate.Spec.Selector.MatchLabels
+		}
 
 		if _, ok := labels["controller-uid"]; ok {
 			delete(labels, "controller-uid")

--- a/kubernetes/resource_kubernetes_cron_job.go
+++ b/kubernetes/resource_kubernetes_cron_job.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/api/batch/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	pkgApi "k8s.io/apimachinery/pkg/types"
 	kubernetes "k8s.io/client-go/kubernetes"
 )
 
@@ -69,29 +68,26 @@ func resourceKubernetesCronJobCreate(d *schema.ResourceData, meta interface{}) e
 func resourceKubernetesCronJobUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	namespace, name, err := idParts(d.Id())
+	namespace, _, err := idParts(d.Id())
 	if err != nil {
 		return err
 	}
 
-	ops := patchMetadata("metadata.0.", "/metadata/", d)
-
-	if d.HasChange("spec") {
-		specOps, err := patchCronJobSpec("/spec", "spec.0.", d)
-		if err != nil {
-			return err
-		}
-		ops = append(ops, specOps...)
-	}
-
-	data, err := ops.MarshalJSON()
+	metadata := expandMetadata(d.Get("metadata").([]interface{}))
+	spec, err := expandCronJobSpec(d.Get("spec").([]interface{}))
 	if err != nil {
-		return fmt.Errorf("Failed to marshal update operations: %s", err)
+		return err
+	}
+	spec.JobTemplate.ObjectMeta.Annotations = metadata.Annotations
+
+	cronjob := &v1beta1.CronJob{
+		ObjectMeta: metadata,
+		Spec:       spec,
 	}
 
-	log.Printf("[INFO] Updating cron job %s: %s", d.Id(), ops)
+	log.Printf("[INFO] Updating cron job %s: %s", d.Id(), cronjob)
 
-	out, err := conn.BatchV1beta1().CronJobs(namespace).Patch(name, pkgApi.JSONPatchType, data)
+	out, err := conn.BatchV1beta1().CronJobs(namespace).Update(cronjob)
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_cron_job.go
+++ b/kubernetes/resource_kubernetes_cron_job.go
@@ -135,12 +135,12 @@ func resourceKubernetesCronJobRead(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	err = d.Set("metadata", flattenMetadata(job.ObjectMeta))
+	err = d.Set("metadata", flattenMetadata(job.ObjectMeta, d))
 	if err != nil {
 		return err
 	}
 
-	jobSpec, err := flattenCronJobSpec(job.Spec)
+	jobSpec, err := flattenCronJobSpec(job.Spec, d)
 	if err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubernetes_cron_job_test.go
+++ b/kubernetes/resource_kubernetes_cron_job_test.go
@@ -82,6 +82,19 @@ func TestAccKubernetesCronJob_extra(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.backoff_limit", "2"),
 				),
 			},
+			{
+				Config: testAccKubernetesCronJobConfig_extraModified(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesCronJobExists("kubernetes_cron_job.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_cron_job.test", "spec.0.schedule"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.concurrency_policy", "Forbid"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.successful_jobs_history_limit", "2"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.failed_jobs_history_limit", "2"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.starting_deadline_seconds", "120"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.backoff_limit", "3"),
+				),
+			},
 		},
 	})
 }
@@ -207,6 +220,36 @@ resource "kubernetes_cron_job" "test" {
 		job_template {
 			spec {
 				backoff_limit = 2
+				template {
+					spec {
+						container {
+							name = "hello"
+							image = "alpine"
+							command = ["echo", "'hello'"]
+						}
+					}
+				}
+			}
+		}
+	}
+}`, name)
+}
+
+func testAccKubernetesCronJobConfig_extraModified(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_cron_job" "test" {
+	metadata {
+		name = "%s"
+	}
+	spec {
+		schedule = "1 0 * * *"
+		concurrency_policy            = "Forbid"
+		successful_jobs_history_limit = 2
+		failed_jobs_history_limit     = 2
+		starting_deadline_seconds     = 120
+		job_template {
+			spec {
+				backoff_limit = 3
 				template {
 					spec {
 						container {

--- a/kubernetes/resource_kubernetes_cron_job_test.go
+++ b/kubernetes/resource_kubernetes_cron_job_test.go
@@ -34,6 +34,7 @@ func TestAccKubernetesCronJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_cron_job.test", "spec.0.schedule"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.parallelism", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.backoff_limit", "2"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.template.0.spec.0.container.0.name", "hello"),
 				),
 			},
@@ -48,6 +49,7 @@ func TestAccKubernetesCronJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_cron_job.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.parallelism", "2"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.backoff_limit", "0"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.template.0.spec.0.container.0.name", "hello"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.template.0.metadata.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.template.0.metadata.0.labels.%", "2"),
@@ -77,6 +79,7 @@ func TestAccKubernetesCronJob_extra(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.successful_jobs_history_limit", "10"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.failed_jobs_history_limit", "10"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.starting_deadline_seconds", "60"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.backoff_limit", "2"),
 				),
 			},
 		},
@@ -141,6 +144,7 @@ resource "kubernetes_cron_job" "test" {
 		schedule = "1 0 * * *"
 		job_template {
 			spec {
+				backoff_limit = 2
 				template {
 					spec {
 						container {
@@ -202,6 +206,7 @@ resource "kubernetes_cron_job" "test" {
 	starting_deadline_seconds     = 60
 		job_template {
 			spec {
+				backoff_limit = 2
 				template {
 					spec {
 						container {

--- a/kubernetes/resource_kubernetes_cron_job_test.go
+++ b/kubernetes/resource_kubernetes_cron_job_test.go
@@ -1,0 +1,163 @@
+package kubernetes
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"k8s.io/api/batch/v1beta1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetes "k8s.io/client-go/kubernetes"
+)
+
+func TestAccKubernetesCronJob_basic(t *testing.T) {
+	var conf v1beta1.CronJob
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "kubernetes_cron_job.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesCronJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesCronJobConfig_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesCronJobExists("kubernetes_cron_job.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_cron_job.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_cron_job.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_cron_job.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_cron_job.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttrSet("kubernetes_cron_job.test", "spec.0.schedule"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.parallelism", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.template.0.spec.0.container.0.name", "hello"),
+				),
+			},
+			{
+				Config: testAccKubernetesCronJobConfig_modified(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesCronJobExists("kubernetes_cron_job.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_cron_job.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_cron_job.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_cron_job.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_cron_job.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.parallelism", "2"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.template.0.spec.0.container.0.name", "hello"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.template.0.metadata.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.template.0.metadata.0.labels.%", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckKubernetesCronJobDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*kubernetes.Clientset)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "kubernetes_cron_job" {
+			continue
+		}
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		resp, err := conn.BatchV1beta1().CronJobs(namespace).Get(name, meta_v1.GetOptions{})
+		if err == nil {
+			if resp.Name == rs.Primary.ID {
+				return fmt.Errorf("CronJob still exists: %s", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckKubernetesCronJobExists(n string, obj *v1beta1.CronJob) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := testAccProvider.Meta().(*kubernetes.Clientset)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		out, err := conn.BatchV1beta1().CronJobs(namespace).Get(name, meta_v1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		*obj = *out
+		return nil
+	}
+}
+
+func testAccKubernetesCronJobConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_cron_job" "test" {
+	metadata {
+		name = "%s"
+	}
+	spec {
+		schedule = "1 0 * * *"
+		job_template {
+			spec {
+				template {
+					spec {
+						container {
+							name = "hello"
+							image = "alpine"
+							command = ["echo", "'hello'"]
+						}
+					}
+				}
+			}
+		}
+	}
+}`, name)
+}
+
+func testAccKubernetesCronJobConfig_modified(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_cron_job" "test" {
+	metadata {
+		name = "%s"
+	}
+	spec {
+		schedule = "1 0 * * *"
+		job_template {
+			spec {
+				parallelism = 2
+				template {
+					metadata {
+						labels {
+							foo = "bar"
+							baz = "foo"
+						}
+					}
+					spec {
+						container {
+							name = "hello"
+							image = "alpine"
+							command = ["echo", "'abcdef'"]
+						}
+					}
+				}
+			}
+		}
+	}
+}`, name)
+}

--- a/kubernetes/resource_kubernetes_cron_job_test.go
+++ b/kubernetes/resource_kubernetes_cron_job_test.go
@@ -33,9 +33,16 @@ func TestAccKubernetesCronJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_cron_job.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttrSet("kubernetes_cron_job.test", "spec.0.schedule"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.concurrency_policy", "Replace"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.failed_jobs_history_limit", "5"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.schedule", "1 0 * * *"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.starting_deadline_seconds", "10"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.successful_jobs_history_limit", "10"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.suspend", "true"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.parallelism", "1"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.backoff_limit", "2"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.template.0.spec.0.container.0.name", "hello"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.template.0.spec.0.container.0.image", "alpine"),
 				),
 			},
 			{
@@ -48,11 +55,17 @@ func TestAccKubernetesCronJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_cron_job.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_cron_job.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.concurrency_policy", "Allow"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.failed_jobs_history_limit", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.schedule", "1 0 * * *"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.starting_deadline_seconds", "0"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.successful_jobs_history_limit", "3"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.suspend", "false"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.parallelism", "2"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.backoff_limit", "0"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.template.0.spec.0.container.0.name", "hello"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.template.0.metadata.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.template.0.metadata.0.labels.%", "2"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.template.0.metadata.0.labels.%", "1"),
 				),
 			},
 		},
@@ -154,11 +167,18 @@ resource "kubernetes_cron_job" "test" {
 		name = "%s"
 	}
 	spec {
+		concurrency_policy = "Replace"
+		failed_jobs_history_limit = 5
 		schedule = "1 0 * * *"
+		starting_deadline_seconds = 10
+		successful_jobs_history_limit = 10
+		suspend = true
 		job_template {
+			metadata {}
 			spec {
 				backoff_limit = 2
 				template {
+					metadata {}
 					spec {
 						container {
 							name = "hello"
@@ -182,20 +202,20 @@ resource "kubernetes_cron_job" "test" {
 	spec {
 		schedule = "1 0 * * *"
 		job_template {
+			metadata {}
 			spec {
 				parallelism = 2
 				template {
 					metadata {
-						labels {
+						labels = {
 							foo = "bar"
-							baz = "foo"
 						}
 					}
 					spec {
 						container {
 							name = "hello"
 							image = "alpine"
-							command = ["echo", "'abcdef'"]
+							command = ["echo", "'hello'"]
 						}
 					}
 				}
@@ -213,14 +233,16 @@ resource "kubernetes_cron_job" "test" {
 	}
 	spec {
 		schedule = "1 0 * * *"
-	concurrency_policy            = "Forbid"
-	successful_jobs_history_limit = 10
-	failed_jobs_history_limit     = 10
-	starting_deadline_seconds     = 60
+		concurrency_policy            = "Forbid"
+		successful_jobs_history_limit = 10
+		failed_jobs_history_limit     = 10
+		starting_deadline_seconds     = 60
 		job_template {
+			metadata {}
 			spec {
 				backoff_limit = 2
 				template {
+					metadata {}
 					spec {
 						container {
 							name = "hello"
@@ -248,9 +270,11 @@ resource "kubernetes_cron_job" "test" {
 		failed_jobs_history_limit     = 2
 		starting_deadline_seconds     = 120
 		job_template {
+			metadata {}
 			spec {
 				backoff_limit = 3
 				template {
+					metadata {}
 					spec {
 						container {
 							name = "hello"

--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -18,7 +18,7 @@ func resourceKubernetesJob() *schema.Resource {
 	s := &schema.Resource{
 		Create: resourceKubernetesJobCreate,
 		Read:   resourceKubernetesJobRead,
-		// Update: resourceKubernetesJobUpdate,
+		Update: resourceKubernetesJobUpdate,
 		Delete: resourceKubernetesJobDelete,
 		Exists: resourceKubernetesJobExists,
 		Importer: &schema.ResourceImporter{
@@ -30,7 +30,6 @@ func resourceKubernetesJob() *schema.Resource {
 				Type:        schema.TypeList,
 				Description: "Spec of the job owned by the cluster",
 				Required:    true,
-				ForceNew:    true,
 				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: jobSpecFields(),
@@ -106,7 +105,6 @@ func resourceKubernetesJobUpdate(d *schema.ResourceData, meta interface{}) error
 	// if err != nil {
 	// 	return err
 	// }
-	// spec.Template.ObjectMeta.Annotations = metadata.Annotations
 
 	// job := batchv1.Job{
 	// 	ObjectMeta: metadata,

--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -38,9 +38,6 @@ func resourceKubernetesJob() *schema.Resource {
 			},
 		},
 	}
-	s.Schema["spec"].Elem.(*schema.Resource).
-		Schema["template"].Elem.(*schema.Resource).
-		Schema["restart_policy"].Default = "OnFailure"
 
 	return s
 }

--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -117,6 +117,25 @@ func resourceKubernetesJobRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	log.Printf("[INFO] Received job: %#v", job)
 
+	// Remove server-generated labels unless using manual selector
+	if _, ok := d.GetOk("spec.0.manual_selector"); !ok {
+		labels := job.ObjectMeta.Labels
+
+		if _, ok := labels["controller-uid"]; ok {
+			delete(labels, "controller-uid")
+		}
+
+		if _, ok := labels["job-name"]; ok {
+			delete(labels, "job-name")
+		}
+
+		labels = job.Spec.Selector.MatchLabels
+
+		if _, ok := labels["controller-uid"]; ok {
+			delete(labels, "controller-uid")
+		}
+	}
+
 	err = d.Set("metadata", flattenMetadata(job.ObjectMeta))
 	if err != nil {
 		return err

--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -10,8 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgApi "k8s.io/apimachinery/pkg/types"
-	batchv1 "k8s.io/kubernetes/pkg/apis/batch/v1"
-	kubernetes "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+	kubernetes "k8s.io/client-go/kubernetes"
+	batchv1 "k8s.io/client-go/pkg/apis/batch/v1"
 )
 
 func resourceKubernetesJob() *schema.Resource {

--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -1,0 +1,191 @@
+package kubernetes
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgApi "k8s.io/apimachinery/pkg/types"
+	batchv1 "k8s.io/kubernetes/pkg/apis/batch/v1"
+	kubernetes "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+)
+
+func resourceKubernetesJob() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceKubernetesJobCreate,
+		Read:   resourceKubernetesJobRead,
+		Update: resourceKubernetesJobUpdate,
+		Delete: resourceKubernetesJobDelete,
+		Exists: resourceKubernetesJobExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"metadata": namespacedMetadataSchema("job", true),
+			"spec": {
+				Type:        schema.TypeList,
+				Description: "Spec of the job owned by the cluster",
+				Required:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: jobSpecFields(),
+				},
+			},
+		},
+	}
+}
+
+func resourceKubernetesJobCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*kubernetes.Clientset)
+
+	metadata := expandMetadata(d.Get("metadata").([]interface{}))
+	spec, err := expandJobSpec(d.Get("spec").([]interface{}))
+	if err != nil {
+		return err
+	}
+
+	job := batchv1.Job{
+		ObjectMeta: metadata,
+		Spec:       spec,
+	}
+
+	log.Printf("[INFO] Creating new job: %#v", job)
+
+	out, err := conn.BatchV1().Jobs(metadata.Namespace).Create(&job)
+	if err != nil {
+		return err
+	}
+	log.Printf("[INFO] Submitted new job: %#v", out)
+
+	d.SetId(buildId(out.ObjectMeta))
+
+	return resourceKubernetesJobRead(d, meta)
+}
+
+func resourceKubernetesJobUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*kubernetes.Clientset)
+
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
+	ops := patchMetadata("metadata.0.", "/metadata/", d)
+
+	if d.HasChange("spec") {
+		specOps, err := patchJobSpec("/spec", "spec.0.", d)
+		if err != nil {
+			return err
+		}
+		ops = append(ops, specOps...)
+	}
+
+	data, err := ops.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("Failed to marshal update operations: %s", err)
+	}
+
+	log.Printf("[INFO] Updating job %s: %s", d.Id(), ops)
+
+	out, err := conn.BatchV1().Jobs(namespace).Patch(name, pkgApi.JSONPatchType, data)
+	if err != nil {
+		return err
+	}
+	log.Printf("[INFO] Submitted updated job: %#v", out)
+
+	d.SetId(buildId(out.ObjectMeta))
+	return resourceKubernetesJobRead(d, meta)
+}
+
+func resourceKubernetesJobRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*kubernetes.Clientset)
+
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Reading job %s", name)
+	job, err := conn.BatchV1().Jobs(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		log.Printf("[DEBUG] Received error: %#v", err)
+		return err
+	}
+	log.Printf("[INFO] Received job: %#v", job)
+
+	err = d.Set("metadata", flattenMetadata(job.ObjectMeta))
+	if err != nil {
+		return err
+	}
+
+	jobSpec, err := flattenJobSpec(job.Spec)
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("spec", jobSpec)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceKubernetesJobDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*kubernetes.Clientset)
+
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Deleting job: %#v", name)
+	err = conn.BatchV1().Jobs(namespace).Delete(name, nil)
+	if err != nil {
+		return err
+	}
+
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		_, err := conn.BatchV1().Jobs(namespace).Get(name, metav1.GetOptions{})
+		if err != nil {
+			if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
+				return nil
+			}
+			return resource.NonRetryableError(err)
+		}
+
+		e := fmt.Errorf("Job %s still exists", name)
+		return resource.RetryableError(e)
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Job %s deleted", name)
+
+	d.SetId("")
+	return nil
+}
+
+func resourceKubernetesJobExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	conn := meta.(*kubernetes.Clientset)
+
+	namespace, name, err := idParts(d.Id())
+	if err != nil {
+		return false, err
+	}
+
+	log.Printf("[INFO] Checking job %s", name)
+	_, err = conn.BatchV1().Jobs(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
+			return false, nil
+		}
+		log.Printf("[DEBUG] Received error: %#v", err)
+	}
+	return true, err
+}

--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgApi "k8s.io/apimachinery/pkg/types"
 	kubernetes "k8s.io/client-go/kubernetes"
-	batchv1 "k8s.io/client-go/pkg/apis/batch/v1"
 )
 
 func resourceKubernetesJob() *schema.Resource {

--- a/kubernetes/resource_kubernetes_job_test.go
+++ b/kubernetes/resource_kubernetes_job_test.go
@@ -33,7 +33,7 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_job.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.parallelism", "2"),
-					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.container.0.name", "hello"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.spec.0.container.0.name", "hello"),
 				),
 			},
 			{
@@ -47,7 +47,7 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_job.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.parallelism", "2"),
-					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.container.0.name", "hello"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.spec.0.container.0.name", "hello"),
 				),
 			},
 		},
@@ -111,10 +111,17 @@ resource "kubernetes_job" "test" {
 	spec {
 		parallelism = 2
 		template {
-			container {
-				name = "hello"
-				image = "alpine"
-				command = ["echo", "'hello'"]
+			metadata {
+				labels {
+					job = "one"
+				}
+			}
+			spec {
+				container {
+					name = "hello"
+					image = "alpine"
+					command = ["echo", "'hello'"]
+				}
 			}
 		}
 	}
@@ -130,10 +137,12 @@ resource "kubernetes_job" "test" {
 	spec {
 		parallelism = 2
 		template {
-			container {
-				name = "hello"
-				image = "alpine"
-				command = ["echo", "'world'"]
+			spec {
+				container {
+					name = "hello"
+					image = "alpine"
+					command = ["echo", "'world'"]
+				}
 			}
 		}
 	}

--- a/kubernetes/resource_kubernetes_job_test.go
+++ b/kubernetes/resource_kubernetes_job_test.go
@@ -110,6 +110,7 @@ resource "kubernetes_job" "test" {
 	}
 	spec {
 		parallelism = 2
+		backoff_limit = 4
 		template {
 			metadata {
 				labels {
@@ -136,6 +137,7 @@ resource "kubernetes_job" "test" {
 	}
 	spec {
 		parallelism = 2
+		backoff_limit = 6
 		template {
 			spec {
 				container {

--- a/kubernetes/resource_kubernetes_job_test.go
+++ b/kubernetes/resource_kubernetes_job_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	api "k8s.io/api/batch/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubernetes "k8s.io/client-go/kubernetes"
-	api "k8s.io/client-go/pkg/apis/batch/v1"
 )
 
 func TestAccKubernetesJob_basic(t *testing.T) {

--- a/kubernetes/resource_kubernetes_job_test.go
+++ b/kubernetes/resource_kubernetes_job_test.go
@@ -32,8 +32,12 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_job.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_job.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.active_deadline_seconds", "120"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.backoff_limit", "10"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.completions", "10"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.parallelism", "2"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.spec.0.container.0.name", "hello"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.spec.0.container.0.image", "alpine"),
 				),
 			},
 			{
@@ -45,9 +49,16 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_job.test", "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet("kubernetes_job.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_job.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "metadata.0.labels.%", "1"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "metadata.0.labels.foo", "bar"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.parallelism", "2"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.active_deadline_seconds", "0"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.backoff_limit", "0"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.completions", "1"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.parallelism", "1"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.manual_selector", "true"),
 					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.spec.0.container.0.name", "hello"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.spec.0.container.0.image", "alpine"),
 				),
 			},
 		},
@@ -109,14 +120,12 @@ resource "kubernetes_job" "test" {
 		name = "%s"
 	}
 	spec {
+		active_deadline_seconds = 120
+		backoff_limit = 10
+		completions = 10
 		parallelism = 2
-		backoff_limit = 4
 		template {
-			metadata {
-				labels {
-					job = "one"
-				}
-			}
+			metadata {}
 			spec {
 				container {
 					name = "hello"
@@ -134,16 +143,28 @@ func testAccKubernetesJobConfig_modified(name string) string {
 resource "kubernetes_job" "test" {
 	metadata {
 		name = "%s"
+		labels = {
+			"foo" = "bar"
+		}
 	}
 	spec {
-		parallelism = 2
-		backoff_limit = 6
+		manual_selector = true
+		selector {
+			match_labels = {
+				"foo" = "bar"
+			}
+		}
 		template {
+			metadata {
+				labels = {
+					"foo" = "bar"
+				}
+			}
 			spec {
 				container {
 					name = "hello"
 					image = "alpine"
-					command = ["echo", "'world'"]
+					command = ["echo", "'hello'"]
 				}
 			}
 		}

--- a/kubernetes/resource_kubernetes_job_test.go
+++ b/kubernetes/resource_kubernetes_job_test.go
@@ -1,0 +1,141 @@
+package kubernetes
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetes "k8s.io/client-go/kubernetes"
+	api "k8s.io/client-go/pkg/apis/batch/v1"
+)
+
+func TestAccKubernetesJob_basic(t *testing.T) {
+	var conf api.Job
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "kubernetes_job.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesJobConfig_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesJobExists("kubernetes_job.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_job.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_job.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_job.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_job.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.parallelism", "2"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.container.0.name", "hello"),
+				),
+			},
+			{
+				Config: testAccKubernetesJobConfig_modified(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesJobExists("kubernetes_job.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_job.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_job.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_job.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_job.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.parallelism", "2"),
+					resource.TestCheckResourceAttr("kubernetes_job.test", "spec.0.template.0.container.0.name", "hello"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckKubernetesJobDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*kubernetes.Clientset)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "kubernetes_job" {
+			continue
+		}
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		resp, err := conn.BatchV1().Jobs(namespace).Get(name, meta_v1.GetOptions{})
+		if err == nil {
+			if resp.Name == rs.Primary.ID {
+				return fmt.Errorf("Job still exists: %s", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckKubernetesJobExists(n string, obj *api.Job) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := testAccProvider.Meta().(*kubernetes.Clientset)
+
+		namespace, name, err := idParts(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		out, err := conn.BatchV1().Jobs(namespace).Get(name, meta_v1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		*obj = *out
+		return nil
+	}
+}
+
+func testAccKubernetesJobConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_job" "test" {
+	metadata {
+		name = "%s"
+	}
+	spec {
+		parallelism = 2
+		template {
+			container {
+				name = "hello"
+				image = "alpine"
+				command = ["echo", "'hello'"]
+			}
+		}
+	}
+}`, name)
+}
+
+func testAccKubernetesJobConfig_modified(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_job" "test" {
+	metadata {
+		name = "%s"
+	}
+	spec {
+		parallelism = 2
+		template {
+			container {
+				name = "hello"
+				image = "alpine"
+				command = ["echo", "'world'"]
+			}
+		}
+	}
+}`, name)
+}

--- a/kubernetes/schema_cron_job_spec.go
+++ b/kubernetes/schema_cron_job_spec.go
@@ -2,15 +2,23 @@ package kubernetes
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func cronJobSpecFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
-		"schedule": {
+		"concurrency_policy": {
 			Type:         schema.TypeString,
-			Required:    true,
-			//ValidateFunc: validate, TODO: validate cron syntax..
-			Description:  "Cron format string, e.g. 0 * * * * or @hourly, as schedule time of its jobs to be created and executed.",
+			Optional:     true,
+			Default:      "Allow",
+			ValidateFunc: validation.StringInSlice([]string{"Allow", "Forbid", "Replace"}, false),
+			Description:  "Specifies how to treat concurrent executions of a Job. Defaults to Allow.",
+		},
+		"failed_jobs_history_limit": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Default:     "1",
+			Description: "The number of failed finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
 		},
 		"job_template": {
 			Type:        schema.TypeList,
@@ -18,8 +26,43 @@ func cronJobSpecFields() map[string]*schema.Schema {
 			Required:    true,
 			MaxItems:    1,
 			Elem: &schema.Resource{
-				Schema: jobSpecFields(),
+				Schema: map[string]*schema.Schema{
+					"metadata": metadataSchema("jobTemplateSpec", true),
+					"spec": {
+						Type:        schema.TypeList,
+						Description: "Specification of the desired behavior of the job",
+						Required:    true,
+						MaxItems:    1,
+						Elem: &schema.Resource{
+							Schema: jobSpecFields(),
+						},
+					},
+				},
 			},
+		},
+		"schedule": {
+			Type:     schema.TypeString,
+			Required: true,
+			//ValidateFunc: validate, TODO: validate cron syntax..
+			Description: "Cron format string, e.g. 0 * * * * or @hourly, as schedule time of its jobs to be created and executed.",
+		},
+		"starting_deadline_seconds": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Default:     0,
+			Description: "Optional deadline in seconds for starting the job if it misses scheduled time for any reason. Missed jobs executions will be counted as failed ones.",
+		},
+		"successful_jobs_history_limit": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Default:     3,
+			Description: "The number of successful finished jobs to retain. Defaults to 3.",
+		},
+		"suspend": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "This flag tells the controller to suspend subsequent executions, it does not apply to already started executions. Defaults to false.",
 		},
 	}
 

--- a/kubernetes/schema_cron_job_spec.go
+++ b/kubernetes/schema_cron_job_spec.go
@@ -1,0 +1,27 @@
+package kubernetes
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func cronJobSpecFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"schedule": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			//ValidateFunc: validate, TODO: validate cron syntax..
+			Description:  "Cron format string, e.g. 0 * * * * or @hourly, as schedule time of its jobs to be created and executed.",
+		},
+		"job_template": {
+			Type:        schema.TypeList,
+			Description: "Describes the pod that will be created when executing a cron job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
+			Required:    true,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: jobSpecFields(),
+			},
+		},
+	}
+
+	return s
+}

--- a/kubernetes/schema_cron_job_spec.go
+++ b/kubernetes/schema_cron_job_spec.go
@@ -8,7 +8,7 @@ func cronJobSpecFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"schedule": {
 			Type:         schema.TypeString,
-			Optional:     true,
+			Required:    true,
 			//ValidateFunc: validate, TODO: validate cron syntax..
 			Description:  "Cron format string, e.g. 0 * * * * or @hourly, as schedule time of its jobs to be created and executed.",
 		},

--- a/kubernetes/schema_job_spec.go
+++ b/kubernetes/schema_job_spec.go
@@ -12,6 +12,12 @@ func jobSpecFields() map[string]*schema.Schema {
 			ValidateFunc: validatePositiveInteger,
 			Description:  "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
 		},
+		"backoff_limit": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ValidateFunc: validatePositiveInteger,
+			Description:  "Specifies the number of retries before marking this job failed. Defaults to 6",
+		},
 		"completions": {
 			Type:         schema.TypeInt,
 			Optional:     true,

--- a/kubernetes/schema_job_spec.go
+++ b/kubernetes/schema_job_spec.go
@@ -83,7 +83,7 @@ func jobSpecFields() map[string]*schema.Schema {
 			Required:    true,
 			MaxItems:    1,
 			Elem: &schema.Resource{
-				Schema: podSpecFields(false),
+				Schema: podTemplateFields("job"),
 			},
 		},
 	}

--- a/kubernetes/schema_job_spec.go
+++ b/kubernetes/schema_job_spec.go
@@ -1,0 +1,50 @@
+package kubernetes
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func jobSpecFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"active_deadline_seconds": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ValidateFunc: validatePositiveInteger,
+			Description:  "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
+		},
+		"completions": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ValidateFunc: validatePositiveInteger,
+			Description:  "Specifies the desired number of successfully finished pods the job should be run with. Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value. Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
+		},
+		"manual_selector": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Controls generation of pod labels and pod selectors. Leave unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template. When true, the user is responsyble for picking unique labels and specifying the selector. Failure to pick a unique label may cause this and other jobs to not function correctly. More info: https://git.k8s.io/community/contributors/design-proposals/selector-generation.md",
+		},
+		"parallelism": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ValidateFunc: validatePositiveInteger,
+			Description:  "Specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
+		},
+		"selector": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Description: "A label query over pods that should match the pod count. Normally, the system sets this field for you. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+		},
+		"template": {
+			Type:        schema.TypeList,
+			Description: "Describes the pod that will be created when executing a job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
+			Required:    true,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: podSpecFields(true),
+			},
+		},
+	}
+
+	return s
+}

--- a/kubernetes/schema_job_spec.go
+++ b/kubernetes/schema_job_spec.go
@@ -15,6 +15,7 @@ func jobSpecFields() map[string]*schema.Schema {
 		"completions": {
 			Type:         schema.TypeInt,
 			Optional:     true,
+			Default:      1,
 			ValidateFunc: validatePositiveInteger,
 			Description:  "Specifies the desired number of successfully finished pods the job should be run with. Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value. Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
 		},
@@ -27,13 +28,54 @@ func jobSpecFields() map[string]*schema.Schema {
 		"parallelism": {
 			Type:         schema.TypeInt,
 			Optional:     true,
+			Default:      1,
 			ValidateFunc: validatePositiveInteger,
 			Description:  "Specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
 		},
 		"selector": {
-			Type:        schema.TypeMap,
+			Type:        schema.TypeList,
+			Description: "A label query over volumes to consider for binding.",
 			Optional:    true,
-			Description: "A label query over pods that should match the pod count. Normally, the system sets this field for you. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"match_expressions": {
+						Type:        schema.TypeList,
+						Description: "A list of label selector requirements. The requirements are ANDed.",
+						Optional:    true,
+						ForceNew:    true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"key": {
+									Type:        schema.TypeString,
+									Description: "The label key that the selector applies to.",
+									Optional:    true,
+									ForceNew:    true,
+								},
+								"operator": {
+									Type:        schema.TypeString,
+									Description: "A key's relationship to a set of values. Valid operators ard `In`, `NotIn`, `Exists` and `DoesNotExist`.",
+									Optional:    true,
+									ForceNew:    true,
+								},
+								"values": {
+									Type:        schema.TypeSet,
+									Description: "An array of string values. If the operator is `In` or `NotIn`, the values array must be non-empty. If the operator is `Exists` or `DoesNotExist`, the values array must be empty. This array is replaced during a strategic merge patch.",
+									Optional:    true,
+									ForceNew:    true,
+									Elem:        &schema.Schema{Type: schema.TypeString},
+									Set:         schema.HashString,
+								},
+							},
+						},
+					},
+					"match_labels": {
+						Type:        schema.TypeMap,
+						Description: "A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+						Optional:    true,
+					},
+				},
+			},
 		},
 		"template": {
 			Type:        schema.TypeList,

--- a/kubernetes/schema_job_spec.go
+++ b/kubernetes/schema_job_spec.go
@@ -4,23 +4,53 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
+func jobMetadataSchema() *schema.Schema {
+	m := namespacedMetadataSchema("job", true)
+	mr := m.Elem.(*schema.Resource)
+	mr.Schema["labels"].Computed = true
+	return m
+}
+
 func jobSpecFields() map[string]*schema.Schema {
+	podTemplateFields := map[string]*schema.Schema{
+		"metadata": metadataSchema("job", true),
+		"spec": {
+			Type:        schema.TypeList,
+			Description: "Spec of the pods owned by the job",
+			Optional:    true,
+			ForceNew:    true,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: podSpecFields(false, false, false),
+			},
+		},
+	}
+	// Job and CronJob don't support "Always" as a value for "restart_policy" in Pod templates.
+	// This changes the default value of "restart_policy" to "Never"
+	// as expected by Job and CronJob resources.
+	podTemplateFieldsSpecSchema := podTemplateFields["spec"].Elem.(*schema.Resource)
+	restartPolicy := podTemplateFieldsSpecSchema.Schema["restart_policy"]
+	restartPolicy.Default = "Never"
+
 	s := map[string]*schema.Schema{
 		"active_deadline_seconds": {
 			Type:         schema.TypeInt,
 			Optional:     true,
+			ForceNew:     true,
 			ValidateFunc: validatePositiveInteger,
 			Description:  "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
 		},
 		"backoff_limit": {
 			Type:         schema.TypeInt,
 			Optional:     true,
+			ForceNew:     true,
 			ValidateFunc: validatePositiveInteger,
 			Description:  "Specifies the number of retries before marking this job failed. Defaults to 6",
 		},
 		"completions": {
 			Type:         schema.TypeInt,
 			Optional:     true,
+			ForceNew:     true,
 			Default:      1,
 			ValidateFunc: validatePositiveInteger,
 			Description:  "Specifies the desired number of successfully finished pods the job should be run with. Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value. Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
@@ -28,12 +58,13 @@ func jobSpecFields() map[string]*schema.Schema {
 		"manual_selector": {
 			Type:        schema.TypeBool,
 			Optional:    true,
-			Default:     false,
+			ForceNew:    true,
 			Description: "Controls generation of pod labels and pod selectors. Leave unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template. When true, the user is responsyble for picking unique labels and specifying the selector. Failure to pick a unique label may cause this and other jobs to not function correctly. More info: https://git.k8s.io/community/contributors/design-proposals/selector-generation.md",
 		},
 		"parallelism": {
 			Type:         schema.TypeInt,
 			Optional:     true,
+			ForceNew:     true,
 			Default:      1,
 			ValidateFunc: validatePositiveInteger,
 			Description:  "Specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
@@ -42,6 +73,8 @@ func jobSpecFields() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Description: "A label query over volumes to consider for binding.",
 			Optional:    true,
+			ForceNew:    true,
+			Computed:    true,
 			MaxItems:    1,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
@@ -79,6 +112,7 @@ func jobSpecFields() map[string]*schema.Schema {
 						Type:        schema.TypeMap,
 						Description: "A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
 						Optional:    true,
+						ForceNew:    true,
 					},
 				},
 			},
@@ -88,8 +122,9 @@ func jobSpecFields() map[string]*schema.Schema {
 			Description: "Describes the pod that will be created when executing a job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
 			Required:    true,
 			MaxItems:    1,
+			ForceNew:    true,
 			Elem: &schema.Resource{
-				Schema: podTemplateFields("job"),
+				Schema: podTemplateFields,
 			},
 		},
 	}

--- a/kubernetes/schema_job_spec.go
+++ b/kubernetes/schema_job_spec.go
@@ -44,6 +44,7 @@ func jobSpecFields() map[string]*schema.Schema {
 			Type:         schema.TypeInt,
 			Optional:     true,
 			ForceNew:     true,
+			Default:      6,
 			ValidateFunc: validatePositiveInteger,
 			Description:  "Specifies the number of retries before marking this job failed. Defaults to 6",
 		},

--- a/kubernetes/schema_job_spec.go
+++ b/kubernetes/schema_job_spec.go
@@ -83,7 +83,7 @@ func jobSpecFields() map[string]*schema.Schema {
 			Required:    true,
 			MaxItems:    1,
 			Elem: &schema.Resource{
-				Schema: podSpecFields(true),
+				Schema: podSpecFields(false),
 			},
 		},
 	}

--- a/kubernetes/structure_cron_job.go
+++ b/kubernetes/structure_cron_job.go
@@ -3,19 +3,52 @@ package kubernetes
 import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"k8s.io/api/batch/v1beta1"
-	"errors"
 )
 
 func flattenCronJobSpec(in v1beta1.CronJobSpec) ([]interface{}, error) {
 	att := make(map[string]interface{})
 
+	att["concurrency_policy"] = in.ConcurrencyPolicy
+	if in.FailedJobsHistoryLimit != nil {
+		att["failed_jobs_history_limit"] = int(*in.FailedJobsHistoryLimit)
+	} else {
+		att["failed_jobs_history_limit"] = 1
+	}
+
 	att["schedule"] = in.Schedule
 
-	jobSpec, err := flattenJobSpec(in.JobTemplate.Spec)
+	jobTemplate, err := flattenJobTemplate(in.JobTemplate)
 	if err != nil {
 		return nil, err
 	}
-	att["job_template"] = jobSpec
+	att["job_template"] = jobTemplate
+
+	if in.StartingDeadlineSeconds != nil {
+		att["starting_deadline_seconds"] = int(*in.StartingDeadlineSeconds)
+	} else {
+		att["starting_deadline_seconds"] = 0
+	}
+
+	if in.SuccessfulJobsHistoryLimit != nil {
+		att["successful_jobs_history_limit"] = int(*in.SuccessfulJobsHistoryLimit)
+	} else {
+		att["successful_jobs_history_limit"] = 3
+	}
+
+	return []interface{}{att}, nil
+}
+
+func flattenJobTemplate(in v1beta1.JobTemplateSpec) ([]interface{}, error) {
+	att := make(map[string]interface{})
+
+	meta := flattenMetadata(in.ObjectMeta)
+	att["metadata"] = meta
+
+	jobSpec, err := flattenJobSpec(in.Spec)
+	if err != nil {
+		return nil, err
+	}
+	att["spec"] = jobSpec
 
 	return []interface{}{att}, nil
 }
@@ -29,16 +62,49 @@ func expandCronJobSpec(j []interface{}) (v1beta1.CronJobSpec, error) {
 
 	in := j[0].(map[string]interface{})
 
+	obj.ConcurrencyPolicy = v1beta1.ConcurrencyPolicy(in["concurrency_policy"].(string))
+
+	if v, ok := in["failed_jobs_history_limit"].(int); ok && v != 1 {
+		obj.FailedJobsHistoryLimit = ptrToInt32(int32(v))
+	}
+
 	obj.Schedule = in["schedule"].(string)
 
-	podSpec, err := expandJobSpec(in["job_template"].([]interface{}))
+	jtSpec, err := expandJobTemplate(in["job_template"].([]interface{}))
 	if err != nil {
 		return obj, err
 	}
+	obj.JobTemplate = jtSpec
 
+	if v, ok := in["starting_deadline_seconds"].(int); ok && v > 0 {
+		obj.StartingDeadlineSeconds = ptrToInt64(int64(v))
+	}
 
-	obj.JobTemplate = v1beta1.JobTemplateSpec {
-		Spec: podSpec,
+	if v, ok := in["successful_jobs_history_limit"].(int); ok && v != 3 {
+		obj.StartingDeadlineSeconds = ptrToInt64(int64(v))
+	}
+
+	if v, ok := in["suspend"].(bool); ok {
+		obj.Suspend = ptrToBool(v)
+	}
+
+	return obj, nil
+}
+
+func expandJobTemplate(in []interface{}) (v1beta1.JobTemplateSpec, error) {
+	obj := v1beta1.JobTemplateSpec{}
+
+	tpl := in[0].(map[string]interface{})
+
+	spec, err := expandJobSpec(tpl["spec"].([]interface{}))
+	if err != nil {
+		return obj, err
+	}
+	obj.Spec = spec
+
+	if metaCfg, ok := tpl["metadata"]; ok {
+		metadata := expandMetadata(metaCfg.([]interface{}))
+		obj.ObjectMeta = metadata
 	}
 
 	return obj, nil

--- a/kubernetes/structure_cron_job.go
+++ b/kubernetes/structure_cron_job.go
@@ -9,11 +9,7 @@ import (
 func flattenCronJobSpec(in v1beta1.CronJobSpec) ([]interface{}, error) {
 	att := make(map[string]interface{})
 
-	if in.Schedule != "" {
-		att["schedule"] = in.Schedule
-	} else {
-		return nil, errors.New("You need to define a schedule.")
-	}
+	att["schedule"] = in.Schedule
 
 	jobSpec, err := flattenJobSpec(in.JobTemplate.Spec)
 	if err != nil {
@@ -33,11 +29,7 @@ func expandCronJobSpec(j []interface{}) (v1beta1.CronJobSpec, error) {
 
 	in := j[0].(map[string]interface{})
 
-	if v, ok := in["schedule"].(string); ok && len(v) > 0 {
-		obj.Schedule = *ptrToString(string(v))
-	} else {
-		return obj, errors.New("You need to define a schedule.")
-	}
+	obj.Schedule = in["schedule"].(string)
 
 	podSpec, err := expandJobSpec(in["job_template"].([]interface{}))
 	if err != nil {

--- a/kubernetes/structure_cron_job.go
+++ b/kubernetes/structure_cron_job.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"github.com/hashicorp/terraform/helper/schema"
 	"k8s.io/api/batch/v1beta1"
 )
 
@@ -108,10 +107,4 @@ func expandJobTemplate(in []interface{}) (v1beta1.JobTemplateSpec, error) {
 	}
 
 	return obj, nil
-}
-
-func patchCronJobSpec(pathPrefix, prefix string, d *schema.ResourceData) (PatchOperations, error) {
-	ops := make([]PatchOperation, 0)
-
-	return ops, nil
 }

--- a/kubernetes/structure_cron_job.go
+++ b/kubernetes/structure_cron_job.go
@@ -24,13 +24,13 @@ func flattenCronJobSpec(in v1beta1.CronJobSpec) ([]interface{}, error) {
 	att["job_template"] = jobTemplate
 
 	if in.StartingDeadlineSeconds != nil {
-		att["starting_deadline_seconds"] = int(*in.StartingDeadlineSeconds)
+		att["starting_deadline_seconds"] = int64(*in.StartingDeadlineSeconds)
 	} else {
 		att["starting_deadline_seconds"] = 0
 	}
 
 	if in.SuccessfulJobsHistoryLimit != nil {
-		att["successful_jobs_history_limit"] = int(*in.SuccessfulJobsHistoryLimit)
+		att["successful_jobs_history_limit"] = int32(*in.SuccessfulJobsHistoryLimit)
 	} else {
 		att["successful_jobs_history_limit"] = 3
 	}
@@ -81,7 +81,7 @@ func expandCronJobSpec(j []interface{}) (v1beta1.CronJobSpec, error) {
 	}
 
 	if v, ok := in["successful_jobs_history_limit"].(int); ok && v != 3 {
-		obj.StartingDeadlineSeconds = ptrToInt64(int64(v))
+		obj.SuccessfulJobsHistoryLimit = ptrToInt32(int32(v))
 	}
 
 	if v, ok := in["suspend"].(bool); ok {

--- a/kubernetes/structure_cron_job.go
+++ b/kubernetes/structure_cron_job.go
@@ -1,0 +1,59 @@
+package kubernetes
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"k8s.io/api/batch/v1beta1"
+	"errors"
+)
+
+func flattenCronJobSpec(in v1beta1.CronJobSpec) ([]interface{}, error) {
+	att := make(map[string]interface{})
+
+	if in.Schedule != "" {
+		att["schedule"] = in.Schedule
+	} else {
+		return nil, errors.New("You need to define a schedule.")
+	}
+
+	jobSpec, err := flattenJobSpec(in.JobTemplate.Spec)
+	if err != nil {
+		return nil, err
+	}
+	att["job_template"] = jobSpec
+
+	return []interface{}{att}, nil
+}
+
+func expandCronJobSpec(j []interface{}) (v1beta1.CronJobSpec, error) {
+	obj := v1beta1.CronJobSpec{}
+
+	if len(j) == 0 || j[0] == nil {
+		return obj, nil
+	}
+
+	in := j[0].(map[string]interface{})
+
+	if v, ok := in["schedule"].(string); ok && len(v) > 0 {
+		obj.Schedule = *ptrToString(string(v))
+	} else {
+		return obj, errors.New("You need to define a schedule.")
+	}
+
+	podSpec, err := expandJobSpec(in["job_template"].([]interface{}))
+	if err != nil {
+		return obj, err
+	}
+
+
+	obj.JobTemplate = v1beta1.JobTemplateSpec {
+		Spec: podSpec,
+	}
+
+	return obj, nil
+}
+
+func patchCronJobSpec(pathPrefix, prefix string, d *schema.ResourceData) (PatchOperations, error) {
+	ops := make([]PatchOperation, 0)
+
+	return ops, nil
+}

--- a/kubernetes/structure_job.go
+++ b/kubernetes/structure_job.go
@@ -12,6 +12,10 @@ func flattenJobSpec(in batchv1.JobSpec) ([]interface{}, error) {
 		att["active_deadline_seconds"] = *in.ActiveDeadlineSeconds
 	}
 
+	if in.BackoffLimit != nil {
+		att["backoff_limit"] = *in.BackoffLimit
+	}
+
 	if in.Completions != nil {
 		att["completions"] = *in.Completions
 	}
@@ -58,6 +62,10 @@ func expandJobSpec(j []interface{}) (batchv1.JobSpec, error) {
 
 	if v, ok := in["active_deadline_seconds"].(int); ok && v > 0 {
 		obj.ActiveDeadlineSeconds = ptrToInt64(int64(v))
+	}
+
+	if v, ok := in["backoff_limit"].(int); ok && v != 6 {
+		obj.BackoffLimit = ptrToInt32(int32(v))
 	}
 
 	if v, ok := in["completions"].(int); ok && v > 0 {

--- a/kubernetes/structure_job.go
+++ b/kubernetes/structure_job.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"github.com/hashicorp/terraform/helper/schema"
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
 )
 
 func flattenJobSpec(in batchv1.JobSpec) ([]interface{}, error) {
@@ -28,8 +27,18 @@ func flattenJobSpec(in batchv1.JobSpec) ([]interface{}, error) {
 	if in.Selector != nil {
 		att["selector"] = flattenLabelSelector(in.Selector)
 	}
+	// Remove server-generated labels
+	labels := in.Template.ObjectMeta.Labels
 
-	podSpec, err := flattenPodSpec(in.Template.Spec)
+	if _, ok := labels["controller-uid"]; ok {
+		delete(labels, "controller-uid")
+	}
+
+	if _, ok := labels["job-name"]; ok {
+		delete(labels, "job-name")
+	}
+
+	podSpec, err := flattenPodTemplateSpec(in.Template)
 	if err != nil {
 		return nil, err
 	}
@@ -67,14 +76,11 @@ func expandJobSpec(j []interface{}) (batchv1.JobSpec, error) {
 		obj.Selector = expandLabelSelector(v)
 	}
 
-	podSpec, err := expandPodSpec(in["template"].([]interface{}))
+	template, err := expandPodTemplate(in["template"].([]interface{}))
 	if err != nil {
 		return obj, err
 	}
-
-	obj.Template = v1.PodTemplateSpec{
-		Spec: podSpec,
-	}
+	obj.Template = *template
 
 	return obj, nil
 }
@@ -83,7 +89,6 @@ func patchJobSpec(pathPrefix, prefix string, d *schema.ResourceData) (PatchOpera
 	ops := make([]PatchOperation, 0)
 
 	if d.HasChange(prefix + "active_deadline_seconds") {
-
 		v := d.Get(prefix + "active_deadline_seconds").(int)
 		ops = append(ops, &ReplaceOperation{
 			Path:  pathPrefix + "/activeDeadlineSeconds",

--- a/kubernetes/structure_job.go
+++ b/kubernetes/structure_job.go
@@ -17,13 +17,17 @@ func flattenJobSpec(in batchv1.JobSpec) ([]interface{}, error) {
 		att["completions"] = *in.Completions
 	}
 
-	att["manual_selector"] = in.ManualSelector
+	if in.ManualSelector != nil {
+		att["manual_selector"] = *in.ManualSelector
+	}
 
 	if in.Parallelism != nil {
 		att["parallelism"] = *in.Parallelism
 	}
 
-	att["selector"] = in.Selector
+	if in.Selector != nil {
+		att["selector"] = flattenLabelSelector(in.Selector)
+	}
 
 	podSpec, err := flattenPodSpec(in.Template.Spec)
 	if err != nil {

--- a/kubernetes/structure_job.go
+++ b/kubernetes/structure_job.go
@@ -1,0 +1,91 @@
+package kubernetes
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"k8s.io/kubernetes/pkg/api/v1"
+	batchv1 "k8s.io/kubernetes/pkg/apis/batch/v1"
+)
+
+func flattenJobSpec(in batchv1.JobSpec) ([]interface{}, error) {
+	att := make(map[string]interface{})
+
+	if in.ActiveDeadlineSeconds != nil {
+		att["active_deadline_seconds"] = *in.ActiveDeadlineSeconds
+	}
+
+	if in.Completions != nil {
+		att["completions"] = *in.Completions
+	}
+
+	att["manual_selector"] = in.ManualSelector
+
+	if in.Parallelism != nil {
+		att["parallelism"] = *in.Parallelism
+	}
+
+	att["selector"] = in.Selector
+
+	podSpec, err := flattenPodSpec(in.Template.Spec)
+	if err != nil {
+		return nil, err
+	}
+	att["template"] = podSpec
+
+	return []interface{}{att}, nil
+}
+
+func expandJobSpec(j []interface{}) (batchv1.JobSpec, error) {
+	obj := batchv1.JobSpec{}
+
+	if len(j) == 0 || j[0] == nil {
+		return obj, nil
+	}
+
+	in := j[0].(map[string]interface{})
+
+	if v, ok := in["active_deadline_seconds"].(int); ok && v > 0 {
+		obj.ActiveDeadlineSeconds = ptrToInt64(int64(v))
+	}
+
+	if v, ok := in["completions"].(int); ok && v > 0 {
+		obj.Completions = ptrToInt32(int32(v))
+	}
+
+	if v, ok := in["manual_selector"]; ok {
+		obj.ManualSelector = ptrToBool(v.(bool))
+	}
+
+	if v, ok := in["parallelism"].(int); ok && v > 0 {
+		obj.Parallelism = ptrToInt32(int32(v))
+	}
+
+	if v, ok := in["selector"].([]interface{}); ok && len(v) > 0 {
+		obj.Selector = expandLabelSelector(v)
+	}
+
+	podSpec, err := expandPodSpec(in["template"].([]interface{}))
+	if err != nil {
+		return obj, err
+	}
+
+	obj.Template = v1.PodTemplateSpec{
+		Spec: podSpec,
+	}
+
+	return obj, nil
+}
+
+func patchJobSpec(pathPrefix, prefix string, d *schema.ResourceData) (PatchOperations, error) {
+	ops := make([]PatchOperation, 0)
+
+	if d.HasChange(prefix + "active_deadline_seconds") {
+
+		v := d.Get(prefix + "active_deadline_seconds").(int)
+		ops = append(ops, &ReplaceOperation{
+			Path:  pathPrefix + "/activeDeadlineSeconds",
+			Value: v,
+		})
+	}
+
+	return ops, nil
+}

--- a/kubernetes/structure_job.go
+++ b/kubernetes/structure_job.go
@@ -2,8 +2,8 @@ package kubernetes
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"k8s.io/client-go/pkg/api/v1"
-	batchv1 "k8s.io/client-go/pkg/apis/batch/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/api/core/v1"
 )
 
 func flattenJobSpec(in batchv1.JobSpec) ([]interface{}, error) {

--- a/kubernetes/structure_job.go
+++ b/kubernetes/structure_job.go
@@ -2,8 +2,8 @@ package kubernetes
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"k8s.io/kubernetes/pkg/api/v1"
-	batchv1 "k8s.io/kubernetes/pkg/apis/batch/v1"
+	"k8s.io/client-go/pkg/api/v1"
+	batchv1 "k8s.io/client-go/pkg/apis/batch/v1"
 )
 
 func flattenJobSpec(in batchv1.JobSpec) ([]interface{}, error) {

--- a/kubernetes/structure_job.go
+++ b/kubernetes/structure_job.go
@@ -5,7 +5,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 )
 
-func flattenJobSpec(in batchv1.JobSpec) ([]interface{}, error) {
+func flattenJobSpec(in batchv1.JobSpec, d *schema.ResourceData, prefix ...string) ([]interface{}, error) {
 	att := make(map[string]interface{})
 
 	if in.ActiveDeadlineSeconds != nil {
@@ -42,7 +42,7 @@ func flattenJobSpec(in batchv1.JobSpec) ([]interface{}, error) {
 		delete(labels, "job-name")
 	}
 
-	podSpec, err := flattenPodTemplateSpec(in.Template)
+	podSpec, err := flattenPodTemplateSpec(in.Template, d, prefix...)
 	if err != nil {
 		return nil, err
 	}

--- a/kubernetes/structures_stateful_set.go
+++ b/kubernetes/structures_stateful_set.go
@@ -182,10 +182,14 @@ func flattenStatefulSetSpec(spec v1.StatefulSetSpec, d *schema.ResourceData) ([]
 	return []interface{}{att}, nil
 }
 
-func flattenPodTemplateSpec(t corev1.PodTemplateSpec, d *schema.ResourceData) ([]interface{}, error) {
+func flattenPodTemplateSpec(t corev1.PodTemplateSpec, d *schema.ResourceData, prefix ...string) ([]interface{}, error) {
 	template := make(map[string]interface{})
 
-	template["metadata"] = flattenMetadata(t.ObjectMeta, d, "spec.0.template.0.")
+	metaPrefix := "spec.0.template.0."
+	if len(prefix) > 0 {
+		metaPrefix = prefix[0]
+	}
+	template["metadata"] = flattenMetadata(t.ObjectMeta, d, metaPrefix)
 	spec, err := flattenPodSpec(t.Spec)
 	if err != nil {
 		return []interface{}{template}, err

--- a/vendor/github.com/robfig/cron/.gitignore
+++ b/vendor/github.com/robfig/cron/.gitignore
@@ -1,0 +1,22 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/vendor/github.com/robfig/cron/.travis.yml
+++ b/vendor/github.com/robfig/cron/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/vendor/github.com/robfig/cron/LICENSE
+++ b/vendor/github.com/robfig/cron/LICENSE
@@ -1,0 +1,21 @@
+Copyright (C) 2012 Rob Figueiredo
+All Rights Reserved.
+
+MIT LICENSE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/robfig/cron/README.md
+++ b/vendor/github.com/robfig/cron/README.md
@@ -1,0 +1,6 @@
+[![GoDoc](http://godoc.org/github.com/robfig/cron?status.png)](http://godoc.org/github.com/robfig/cron) 
+[![Build Status](https://travis-ci.org/robfig/cron.svg?branch=master)](https://travis-ci.org/robfig/cron)
+
+# cron
+
+Documentation here: https://godoc.org/github.com/robfig/cron

--- a/vendor/github.com/robfig/cron/constantdelay.go
+++ b/vendor/github.com/robfig/cron/constantdelay.go
@@ -1,0 +1,27 @@
+package cron
+
+import "time"
+
+// ConstantDelaySchedule represents a simple recurring duty cycle, e.g. "Every 5 minutes".
+// It does not support jobs more frequent than once a second.
+type ConstantDelaySchedule struct {
+	Delay time.Duration
+}
+
+// Every returns a crontab Schedule that activates once every duration.
+// Delays of less than a second are not supported (will round up to 1 second).
+// Any fields less than a Second are truncated.
+func Every(duration time.Duration) ConstantDelaySchedule {
+	if duration < time.Second {
+		duration = time.Second
+	}
+	return ConstantDelaySchedule{
+		Delay: duration - time.Duration(duration.Nanoseconds())%time.Second,
+	}
+}
+
+// Next returns the next time this should be run.
+// This rounds so that the next activation time will be on the second.
+func (schedule ConstantDelaySchedule) Next(t time.Time) time.Time {
+	return t.Add(schedule.Delay - time.Duration(t.Nanosecond())*time.Nanosecond)
+}

--- a/vendor/github.com/robfig/cron/cron.go
+++ b/vendor/github.com/robfig/cron/cron.go
@@ -1,0 +1,259 @@
+package cron
+
+import (
+	"log"
+	"runtime"
+	"sort"
+	"time"
+)
+
+// Cron keeps track of any number of entries, invoking the associated func as
+// specified by the schedule. It may be started, stopped, and the entries may
+// be inspected while running.
+type Cron struct {
+	entries  []*Entry
+	stop     chan struct{}
+	add      chan *Entry
+	snapshot chan []*Entry
+	running  bool
+	ErrorLog *log.Logger
+	location *time.Location
+}
+
+// Job is an interface for submitted cron jobs.
+type Job interface {
+	Run()
+}
+
+// The Schedule describes a job's duty cycle.
+type Schedule interface {
+	// Return the next activation time, later than the given time.
+	// Next is invoked initially, and then each time the job is run.
+	Next(time.Time) time.Time
+}
+
+// Entry consists of a schedule and the func to execute on that schedule.
+type Entry struct {
+	// The schedule on which this job should be run.
+	Schedule Schedule
+
+	// The next time the job will run. This is the zero time if Cron has not been
+	// started or this entry's schedule is unsatisfiable
+	Next time.Time
+
+	// The last time this job was run. This is the zero time if the job has never
+	// been run.
+	Prev time.Time
+
+	// The Job to run.
+	Job Job
+}
+
+// byTime is a wrapper for sorting the entry array by time
+// (with zero time at the end).
+type byTime []*Entry
+
+func (s byTime) Len() int      { return len(s) }
+func (s byTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s byTime) Less(i, j int) bool {
+	// Two zero times should return false.
+	// Otherwise, zero is "greater" than any other time.
+	// (To sort it at the end of the list.)
+	if s[i].Next.IsZero() {
+		return false
+	}
+	if s[j].Next.IsZero() {
+		return true
+	}
+	return s[i].Next.Before(s[j].Next)
+}
+
+// New returns a new Cron job runner, in the Local time zone.
+func New() *Cron {
+	return NewWithLocation(time.Now().Location())
+}
+
+// NewWithLocation returns a new Cron job runner.
+func NewWithLocation(location *time.Location) *Cron {
+	return &Cron{
+		entries:  nil,
+		add:      make(chan *Entry),
+		stop:     make(chan struct{}),
+		snapshot: make(chan []*Entry),
+		running:  false,
+		ErrorLog: nil,
+		location: location,
+	}
+}
+
+// A wrapper that turns a func() into a cron.Job
+type FuncJob func()
+
+func (f FuncJob) Run() { f() }
+
+// AddFunc adds a func to the Cron to be run on the given schedule.
+func (c *Cron) AddFunc(spec string, cmd func()) error {
+	return c.AddJob(spec, FuncJob(cmd))
+}
+
+// AddJob adds a Job to the Cron to be run on the given schedule.
+func (c *Cron) AddJob(spec string, cmd Job) error {
+	schedule, err := Parse(spec)
+	if err != nil {
+		return err
+	}
+	c.Schedule(schedule, cmd)
+	return nil
+}
+
+// Schedule adds a Job to the Cron to be run on the given schedule.
+func (c *Cron) Schedule(schedule Schedule, cmd Job) {
+	entry := &Entry{
+		Schedule: schedule,
+		Job:      cmd,
+	}
+	if !c.running {
+		c.entries = append(c.entries, entry)
+		return
+	}
+
+	c.add <- entry
+}
+
+// Entries returns a snapshot of the cron entries.
+func (c *Cron) Entries() []*Entry {
+	if c.running {
+		c.snapshot <- nil
+		x := <-c.snapshot
+		return x
+	}
+	return c.entrySnapshot()
+}
+
+// Location gets the time zone location
+func (c *Cron) Location() *time.Location {
+	return c.location
+}
+
+// Start the cron scheduler in its own go-routine, or no-op if already started.
+func (c *Cron) Start() {
+	if c.running {
+		return
+	}
+	c.running = true
+	go c.run()
+}
+
+// Run the cron scheduler, or no-op if already running.
+func (c *Cron) Run() {
+	if c.running {
+		return
+	}
+	c.running = true
+	c.run()
+}
+
+func (c *Cron) runWithRecovery(j Job) {
+	defer func() {
+		if r := recover(); r != nil {
+			const size = 64 << 10
+			buf := make([]byte, size)
+			buf = buf[:runtime.Stack(buf, false)]
+			c.logf("cron: panic running job: %v\n%s", r, buf)
+		}
+	}()
+	j.Run()
+}
+
+// Run the scheduler. this is private just due to the need to synchronize
+// access to the 'running' state variable.
+func (c *Cron) run() {
+	// Figure out the next activation times for each entry.
+	now := c.now()
+	for _, entry := range c.entries {
+		entry.Next = entry.Schedule.Next(now)
+	}
+
+	for {
+		// Determine the next entry to run.
+		sort.Sort(byTime(c.entries))
+
+		var timer *time.Timer
+		if len(c.entries) == 0 || c.entries[0].Next.IsZero() {
+			// If there are no entries yet, just sleep - it still handles new entries
+			// and stop requests.
+			timer = time.NewTimer(100000 * time.Hour)
+		} else {
+			timer = time.NewTimer(c.entries[0].Next.Sub(now))
+		}
+
+		for {
+			select {
+			case now = <-timer.C:
+				now = now.In(c.location)
+				// Run every entry whose next time was less than now
+				for _, e := range c.entries {
+					if e.Next.After(now) || e.Next.IsZero() {
+						break
+					}
+					go c.runWithRecovery(e.Job)
+					e.Prev = e.Next
+					e.Next = e.Schedule.Next(now)
+				}
+
+			case newEntry := <-c.add:
+				timer.Stop()
+				now = c.now()
+				newEntry.Next = newEntry.Schedule.Next(now)
+				c.entries = append(c.entries, newEntry)
+
+			case <-c.snapshot:
+				c.snapshot <- c.entrySnapshot()
+				continue
+
+			case <-c.stop:
+				timer.Stop()
+				return
+			}
+
+			break
+		}
+	}
+}
+
+// Logs an error to stderr or to the configured error log
+func (c *Cron) logf(format string, args ...interface{}) {
+	if c.ErrorLog != nil {
+		c.ErrorLog.Printf(format, args...)
+	} else {
+		log.Printf(format, args...)
+	}
+}
+
+// Stop stops the cron scheduler if it is running; otherwise it does nothing.
+func (c *Cron) Stop() {
+	if !c.running {
+		return
+	}
+	c.stop <- struct{}{}
+	c.running = false
+}
+
+// entrySnapshot returns a copy of the current cron entry list.
+func (c *Cron) entrySnapshot() []*Entry {
+	entries := []*Entry{}
+	for _, e := range c.entries {
+		entries = append(entries, &Entry{
+			Schedule: e.Schedule,
+			Next:     e.Next,
+			Prev:     e.Prev,
+			Job:      e.Job,
+		})
+	}
+	return entries
+}
+
+// now returns current time in c location
+func (c *Cron) now() time.Time {
+	return time.Now().In(c.location)
+}

--- a/vendor/github.com/robfig/cron/doc.go
+++ b/vendor/github.com/robfig/cron/doc.go
@@ -1,0 +1,129 @@
+/*
+Package cron implements a cron spec parser and job runner.
+
+Usage
+
+Callers may register Funcs to be invoked on a given schedule.  Cron will run
+them in their own goroutines.
+
+	c := cron.New()
+	c.AddFunc("0 30 * * * *", func() { fmt.Println("Every hour on the half hour") })
+	c.AddFunc("@hourly",      func() { fmt.Println("Every hour") })
+	c.AddFunc("@every 1h30m", func() { fmt.Println("Every hour thirty") })
+	c.Start()
+	..
+	// Funcs are invoked in their own goroutine, asynchronously.
+	...
+	// Funcs may also be added to a running Cron
+	c.AddFunc("@daily", func() { fmt.Println("Every day") })
+	..
+	// Inspect the cron job entries' next and previous run times.
+	inspect(c.Entries())
+	..
+	c.Stop()  // Stop the scheduler (does not stop any jobs already running).
+
+CRON Expression Format
+
+A cron expression represents a set of times, using 6 space-separated fields.
+
+	Field name   | Mandatory? | Allowed values  | Allowed special characters
+	----------   | ---------- | --------------  | --------------------------
+	Seconds      | Yes        | 0-59            | * / , -
+	Minutes      | Yes        | 0-59            | * / , -
+	Hours        | Yes        | 0-23            | * / , -
+	Day of month | Yes        | 1-31            | * / , - ?
+	Month        | Yes        | 1-12 or JAN-DEC | * / , -
+	Day of week  | Yes        | 0-6 or SUN-SAT  | * / , - ?
+
+Note: Month and Day-of-week field values are case insensitive.  "SUN", "Sun",
+and "sun" are equally accepted.
+
+Special Characters
+
+Asterisk ( * )
+
+The asterisk indicates that the cron expression will match for all values of the
+field; e.g., using an asterisk in the 5th field (month) would indicate every
+month.
+
+Slash ( / )
+
+Slashes are used to describe increments of ranges. For example 3-59/15 in the
+1st field (minutes) would indicate the 3rd minute of the hour and every 15
+minutes thereafter. The form "*\/..." is equivalent to the form "first-last/...",
+that is, an increment over the largest possible range of the field.  The form
+"N/..." is accepted as meaning "N-MAX/...", that is, starting at N, use the
+increment until the end of that specific range.  It does not wrap around.
+
+Comma ( , )
+
+Commas are used to separate items of a list. For example, using "MON,WED,FRI" in
+the 5th field (day of week) would mean Mondays, Wednesdays and Fridays.
+
+Hyphen ( - )
+
+Hyphens are used to define ranges. For example, 9-17 would indicate every
+hour between 9am and 5pm inclusive.
+
+Question mark ( ? )
+
+Question mark may be used instead of '*' for leaving either day-of-month or
+day-of-week blank.
+
+Predefined schedules
+
+You may use one of several pre-defined schedules in place of a cron expression.
+
+	Entry                  | Description                                | Equivalent To
+	-----                  | -----------                                | -------------
+	@yearly (or @annually) | Run once a year, midnight, Jan. 1st        | 0 0 0 1 1 *
+	@monthly               | Run once a month, midnight, first of month | 0 0 0 1 * *
+	@weekly                | Run once a week, midnight between Sat/Sun  | 0 0 0 * * 0
+	@daily (or @midnight)  | Run once a day, midnight                   | 0 0 0 * * *
+	@hourly                | Run once an hour, beginning of hour        | 0 0 * * * *
+
+Intervals
+
+You may also schedule a job to execute at fixed intervals, starting at the time it's added 
+or cron is run. This is supported by formatting the cron spec like this:
+
+    @every <duration>
+
+where "duration" is a string accepted by time.ParseDuration
+(http://golang.org/pkg/time/#ParseDuration).
+
+For example, "@every 1h30m10s" would indicate a schedule that activates after
+1 hour, 30 minutes, 10 seconds, and then every interval after that.
+
+Note: The interval does not take the job runtime into account.  For example,
+if a job takes 3 minutes to run, and it is scheduled to run every 5 minutes,
+it will have only 2 minutes of idle time between each run.
+
+Time zones
+
+All interpretation and scheduling is done in the machine's local time zone (as
+provided by the Go time package (http://www.golang.org/pkg/time).
+
+Be aware that jobs scheduled during daylight-savings leap-ahead transitions will
+not be run!
+
+Thread safety
+
+Since the Cron service runs concurrently with the calling code, some amount of
+care must be taken to ensure proper synchronization.
+
+All cron methods are designed to be correctly synchronized as long as the caller
+ensures that invocations have a clear happens-before ordering between them.
+
+Implementation
+
+Cron entries are stored in an array, sorted by their next activation time.  Cron
+sleeps until the next job is due to be run.
+
+Upon waking:
+ - it runs each entry that is active on that second
+ - it calculates the next run times for the jobs that were run
+ - it re-sorts the array of entries by next activation time.
+ - it goes to sleep until the soonest job.
+*/
+package cron

--- a/vendor/github.com/robfig/cron/parser.go
+++ b/vendor/github.com/robfig/cron/parser.go
@@ -1,0 +1,380 @@
+package cron
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Configuration options for creating a parser. Most options specify which
+// fields should be included, while others enable features. If a field is not
+// included the parser will assume a default value. These options do not change
+// the order fields are parse in.
+type ParseOption int
+
+const (
+	Second      ParseOption = 1 << iota // Seconds field, default 0
+	Minute                              // Minutes field, default 0
+	Hour                                // Hours field, default 0
+	Dom                                 // Day of month field, default *
+	Month                               // Month field, default *
+	Dow                                 // Day of week field, default *
+	DowOptional                         // Optional day of week field, default *
+	Descriptor                          // Allow descriptors such as @monthly, @weekly, etc.
+)
+
+var places = []ParseOption{
+	Second,
+	Minute,
+	Hour,
+	Dom,
+	Month,
+	Dow,
+}
+
+var defaults = []string{
+	"0",
+	"0",
+	"0",
+	"*",
+	"*",
+	"*",
+}
+
+// A custom Parser that can be configured.
+type Parser struct {
+	options   ParseOption
+	optionals int
+}
+
+// Creates a custom Parser with custom options.
+//
+//  // Standard parser without descriptors
+//  specParser := NewParser(Minute | Hour | Dom | Month | Dow)
+//  sched, err := specParser.Parse("0 0 15 */3 *")
+//
+//  // Same as above, just excludes time fields
+//  subsParser := NewParser(Dom | Month | Dow)
+//  sched, err := specParser.Parse("15 */3 *")
+//
+//  // Same as above, just makes Dow optional
+//  subsParser := NewParser(Dom | Month | DowOptional)
+//  sched, err := specParser.Parse("15 */3")
+//
+func NewParser(options ParseOption) Parser {
+	optionals := 0
+	if options&DowOptional > 0 {
+		options |= Dow
+		optionals++
+	}
+	return Parser{options, optionals}
+}
+
+// Parse returns a new crontab schedule representing the given spec.
+// It returns a descriptive error if the spec is not valid.
+// It accepts crontab specs and features configured by NewParser.
+func (p Parser) Parse(spec string) (Schedule, error) {
+	if len(spec) == 0 {
+		return nil, fmt.Errorf("Empty spec string")
+	}
+	if spec[0] == '@' && p.options&Descriptor > 0 {
+		return parseDescriptor(spec)
+	}
+
+	// Figure out how many fields we need
+	max := 0
+	for _, place := range places {
+		if p.options&place > 0 {
+			max++
+		}
+	}
+	min := max - p.optionals
+
+	// Split fields on whitespace
+	fields := strings.Fields(spec)
+
+	// Validate number of fields
+	if count := len(fields); count < min || count > max {
+		if min == max {
+			return nil, fmt.Errorf("Expected exactly %d fields, found %d: %s", min, count, spec)
+		}
+		return nil, fmt.Errorf("Expected %d to %d fields, found %d: %s", min, max, count, spec)
+	}
+
+	// Fill in missing fields
+	fields = expandFields(fields, p.options)
+
+	var err error
+	field := func(field string, r bounds) uint64 {
+		if err != nil {
+			return 0
+		}
+		var bits uint64
+		bits, err = getField(field, r)
+		return bits
+	}
+
+	var (
+		second     = field(fields[0], seconds)
+		minute     = field(fields[1], minutes)
+		hour       = field(fields[2], hours)
+		dayofmonth = field(fields[3], dom)
+		month      = field(fields[4], months)
+		dayofweek  = field(fields[5], dow)
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SpecSchedule{
+		Second: second,
+		Minute: minute,
+		Hour:   hour,
+		Dom:    dayofmonth,
+		Month:  month,
+		Dow:    dayofweek,
+	}, nil
+}
+
+func expandFields(fields []string, options ParseOption) []string {
+	n := 0
+	count := len(fields)
+	expFields := make([]string, len(places))
+	copy(expFields, defaults)
+	for i, place := range places {
+		if options&place > 0 {
+			expFields[i] = fields[n]
+			n++
+		}
+		if n == count {
+			break
+		}
+	}
+	return expFields
+}
+
+var standardParser = NewParser(
+	Minute | Hour | Dom | Month | Dow | Descriptor,
+)
+
+// ParseStandard returns a new crontab schedule representing the given standardSpec
+// (https://en.wikipedia.org/wiki/Cron). It differs from Parse requiring to always
+// pass 5 entries representing: minute, hour, day of month, month and day of week,
+// in that order. It returns a descriptive error if the spec is not valid.
+//
+// It accepts
+//   - Standard crontab specs, e.g. "* * * * ?"
+//   - Descriptors, e.g. "@midnight", "@every 1h30m"
+func ParseStandard(standardSpec string) (Schedule, error) {
+	return standardParser.Parse(standardSpec)
+}
+
+var defaultParser = NewParser(
+	Second | Minute | Hour | Dom | Month | DowOptional | Descriptor,
+)
+
+// Parse returns a new crontab schedule representing the given spec.
+// It returns a descriptive error if the spec is not valid.
+//
+// It accepts
+//   - Full crontab specs, e.g. "* * * * * ?"
+//   - Descriptors, e.g. "@midnight", "@every 1h30m"
+func Parse(spec string) (Schedule, error) {
+	return defaultParser.Parse(spec)
+}
+
+// getField returns an Int with the bits set representing all of the times that
+// the field represents or error parsing field value.  A "field" is a comma-separated
+// list of "ranges".
+func getField(field string, r bounds) (uint64, error) {
+	var bits uint64
+	ranges := strings.FieldsFunc(field, func(r rune) bool { return r == ',' })
+	for _, expr := range ranges {
+		bit, err := getRange(expr, r)
+		if err != nil {
+			return bits, err
+		}
+		bits |= bit
+	}
+	return bits, nil
+}
+
+// getRange returns the bits indicated by the given expression:
+//   number | number "-" number [ "/" number ]
+// or error parsing range.
+func getRange(expr string, r bounds) (uint64, error) {
+	var (
+		start, end, step uint
+		rangeAndStep     = strings.Split(expr, "/")
+		lowAndHigh       = strings.Split(rangeAndStep[0], "-")
+		singleDigit      = len(lowAndHigh) == 1
+		err              error
+	)
+
+	var extra uint64
+	if lowAndHigh[0] == "*" || lowAndHigh[0] == "?" {
+		start = r.min
+		end = r.max
+		extra = starBit
+	} else {
+		start, err = parseIntOrName(lowAndHigh[0], r.names)
+		if err != nil {
+			return 0, err
+		}
+		switch len(lowAndHigh) {
+		case 1:
+			end = start
+		case 2:
+			end, err = parseIntOrName(lowAndHigh[1], r.names)
+			if err != nil {
+				return 0, err
+			}
+		default:
+			return 0, fmt.Errorf("Too many hyphens: %s", expr)
+		}
+	}
+
+	switch len(rangeAndStep) {
+	case 1:
+		step = 1
+	case 2:
+		step, err = mustParseInt(rangeAndStep[1])
+		if err != nil {
+			return 0, err
+		}
+
+		// Special handling: "N/step" means "N-max/step".
+		if singleDigit {
+			end = r.max
+		}
+	default:
+		return 0, fmt.Errorf("Too many slashes: %s", expr)
+	}
+
+	if start < r.min {
+		return 0, fmt.Errorf("Beginning of range (%d) below minimum (%d): %s", start, r.min, expr)
+	}
+	if end > r.max {
+		return 0, fmt.Errorf("End of range (%d) above maximum (%d): %s", end, r.max, expr)
+	}
+	if start > end {
+		return 0, fmt.Errorf("Beginning of range (%d) beyond end of range (%d): %s", start, end, expr)
+	}
+	if step == 0 {
+		return 0, fmt.Errorf("Step of range should be a positive number: %s", expr)
+	}
+
+	return getBits(start, end, step) | extra, nil
+}
+
+// parseIntOrName returns the (possibly-named) integer contained in expr.
+func parseIntOrName(expr string, names map[string]uint) (uint, error) {
+	if names != nil {
+		if namedInt, ok := names[strings.ToLower(expr)]; ok {
+			return namedInt, nil
+		}
+	}
+	return mustParseInt(expr)
+}
+
+// mustParseInt parses the given expression as an int or returns an error.
+func mustParseInt(expr string) (uint, error) {
+	num, err := strconv.Atoi(expr)
+	if err != nil {
+		return 0, fmt.Errorf("Failed to parse int from %s: %s", expr, err)
+	}
+	if num < 0 {
+		return 0, fmt.Errorf("Negative number (%d) not allowed: %s", num, expr)
+	}
+
+	return uint(num), nil
+}
+
+// getBits sets all bits in the range [min, max], modulo the given step size.
+func getBits(min, max, step uint) uint64 {
+	var bits uint64
+
+	// If step is 1, use shifts.
+	if step == 1 {
+		return ^(math.MaxUint64 << (max + 1)) & (math.MaxUint64 << min)
+	}
+
+	// Else, use a simple loop.
+	for i := min; i <= max; i += step {
+		bits |= 1 << i
+	}
+	return bits
+}
+
+// all returns all bits within the given bounds.  (plus the star bit)
+func all(r bounds) uint64 {
+	return getBits(r.min, r.max, 1) | starBit
+}
+
+// parseDescriptor returns a predefined schedule for the expression, or error if none matches.
+func parseDescriptor(descriptor string) (Schedule, error) {
+	switch descriptor {
+	case "@yearly", "@annually":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   1 << hours.min,
+			Dom:    1 << dom.min,
+			Month:  1 << months.min,
+			Dow:    all(dow),
+		}, nil
+
+	case "@monthly":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   1 << hours.min,
+			Dom:    1 << dom.min,
+			Month:  all(months),
+			Dow:    all(dow),
+		}, nil
+
+	case "@weekly":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   1 << hours.min,
+			Dom:    all(dom),
+			Month:  all(months),
+			Dow:    1 << dow.min,
+		}, nil
+
+	case "@daily", "@midnight":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   1 << hours.min,
+			Dom:    all(dom),
+			Month:  all(months),
+			Dow:    all(dow),
+		}, nil
+
+	case "@hourly":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   all(hours),
+			Dom:    all(dom),
+			Month:  all(months),
+			Dow:    all(dow),
+		}, nil
+	}
+
+	const every = "@every "
+	if strings.HasPrefix(descriptor, every) {
+		duration, err := time.ParseDuration(descriptor[len(every):])
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse duration %s: %s", descriptor, err)
+		}
+		return Every(duration), nil
+	}
+
+	return nil, fmt.Errorf("Unrecognized descriptor: %s", descriptor)
+}

--- a/vendor/github.com/robfig/cron/spec.go
+++ b/vendor/github.com/robfig/cron/spec.go
@@ -1,0 +1,158 @@
+package cron
+
+import "time"
+
+// SpecSchedule specifies a duty cycle (to the second granularity), based on a
+// traditional crontab specification. It is computed initially and stored as bit sets.
+type SpecSchedule struct {
+	Second, Minute, Hour, Dom, Month, Dow uint64
+}
+
+// bounds provides a range of acceptable values (plus a map of name to value).
+type bounds struct {
+	min, max uint
+	names    map[string]uint
+}
+
+// The bounds for each field.
+var (
+	seconds = bounds{0, 59, nil}
+	minutes = bounds{0, 59, nil}
+	hours   = bounds{0, 23, nil}
+	dom     = bounds{1, 31, nil}
+	months  = bounds{1, 12, map[string]uint{
+		"jan": 1,
+		"feb": 2,
+		"mar": 3,
+		"apr": 4,
+		"may": 5,
+		"jun": 6,
+		"jul": 7,
+		"aug": 8,
+		"sep": 9,
+		"oct": 10,
+		"nov": 11,
+		"dec": 12,
+	}}
+	dow = bounds{0, 6, map[string]uint{
+		"sun": 0,
+		"mon": 1,
+		"tue": 2,
+		"wed": 3,
+		"thu": 4,
+		"fri": 5,
+		"sat": 6,
+	}}
+)
+
+const (
+	// Set the top bit if a star was included in the expression.
+	starBit = 1 << 63
+)
+
+// Next returns the next time this schedule is activated, greater than the given
+// time.  If no time can be found to satisfy the schedule, return the zero time.
+func (s *SpecSchedule) Next(t time.Time) time.Time {
+	// General approach:
+	// For Month, Day, Hour, Minute, Second:
+	// Check if the time value matches.  If yes, continue to the next field.
+	// If the field doesn't match the schedule, then increment the field until it matches.
+	// While incrementing the field, a wrap-around brings it back to the beginning
+	// of the field list (since it is necessary to re-verify previous field
+	// values)
+
+	// Start at the earliest possible time (the upcoming second).
+	t = t.Add(1*time.Second - time.Duration(t.Nanosecond())*time.Nanosecond)
+
+	// This flag indicates whether a field has been incremented.
+	added := false
+
+	// If no time is found within five years, return zero.
+	yearLimit := t.Year() + 5
+
+WRAP:
+	if t.Year() > yearLimit {
+		return time.Time{}
+	}
+
+	// Find the first applicable month.
+	// If it's this month, then do nothing.
+	for 1<<uint(t.Month())&s.Month == 0 {
+		// If we have to add a month, reset the other parts to 0.
+		if !added {
+			added = true
+			// Otherwise, set the date at the beginning (since the current time is irrelevant).
+			t = time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, t.Location())
+		}
+		t = t.AddDate(0, 1, 0)
+
+		// Wrapped around.
+		if t.Month() == time.January {
+			goto WRAP
+		}
+	}
+
+	// Now get a day in that month.
+	for !dayMatches(s, t) {
+		if !added {
+			added = true
+			t = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+		}
+		t = t.AddDate(0, 0, 1)
+
+		if t.Day() == 1 {
+			goto WRAP
+		}
+	}
+
+	for 1<<uint(t.Hour())&s.Hour == 0 {
+		if !added {
+			added = true
+			t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, t.Location())
+		}
+		t = t.Add(1 * time.Hour)
+
+		if t.Hour() == 0 {
+			goto WRAP
+		}
+	}
+
+	for 1<<uint(t.Minute())&s.Minute == 0 {
+		if !added {
+			added = true
+			t = t.Truncate(time.Minute)
+		}
+		t = t.Add(1 * time.Minute)
+
+		if t.Minute() == 0 {
+			goto WRAP
+		}
+	}
+
+	for 1<<uint(t.Second())&s.Second == 0 {
+		if !added {
+			added = true
+			t = t.Truncate(time.Second)
+		}
+		t = t.Add(1 * time.Second)
+
+		if t.Second() == 0 {
+			goto WRAP
+		}
+	}
+
+	return t
+}
+
+// dayMatches returns true if the schedule's day-of-week and day-of-month
+// restrictions are satisfied by the given time.
+func dayMatches(s *SpecSchedule, t time.Time) bool {
+	var (
+		domMatch bool = 1<<uint(t.Day())&s.Dom > 0
+		dowMatch bool = 1<<uint(t.Weekday())&s.Dow > 0
+	)
+	if s.Dom&starBit > 0 || s.Dow&starBit > 0 {
+		return domMatch && dowMatch
+	}
+	return domMatch || dowMatch
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -432,6 +432,8 @@ github.com/posener/complete
 github.com/posener/complete/cmd/install
 github.com/posener/complete/cmd
 github.com/posener/complete/match
+# github.com/robfig/cron v1.2.0
+github.com/robfig/cron
 # github.com/satori/go.uuid v1.2.0
 github.com/satori/go.uuid
 # github.com/spf13/afero v1.2.1
@@ -641,6 +643,8 @@ gopkg.in/yaml.v2
 # k8s.io/api v0.0.0-20181221193117-173ce66c1e39
 k8s.io/api/apps/v1
 k8s.io/api/autoscaling/v1
+k8s.io/api/batch/v1
+k8s.io/api/batch/v1beta1
 k8s.io/api/core/v1
 k8s.io/api/extensions/v1beta1
 k8s.io/api/networking/v1
@@ -657,8 +661,6 @@ k8s.io/api/authorization/v1
 k8s.io/api/authorization/v1beta1
 k8s.io/api/autoscaling/v2beta1
 k8s.io/api/autoscaling/v2beta2
-k8s.io/api/batch/v1
-k8s.io/api/batch/v1beta1
 k8s.io/api/batch/v2alpha1
 k8s.io/api/certificates/v1beta1
 k8s.io/api/coordination/v1beta1

--- a/website/docs/r/cron_job.html.markdown
+++ b/website/docs/r/cron_job.html.markdown
@@ -1,0 +1,127 @@
+---
+layout: "kubernetes"
+page_title: "Kubernetes: kubernetes_cron_job"
+sidebar_current: "docs-kubernetes-resource-cron-job"
+description: |-
+    A Cron Job creates Jobs on a time-based schedule. One CronJob object is like one line of a crontab (cron table) file.
+---
+
+# kubernetes_cron_job
+
+  A Cron Job creates Jobs on a time-based schedule.
+
+  One CronJob object is like one line of a crontab (cron table) file. It runs a job periodically on a given schedule, written in Cron format.
+
+  Note: All CronJob `schedule` times are based on the timezone of the master where the job is initiated.
+  For instructions on creating and working with cron jobs, and for an example of a spec file for a cron job, see Running automated tasks with cron jobs.
+
+## Example Usage
+
+```hcl
+resource "kubernetes_cron_job" "demo" {
+  metadata {
+    name = "demo"
+  }
+  spec {
+    concurrency_policy            = "Replace"
+    failed_jobs_history_limit     = 5
+    schedule                      = "1 0 * * *"
+    starting_deadline_seconds     = 10
+    successful_jobs_history_limit = 10
+    suspend                       = true
+    job_template {
+      metadata {}
+      spec {
+        backoff_limit = 2
+        template {
+          metadata {}
+          spec {
+            container {
+              name    = "hello"
+              image   = "busybox"
+              command = ["/bin/sh", "-c", "date; echo Hello from the Kubernetes cluster"]
+            }
+            restart_policy = "OnFailure"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `metadata` - (Required) Standard resource's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+* `spec` - (Required) Spec defines the behavior of a CronJob. https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+
+## Nested Blocks
+
+### `metadata`
+
+#### Arguments
+
+* `annotations` - (Optional) An unstructured key value map stored with the resource that may be used to store arbitrary metadata.
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+More info: http://kubernetes.io/docs/user-guide/annotations
+* `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#idempotency
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the service. May match selectors of replication controllers and services. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+More info: http://kubernetes.io/docs/user-guide/labels
+* `name` - (Optional) Name of the service, must be unique. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names
+* `namespace` - (Optional) Namespace defines the space within which name of the service must be unique.
+
+#### Attributes
+
+* `generation` - A sequence number representing a specific generation of the desired state.
+* `resource_version` - An opaque value that represents the internal version of this service that can be used by clients to determine when service has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+* `self_link` - A URL representing this service.
+* `uid` - The unique in time and space value for this service. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+
+### `spec`
+
+#### Arguments
+
+* `concurrency_policy` - (Optional) Specifies how to treat concurrent executions of a Job. Valid values are: - "Allow" (default): allows CronJobs to run concurrently; - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet; - "Replace": cancels currently running job and replaces it with a new one
+* `failed_jobs_history_limit` - (Optional) The number of failed finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+* `job_template` - (Required) Specifies the job that will be created when executing a CronJob.
+* `schedule` - (Required) The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+* `starting_deadline_seconds` - (Optional) Deadline in seconds for starting the job if it misses scheduled time for any reason. Missed jobs executions will be counted as failed ones.
+* `successful_jobs_history_limit` - (Optional) The number of successful finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified. Defaults to 3.
+* `suspend` - (Optional) This flag tells the controller to suspend subsequent executions, it does not apply to already started executions. Defaults to false.
+
+### `job_template`
+
+#### Arguments
+
+* `metadata` - (Required) Standard object's metadata of the jobs created from this template. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+* `spec` - (Required) Specification of the desired behavior of the job. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
+
+### `spec`
+
+#### Arguments
+
+* `active_deadline_seconds` - (Optional) Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer.
+* `backoff_limit` - (Optional) Specifies the number of retries before marking this job failed. Defaults to 6
+* `completions` - (Optional) Specifies the desired number of successfully finished pods the job should be run with. Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value. Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+* `manual_selector` - (Optional) Controls generation of pod labels and pod selectors. Leave `manualSelector` unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template. When true, the user is responsible for picking unique labels and specifying the selector. Failure to pick a unique label may cause this and other jobs to not function correctly. However, You may see `manualSelector=true` in jobs that were created with the old `extensions/v1beta1` API. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector
+* `parallelism` - (Optional) Specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when `((.spec.completions - .status.successful) < .spec.parallelism)`, i.e. when the work left to do is less than max parallelism. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+* `selector` - (Optional) A label query over pods that should match the pod count. Normally, the system sets this field for you. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+* `template` - (Optional) Describes the pod that will be created when executing a job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+
+### `selector`
+
+#### Arguments
+
+* `match_expressions` - (Optional) A list of label selector requirements. The requirements are ANDed.
+* `match_labels` - (Optional) A map of `{key,value}` pairs. A single `{key,value}` in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+
+### `template`
+
+#### Arguments
+
+These arguments are the same as the for the `spec` block of a Pod.
+
+Please see the [Pod resource](pod.html#spec-1) for reference.

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -1,0 +1,96 @@
+---
+layout: "kubernetes"
+page_title: "Kubernetes: kubernetes_job"
+sidebar_current: "docs-kubernetes-resource-job"
+description: |-
+    A Job creates one or more Pods and ensures that a specified number of them successfully terminate. You can also use a Job to run multiple Pods in parallel.
+---
+
+# kubernetes_job
+
+  A Job creates one or more Pods and ensures that a specified number of them successfully terminate. As pods successfully complete, the Job tracks the successful completions. When a specified number of successful completions is reached, the task (ie, Job) is complete. Deleting a Job will clean up the Pods it created.
+
+  A simple case is to create one Job object in order to reliably run one Pod to completion. The Job object will start a new Pod if the first Pod fails or is deleted (for example due to a node hardware failure or a node reboot.
+
+  You can also use a Job to run multiple Pods in parallel.
+
+## Example Usage
+
+```hcl
+resource "kubernetes_job" "demo" {
+  metadata {
+    name = "demo"
+  }
+  spec {
+    template {
+      metadata {}
+      spec {
+        container {
+          name    = "pi"
+          image   = "perl"
+          command = ["perl", "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        }
+        restart_policy = "Never"
+      }
+    }
+    backoff_limit = 4
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `metadata` - (Required) Standard resource's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+* `spec` - (Required) Specification of the desired behavior of a job. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
+
+## Nested Blocks
+
+### `metadata`
+
+#### Arguments
+
+* `annotations` - (Optional) An unstructured key value map stored with the resource that may be used to store arbitrary metadata.
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+More info: http://kubernetes.io/docs/user-guide/annotations
+* `generate_name` - (Optional) Prefix, used by the server, to generate a unique name ONLY IF the `name` field has not been provided. This value will also be combined with a unique suffix. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#idempotency
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) the service. May match selectors of replication controllers and services. 
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+More info: http://kubernetes.io/docs/user-guide/labels
+* `name` - (Optional) Name of the service, must be unique. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names
+* `namespace` - (Optional) Namespace defines the space within which name of the service must be unique.
+
+#### Attributes
+
+* `generation` - A sequence number representing a specific generation of the desired state.
+* `resource_version` - An opaque value that represents the internal version of this service that can be used by clients to determine when service has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+* `self_link` - A URL representing this service.
+* `uid` - The unique in time and space value for this service. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+
+### `spec`
+
+#### Arguments
+
+* `active_deadline_seconds` - (Optional) Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer.
+* `backoff_limit` - (Optional) Specifies the number of retries before marking this job failed. Defaults to 6
+* `completions` - (Optional) Specifies the desired number of successfully finished pods the job should be run with. Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value. Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+* `manual_selector` - (Optional) Controls generation of pod labels and pod selectors. Leave `manualSelector` unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template. When true, the user is responsible for picking unique labels and specifying the selector. Failure to pick a unique label may cause this and other jobs to not function correctly. However, You may see `manualSelector=true` in jobs that were created with the old `extensions/v1beta1` API. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector
+* `parallelism` - (Optional) Specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when `((.spec.completions - .status.successful) < .spec.parallelism)`, i.e. when the work left to do is less than max parallelism. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+* `selector` - (Optional) A label query over pods that should match the pod count. Normally, the system sets this field for you. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+* `template` - (Optional) Describes the pod that will be created when executing a job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+
+### `selector`
+
+#### Arguments
+
+* `match_expressions` - (Optional) A list of label selector requirements. The requirements are ANDed.
+* `match_labels` - (Optional) A map of `{key,value}` pairs. A single `{key,value}` in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+
+### `template`
+
+#### Arguments
+
+These arguments are the same as the for the `spec` block of a Pod.
+
+Please see the [Pod resource](pod.html#spec-1) for reference.

--- a/website/kubernetes.erb
+++ b/website/kubernetes.erb
@@ -33,15 +33,17 @@
         <li<%= sidebar_current("docs-kubernetes-resource") %>>
           <a href="#">Resources</a>
           <ul class="nav nav-visible">
-            <li<%= sidebar_current("docs-kubernetes-resource-config-map") %>>
-              <a href="/docs/providers/kubernetes/r/config_map.html">kubernetes_config_map</a>
-            </li>
             <li<%= sidebar_current("docs-kubernetes-resource-cluster-role") %>>
               <a href="/docs/providers/kubernetes/r/cluster_role.html">kubernetes_cluster_role</a>
             </li>
             <li<%= sidebar_current("docs-kubernetes-resource-cluster-role-binding") %>>
               <a href="/docs/providers/kubernetes/r/cluster_role_binding.html">kubernetes_cluster_role_binding</a>
             </li>
+            <li<%= sidebar_current("docs-kubernetes-resource-config-map") %>>
+              <a href="/docs/providers/kubernetes/r/config_map.html">kubernetes_config_map</a>
+            </li>
+            <li<%= sidebar_current("docs-kubernetes-resource-cron-job") %>>
+              <a href="/docs/providers/kubernetes/r/cron_job.html">kubernetes_cron_job</a>
             </li>
             <li<%= sidebar_current("docs-kubernetes-resource-daemonset") %>>
               <a href="/docs/providers/kubernetes/r/daemonset.html">kubernetes_daemonset</a>
@@ -57,6 +59,9 @@
             </li>
             <li<%= sidebar_current("docs-kubernetes-resource-ingress") %>>
               <a href="/docs/providers/kubernetes/r/ingress.html">kubernetes_ingress</a>
+            </li>
+            <li<%= sidebar_current("docs-kubernetes-resource-job") %>>
+              <a href="/docs/providers/kubernetes/r/job.html">kubernetes_job</a>
             </li>
             <li<%= sidebar_current("docs-kubernetes-resource-limit-range") %>>
               <a href="/docs/providers/kubernetes/r/limit_range.html">kubernetes_limit_range</a>


### PR DESCRIPTION
This PR adds Terraform resources for Kubernetes Job and CronJob objects, and closes #86 and #212. It is mostly cherry picks from the sl1pm4t fork, using contributions from @srhaber, @sl1pm4t and @bassrock, and rebased against the head of master (currently just past 1.6.2). The licensing on the other branch should be compatible for cherry-picking here.

Although the commits are ostensibly cherry-picks, I've had to modify some of them for compatibility with the original branch. For followers of the sl1pm4t fork, these changes are:

* Does not copy the top level metadata to the pod spec's metadata
* Uses expandPodTemplate from the main branch rather than expandPodTemplateSpec from the fork
* Does not hard code job spec restart policy to OnFailure
* Forces job to use BatchV1beta1 api, removing support for BatchV2alpha1 api
* Restore ability to patch kubernetes_job resources

