### PR TITLE
Link Endpoints resource docs into sidebar

### DIFF
--- a/website/docs/r/endpoints.html.markdown
+++ b/website/docs/r/endpoints.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "kubernetes"
 page_title: "Kubernetes: kubernetes_endpoints"
-sidebar_current: "docs-kubernetes-resource-endpoint-x"
+sidebar_current: "docs-kubernetes-resource-endpoints-x"
 description: |-
   An Endpoints resource is an abstraction, linked to a Service, which defines the list of endpoints that actually implement the service.
 ---

--- a/website/kubernetes.erb
+++ b/website/kubernetes.erb
@@ -49,6 +49,9 @@
             <li<%= sidebar_current("docs-kubernetes-resource-deployment") %>>
               <a href="/docs/providers/kubernetes/r/deployment.html">kubernetes_deployment</a>
             </li>
+            <li<%= sidebar_current("docs-kubernetes-resource-endpoints") %>>
+              <a href="/docs/providers/kubernetes/r/endpoints.html">kubernetes_endpoints</a>
+            </li>
             <li<%= sidebar_current("docs-kubernetes-resource-horizontal-pod-autoscaler") %>>
               <a href="/docs/providers/kubernetes/r/horizontal_pod_autoscaler.html">kubernetes_horizontal_pod_autoscaler</a>
             </li>


### PR DESCRIPTION
This change links the documentation page for the Endpoints resource into the sidebar.
It was missed in the original PR that introduced Endpoints.
