### PR TITLE
add mount_options argument to kubernetes_persistent_volume

### DIFF
--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -131,6 +131,13 @@ func resourceKubernetesPersistentVolume() *schema.Resource {
 								},
 							},
 						},
+						"mount_options": {
+							Type:        schema.TypeSet,
+							Description: "A list of mount options, e.g. [\"ro\", \"soft\"]. Not validated - mount will simply fail if one is invalid.",
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         schema.HashString,
+						},
 					},
 				},
 			},

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -560,6 +560,29 @@ func TestAccKubernetesPersistentVolume_hostPath_nodeAffinity(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesPersistentVolume_hostPath_mountOptions(t *testing.T) {
+	var conf api.PersistentVolume
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	name := fmt.Sprintf("tf-acc-test-%s", randString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "kubernetes_persistent_volume.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesPersistentVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesPersistentVolumeConfig_hostPath_mountOptions(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPersistentVolumeExists("kubernetes_persistent_volume.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.mount_options.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.mount_options.0", "rw"),
+				),
+			},
+		},
+	})
+}
+
 func waitForPersistenceVolumeDeleted(pvName string, poll, timeout time.Duration) error {
 	conn := testAccProvider.Meta().(*kubernetes.Clientset)
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
@@ -1018,4 +1041,25 @@ func testAccKubernetesPersistentVolumeConfig_hostPath_nodeAffinity_match(name, s
 
 func testAccKubernetesPersistentVolumeConfig_hostPath_withoutNodeAffinity(name string) string {
 	return testAccKubernetesPersistentVolumeConfig_hostPath_nodeAffinity(name, "")
+}
+
+func testAccKubernetesPersistentVolumeConfig_hostPath_mountOptions(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_persistent_volume" "test" {
+  metadata {
+    name = "%s"
+  }
+  spec {
+    capacity = {
+      storage = "1Gi"
+    }
+    access_modes = ["ReadWriteMany"]
+    mount_options = ["rw"]
+    persistent_volume_source {
+      host_path {
+        path = "/mnt/local-volume"
+      }
+    }
+  }
+}`, name)
 }

--- a/kubernetes/structure_persistent_volume_spec.go
+++ b/kubernetes/structure_persistent_volume_spec.go
@@ -376,6 +376,9 @@ func flattenPersistentVolumeSpec(in v1.PersistentVolumeSpec) []interface{} {
 	if in.NodeAffinity != nil {
 		att["node_affinity"] = flattenVolumeNodeAffinity(in.NodeAffinity)
 	}
+	if in.MountOptions != nil {
+		att["mount_options"] = flattenPersistentVolumeMountOptions(in.MountOptions)
+	}
 	return []interface{}{att}
 }
 
@@ -947,6 +950,9 @@ func expandPersistentVolumeSpec(l []interface{}) (*v1.PersistentVolumeSpec, erro
 	if v, ok := in["node_affinity"].([]interface{}); ok && len(v) > 0 {
 		obj.NodeAffinity = expandVolumeNodeAffinity(v)
 	}
+	if v, ok := in["mount_options"].(*schema.Set); ok && v.Len() > 0 {
+		obj.MountOptions = expandPersistentVolumeMountOptions(v.List())
+	}
 	return obj, nil
 }
 
@@ -1117,6 +1123,13 @@ func patchPersistentVolumeSpec(pathPrefix, prefix string, d *schema.ResourceData
 		ops = append(ops, &ReplaceOperation{
 			Path:  pathPrefix + "/nodeAffinity",
 			Value: nodeAffinity,
+		})
+	}
+	if d.HasChange(prefix + "mount_options") {
+		v := d.Get(prefix + "mount_options").(*schema.Set)
+		ops = append(ops, &ReplaceOperation{
+			Path:  pathPrefix + "/mountOptions",
+			Value: expandPersistentVolumeAccessModes(v.List()),
 		})
 	}
 

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -576,3 +576,19 @@ func expandNodeSelectorTerm(l []interface{}) api.NodeSelectorTerm {
 	}
 	return obj
 }
+
+func flattenPersistentVolumeMountOptions(in []string) *schema.Set {
+	var out = make([]interface{}, len(in), len(in))
+	for i, v := range in {
+		out[i] = string(v)
+	}
+	return schema.NewSet(schema.HashString, out)
+}
+
+func expandPersistentVolumeMountOptions(s []interface{}) []string {
+	out := make([]string, len(s), len(s))
+	for i, v := range s {
+		out[i] = v.(string)
+	}
+	return out
+}


### PR DESCRIPTION
This is particularly useful with NFS mounts. Eg.,

    resource "kubernetes_persistent_volume" "foo" {
      count = "42"

      metadata {
        name = "foo-${count.index}"
      }

      spec {
        capacity {
          storage = "1000000Ti"
        }

        access_modes  = ["ReadWriteMany"]
        mount_options = ["local_lock=all"]

        persistent_volume_source {
          nfs {
            path   = "/baz/bar/foo-${count.index}"
            server = "bar.example.org"
          }
        }
      }
    }

resolves #258
resolves #348