### PR TITLE
Add doc examples for container health probes.

### DIFF
--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -52,6 +52,22 @@ resource "kubernetes_daemonset" "example" {
               memory = "50Mi"
             }
           }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+
         }
       }
     }

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -53,6 +53,21 @@ resource "kubernetes_deployment" "example" {
               memory = "50Mi"
             }
           }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
         }
       }
     }

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -29,21 +29,36 @@ resource "kubernetes_pod" "test" {
         name  = "environment"
         value = "test"
       }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
     }
 
-		dns_config {
-			nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
-			searches    = ["example.com"]
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
 
-			option {
-				name  = "ndots"
-				value = 1
-			}
+      option {
+        name  = "ndots"
+        value = 1
+      }
 
-			option {
-				name = "use-vc"
-			}
-		}
+      option {
+        name = "use-vc"
+      }
+    }
 
     dns_policy = "None"
   }

--- a/website/docs/r/replication_controller.html.markdown
+++ b/website/docs/r/replication_controller.html.markdown
@@ -41,6 +41,21 @@ resource "kubernetes_replication_controller" "example" {
           image = "nginx:1.7.8"
           name  = "example"
 
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 8080
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+
           resources{
             limits{
               cpu    = "0.5"

--- a/website/docs/r/stateful_set.html.markdown
+++ b/website/docs/r/stateful_set.html.markdown
@@ -160,6 +160,7 @@ resource "kubernetes_stateful_set" "prometheus" {
             http_get {
               path = "/-/healthy"
               port = 9090
+              scheme = "HTTPS"
             }
 
             initial_delay_seconds = 30


### PR DESCRIPTION
Adds examples of how to specify probes like `liveness_probe` on `container` blocks. 