### PR TITLE
Mention newly created slack channel in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 - Website: https://www.terraform.io
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
+- Slack channel: [#terraform-providers in Kubernetes](https://kubernetes.slack.com/messages/CJY6ATQH4) ([Sign up here](http://slack.k8s.io/))
 
 <img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" width="600px">
 


### PR DESCRIPTION
This change adds a link in the README to the Kubernetes Slack channel dedicated to this Terraform provider.