### PR TITLE
add mount_options argument to kubernetes_persistent_volume

### DIFF
--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -134,6 +134,13 @@ func resourceKubernetesPersistentVolume() *schema.Resource {
 								},
 							},
 						},
+						"mount_options": {
+							Type:        schema.TypeSet,
+							Description: "A list of mount options, e.g. [\"ro\", \"soft\"]. Not validated - mount will simply fail if one is invalid.",
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         schema.HashString,
+						},
 					},
 				},
 			},

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -578,7 +578,7 @@ func TestAccKubernetesPersistentVolume_hostPath_mountOptions(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesPersistentVolumeExists("kubernetes_persistent_volume.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.mount_options.#", "1"),
-					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.mount_options.0", "rw"),
+					resource.TestCheckResourceAttr("kubernetes_persistent_volume.test", "spec.0.mount_options.2356372769", "foo"),
 				),
 			},
 		},
@@ -1067,7 +1067,7 @@ resource "kubernetes_persistent_volume" "test" {
       storage = "1Gi"
     }
     access_modes = ["ReadWriteMany"]
-    mount_options = ["rw"]
+    mount_options = ["foo"]
     persistent_volume_source {
       host_path {
         path = "/mnt/local-volume"

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -613,3 +613,11 @@ func expandNodeSelectorTerms(l []interface{}) []api.NodeSelectorTerm {
 	}
 	return obj
 }
+
+func flattenPersistentVolumeMountOptions(in []string) *schema.Set {
+	var out = make([]interface{}, len(in), len(in))
+	for i, v := range in {
+		out[i] = string(v)
+	}
+	return schema.NewSet(schema.HashString, out)
+}

--- a/website/docs/r/persistent_volume.html.markdown
+++ b/website/docs/r/persistent_volume.html.markdown
@@ -52,6 +52,7 @@ The following arguments are supported:
 * `persistent_volume_reclaim_policy` - (Optional) What happens to a persistent volume when released from its claim. Valid options are Retain (default) and Recycle. Recycling must be supported by the volume plugin underlying this persistent volume. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/persistent-volumes#recycling-policy)
 * `persistent_volume_source` - (Required) The specification of a persistent volume.
 * `storage_class_name` - (Optional) The name of the persistent volume's storage class. For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class)
+* `mount_options` - (Options) A Kubernetes administrator can specify additional mount options for when a Persistent Volume is mounted on a node. *Note: Not all Persistent Volume types support mount options.* For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#mount-options)
 
 ### `node_affinity`
 


### PR DESCRIPTION
This is particularly useful with NFS mounts. Eg.,

    resource "kubernetes_persistent_volume" "foo" {
      count = "42"

      metadata {
        name = "foo-${count.index}"
      }

      spec {
        capacity {
          storage = "1000000Ti"
        }

        access_modes  = ["ReadWriteMany"]
        mount_options = ["local_lock=all"]

        persistent_volume_source {
          nfs {
            path   = "/baz/bar/foo-${count.index}"
            server = "bar.example.org"
          }
        }
      }
    }

resolves #258
resolves #348
replaces #425