### PR TITLE
Link Ingress resource doc page into sidebar.

### DIFF
--- a/website/kubernetes.erb
+++ b/website/kubernetes.erb
@@ -55,6 +55,9 @@
             <li<%= sidebar_current("docs-kubernetes-resource-horizontal-pod-autoscaler") %>>
               <a href="/docs/providers/kubernetes/r/horizontal_pod_autoscaler.html">kubernetes_horizontal_pod_autoscaler</a>
             </li>
+            <li<%= sidebar_current("docs-kubernetes-resource-ingress") %>>
+              <a href="/docs/providers/kubernetes/r/ingress.html">kubernetes_ingress</a>
+            </li>
             <li<%= sidebar_current("docs-kubernetes-resource-limit-range") %>>
               <a href="/docs/providers/kubernetes/r/limit_range.html">kubernetes_limit_range</a>
             </li>


### PR DESCRIPTION
This was omitted in the original PR which introduced the resource.