### PR TITLE
Adapt examples syntax to TF 0.12

### DIFF
--- a/_examples/google-gke-cluster/README.md
+++ b/_examples/google-gke-cluster/README.md
@@ -7,6 +7,9 @@ You can read more about GKE at https://cloud.google.com/container-engine/
 
 ## Prerequsities
 
+*This example uses syntax elements specific to Terraform version 0.12+.
+It will not work out-of-the-box with Terraform 0.11.x and lower.*
+
 Configure the Google Cloud provider by supplying environment variables
 and/or standard config files.
 Check out [related docs](https://www.terraform.io/docs/providers/google/index.html#configuration-reference)

--- a/_examples/google-gke-cluster/main.tf
+++ b/_examples/google-gke-cluster/main.tf
@@ -1,12 +1,13 @@
-variable "region" {}
+variable "region" {
+}
 
 provider "google" {
-  region = "${var.region}"
-
+  region = var.region
   // Provider settings to be provided via ENV variables
 }
 
-data "google_compute_zones" "available" {}
+data "google_compute_zones" "available" {
+}
 
 variable "cluster_name" {
   default = "terraform-example-cluster"
@@ -16,24 +17,27 @@ variable "kubernetes_version" {
   default = "1.10.11"
 }
 
-variable "username" {}
-variable "password" {}
+variable "username" {
+}
+
+variable "password" {
+}
 
 resource "google_container_cluster" "primary" {
-  name               = "${var.cluster_name}"
-  zone               = "${data.google_compute_zones.available.names[0]}"
+  name               = var.cluster_name
+  zone               = data.google_compute_zones.available.names[0]
   initial_node_count = 3
 
-  min_master_version = "${var.kubernetes_version}"
-  node_version       = "${var.kubernetes_version}"
+  min_master_version = var.kubernetes_version
+  node_version       = var.kubernetes_version
 
   additional_zones = [
-    "${data.google_compute_zones.available.names[1]}",
+    data.google_compute_zones.available.names[1],
   ]
 
   master_auth {
-    username = "${var.username}"
-    password = "${var.password}"
+    username = var.username
+    password = var.password
   }
 
   node_config {
@@ -47,21 +51,22 @@ resource "google_container_cluster" "primary" {
 }
 
 output "cluster_name" {
-  value = "${google_container_cluster.primary.name}"
+  value = google_container_cluster.primary.name
 }
 
 output "primary_zone" {
-  value = "${google_container_cluster.primary.zone}"
+  value = google_container_cluster.primary.zone
 }
 
 output "additional_zones" {
-  value = "${google_container_cluster.primary.additional_zones}"
+  value = google_container_cluster.primary.additional_zones
 }
 
 output "endpoint" {
-  value = "${google_container_cluster.primary.endpoint}"
+  value = google_container_cluster.primary.endpoint
 }
 
 output "node_version" {
-  value = "${google_container_cluster.primary.node_version}"
+  value = google_container_cluster.primary.node_version
 }
+

--- a/_examples/http-nginx/README.md
+++ b/_examples/http-nginx/README.md
@@ -12,6 +12,9 @@ which is exposed to the internet through a load balancer (provisioned automatica
 
 ## Prerequsites
 
+*This example uses syntax elements specific to Terraform version 0.12+.
+It will not work out-of-the-box with Terraform 0.11.x and lower.*
+
 This example expects you to already have a running K8S cluster
 and credentials set up in a config or environment variables.
 

--- a/_examples/http-nginx/replication-controller.tf
+++ b/_examples/http-nginx/replication-controller.tf
@@ -1,13 +1,13 @@
 resource "kubernetes_replication_controller" "example" {
   metadata {
     name = "terraform-nginx-example"
-    labels {
+    labels = {
       App = "TerraformNginxExample"
     }
   }
 
   spec {
-    selector {
+    selector = {
       App = "TerraformNginxExample"
     }
     template {
@@ -25,15 +25,15 @@ resource "kubernetes_replication_controller" "example" {
             port = 80
           }
           initial_delay_seconds = 30
-          timeout_seconds = 1
+          timeout_seconds       = 1
         }
 
-        resources{
-          limits{
+        resources {
+          limits {
             cpu    = "0.5"
             memory = "512Mi"
           }
-          requests{
+          requests {
             cpu    = "250m"
             memory = "50Mi"
           }
@@ -42,3 +42,4 @@ resource "kubernetes_replication_controller" "example" {
     }
   }
 }
+

--- a/_examples/http-nginx/service.tf
+++ b/_examples/http-nginx/service.tf
@@ -3,12 +3,12 @@ resource "kubernetes_service" "example" {
     name = "terraform-nginx-example"
   }
   spec {
-    selector {
-      App = "${kubernetes_replication_controller.example.metadata.0.labels.App}"
+    selector = {
+      App = kubernetes_replication_controller.example.metadata[0].labels.App
     }
     session_affinity = "ClientIP"
     port {
-      port = 80
+      port        = 80
       target_port = 80
     }
 
@@ -17,5 +17,6 @@ resource "kubernetes_service" "example" {
 }
 
 output "lb_ip" {
-  value = "${kubernetes_service.example.load_balancer_ingress.0.ip}"
+  value = kubernetes_service.example.load_balancer_ingress[0].ip
 }
+

--- a/_examples/http-nginx/variables.tf
+++ b/_examples/http-nginx/variables.tf
@@ -1,3 +1,4 @@
 variable "nginx_version" {
   default = "1.7.8"
 }
+

--- a/_examples/ingress/README.md
+++ b/_examples/ingress/README.md
@@ -1,0 +1,6 @@
+# Example: Ingress
+
+## Prerequsites
+
+*This example uses syntax elements specific to Terraform version 0.12+.
+It will not work out-of-the-box with Terraform 0.11.x and lower.*

--- a/_examples/ingress/main.tf
+++ b/_examples/ingress/main.tf
@@ -1,13 +1,11 @@
 provider "kubernetes" {
-  config_context_auth_info = "minikube"
-  config_context_cluster   = "minikube"
 }
 
 resource "kubernetes_ingress" "example" {
   metadata {
     name = "example"
 
-    annotations {
+    annotations = {
       "ingress.kubernetes.io/rewrite-target" = "/"
     }
   }
@@ -65,7 +63,7 @@ resource "kubernetes_service" "echoserver" {
   }
 
   spec {
-    selector {
+    selector = {
       app = "echoserver"
     }
 
@@ -85,12 +83,14 @@ resource "kubernetes_deployment" "echoserver" {
 
   spec {
     selector {
-      app = "echoserver"
+      match_labels = {
+        app = "echoserver"
+      }
     }
 
     template {
       metadata {
-        labels {
+        labels = {
           app = "echoserver"
         }
       }
@@ -116,12 +116,14 @@ resource "kubernetes_deployment" "cheddar" {
 
   spec {
     selector {
-      app = "cheddar"
+      match_labels = {
+        app = "cheddar"
+      }
     }
 
     template {
       metadata {
-        labels {
+        labels = {
           app = "cheddar"
         }
       }
@@ -146,7 +148,7 @@ resource "kubernetes_service" "cheddar" {
   }
 
   spec {
-    selector {
+    selector = {
       app = "cheddar"
     }
 
@@ -160,5 +162,5 @@ resource "kubernetes_service" "cheddar" {
 }
 
 output "ingress_ip" {
-  value = "${kubernetes_ingress.example.load_balancer_ingress.0.ip}"
+  value = formatlist("%s ", kubernetes_ingress.example.load_balancer_ingress.*.ip)
 }

--- a/_examples/wordpress-mysql-gce-pv/README.md
+++ b/_examples/wordpress-mysql-gce-pv/README.md
@@ -21,6 +21,9 @@ and [MySQL](https://www.mysql.com/) on Kubernetes.
 
 ## Prerequsites
 
+*This example uses syntax elements specific to Terraform version 0.12+.
+It will not work out-of-the-box with Terraform 0.11.x and lower.*
+
 ### Kubernetes
 
 This example expects you to already have a running K8S cluster

--- a/_examples/wordpress-mysql-gce-pv/gce-volumes.tf
+++ b/_examples/wordpress-mysql-gce-pv/gce-volumes.tf
@@ -1,14 +1,17 @@
-variable "gcp_region" {}
-variable "gcp_zone" {}
+variable "gcp_region" {
+}
+
+variable "gcp_zone" {
+}
 
 provider "google" {
-  region = "${var.gcp_region}"
+  region = var.gcp_region
 }
 
 resource "google_compute_disk" "mysql" {
-  name  = "wordpress-mysql"
-  type  = "pd-ssd"
-  zone  = "${var.gcp_zone}"
+  name = "wordpress-mysql"
+  type = "pd-ssd"
+  zone = var.gcp_zone
   size = 20
 }
 
@@ -17,13 +20,13 @@ resource "kubernetes_persistent_volume" "mysql" {
     name = "mysql-pv"
   }
   spec {
-    capacity {
+    capacity = {
       storage = "20Gi"
     }
     access_modes = ["ReadWriteOnce"]
     persistent_volume_source {
       gce_persistent_disk {
-        pd_name = "${google_compute_disk.mysql.name}"
+        pd_name = google_compute_disk.mysql.name
         fs_type = "ext4"
       }
     }
@@ -31,9 +34,9 @@ resource "kubernetes_persistent_volume" "mysql" {
 }
 
 resource "google_compute_disk" "wordpress" {
-  name  = "wordpress-frontend"
-  type  = "pd-ssd"
-  zone  = "${var.gcp_zone}"
+  name = "wordpress-frontend"
+  type = "pd-ssd"
+  zone = var.gcp_zone
   size = 20
 }
 
@@ -42,13 +45,13 @@ resource "kubernetes_persistent_volume" "wordpress" {
     name = "wordpress-pv"
   }
   spec {
-    capacity {
+    capacity = {
       storage = "20Gi"
     }
     access_modes = ["ReadWriteOnce"]
     persistent_volume_source {
       gce_persistent_disk {
-        pd_name = "${google_compute_disk.wordpress.name}"
+        pd_name = google_compute_disk.wordpress.name
         fs_type = "ext4"
       }
     }

--- a/_examples/wordpress-mysql-gce-pv/mysql.tf
+++ b/_examples/wordpress-mysql-gce-pv/mysql.tf
@@ -1,4 +1,6 @@
-variable "mysql_password" {}
+variable "mysql_password" {
+}
+
 variable "mysql_version" {
   default = "5.6"
 }
@@ -6,18 +8,18 @@ variable "mysql_version" {
 resource "kubernetes_service" "mysql" {
   metadata {
     name = "wordpress-mysql"
-    labels {
+    labels = {
       app = "wordpress"
     }
   }
   spec {
     port {
-      port = 3306
+      port        = 3306
       target_port = 3306
     }
-    selector {
-      app = "wordpress"
-      tier = "${kubernetes_replication_controller.mysql.spec.0.selector.tier}"
+    selector = {
+      app  = "wordpress"
+      tier = kubernetes_replication_controller.mysql.spec[0].selector.tier
     }
     cluster_ip = "None"
   }
@@ -26,18 +28,18 @@ resource "kubernetes_service" "mysql" {
 resource "kubernetes_persistent_volume_claim" "mysql" {
   metadata {
     name = "mysql-pv-claim"
-    labels {
+    labels = {
       app = "wordpress"
     }
   }
   spec {
     access_modes = ["ReadWriteOnce"]
     resources {
-      requests {
+      requests = {
         storage = "20Gi"
       }
     }
-    volume_name = "${kubernetes_persistent_volume.mysql.metadata.0.name}"
+    volume_name = kubernetes_persistent_volume.mysql.metadata[0].name
   }
 }
 
@@ -46,21 +48,21 @@ resource "kubernetes_secret" "mysql" {
     name = "mysql-pass"
   }
 
-  data {
-    password = "${var.mysql_password}"
+  data = {
+    password = var.mysql_password
   }
 }
 
 resource "kubernetes_replication_controller" "mysql" {
   metadata {
     name = "wordpress-mysql"
-    labels {
+    labels = {
       app = "wordpress"
     }
   }
   spec {
-    selector {
-      app = "wordpress"
+    selector = {
+      app  = "wordpress"
       tier = "mysql"
     }
     template {
@@ -72,19 +74,19 @@ resource "kubernetes_replication_controller" "mysql" {
           name = "MYSQL_ROOT_PASSWORD"
           value_from {
             secret_key_ref {
-              name = "${kubernetes_secret.mysql.metadata.0.name}"
-              key = "password"
+              name = kubernetes_secret.mysql.metadata[0].name
+              key  = "password"
             }
           }
         }
 
         port {
           container_port = 3306
-          name = "mysql"
+          name           = "mysql"
         }
 
         volume_mount {
-          name = "mysql-persistent-storage"
+          name       = "mysql-persistent-storage"
           mount_path = "/var/lib/mysql"
         }
       }
@@ -92,9 +94,10 @@ resource "kubernetes_replication_controller" "mysql" {
       volume {
         name = "mysql-persistent-storage"
         persistent_volume_claim {
-          claim_name = "${kubernetes_persistent_volume_claim.mysql.metadata.0.name}"
+          claim_name = kubernetes_persistent_volume_claim.mysql.metadata[0].name
         }
       }
     }
   }
 }
+

--- a/_examples/wordpress-mysql-gce-pv/wordpress.tf
+++ b/_examples/wordpress-mysql-gce-pv/wordpress.tf
@@ -5,55 +5,55 @@ variable "wordpress_version" {
 resource "kubernetes_service" "wordpress" {
   metadata {
     name = "wordpress"
-    labels {
+    labels = {
       app = "wordpress"
     }
   }
   spec {
     port {
-      port = 80
+      port        = 80
       target_port = 80
     }
-    selector {
-      app = "wordpress"
-      tier = "${kubernetes_replication_controller.wordpress.spec.0.selector.tier}"
+    selector = {
+      app  = "wordpress"
+      tier = kubernetes_replication_controller.wordpress.spec[0].selector.tier
     }
     type = "LoadBalancer"
   }
 }
 
 output "lb_ip" {
-  value = "${kubernetes_service.wordpress.load_balancer_ingress.0.ip}"
+  value = kubernetes_service.wordpress.load_balancer_ingress[0].ip
 }
 
 resource "kubernetes_persistent_volume_claim" "wordpress" {
   metadata {
     name = "wp-pv-claim"
-    labels {
+    labels = {
       app = "wordpress"
     }
   }
   spec {
     access_modes = ["ReadWriteOnce"]
     resources {
-      requests {
+      requests = {
         storage = "20Gi"
       }
     }
-    volume_name = "${kubernetes_persistent_volume.wordpress.metadata.0.name}"
+    volume_name = kubernetes_persistent_volume.wordpress.metadata[0].name
   }
 }
 
 resource "kubernetes_replication_controller" "wordpress" {
   metadata {
     name = "wordpress"
-    labels {
+    labels = {
       app = "wordpress"
     }
   }
   spec {
-    selector {
-      app = "wordpress"
+    selector = {
+      app  = "wordpress"
       tier = "frontend"
     }
     template {
@@ -62,26 +62,26 @@ resource "kubernetes_replication_controller" "wordpress" {
         name  = "wordpress"
 
         env {
-          name = "WORDPRESS_DB_HOST"
+          name  = "WORDPRESS_DB_HOST"
           value = "wordpress-mysql"
         }
         env {
           name = "WORDPRESS_DB_PASSWORD"
           value_from {
             secret_key_ref {
-              name = "${kubernetes_secret.mysql.metadata.0.name}"
-              key = "password"
+              name = kubernetes_secret.mysql.metadata[0].name
+              key  = "password"
             }
           }
         }
 
         port {
           container_port = 80
-          name = "wordpress"
+          name           = "wordpress"
         }
 
         volume_mount {
-          name = "wordpress-persistent-storage"
+          name       = "wordpress-persistent-storage"
           mount_path = "/var/www/html"
         }
       }
@@ -89,9 +89,10 @@ resource "kubernetes_replication_controller" "wordpress" {
       volume {
         name = "wordpress-persistent-storage"
         persistent_volume_claim {
-          claim_name = "${kubernetes_persistent_volume_claim.wordpress.metadata.0.name}"
+          claim_name = kubernetes_persistent_volume_claim.wordpress.metadata[0].name
         }
       }
     }
   }
 }
+


### PR DESCRIPTION
This change adapts the syntax of the example configurations included with the provider to HCL2 / Terraform 0.12