### PR TITLE
Support in-cluster configuration with service accounts

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -150,7 +150,16 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		return nil, err
 	}
 	if cfg == nil {
-		cfg = &restclient.Config{}
+		// Attempt to load in-cluster config
+		cfg, err = restclient.InClusterConfig()
+		if err != nil {
+			// Fallback to standard config if we are not running inside a cluster
+			if err == restclient.ErrNotInCluster {
+				cfg = &restclient.Config{}
+			} else {
+				return nil, fmt.Errorf("Failed to configure: %s", err)
+			}
+		}
 	}
 
 	// Overriding with static configuration


### PR DESCRIPTION
Prior to this commit, the provider supports authenticating through
a local `kubeconfig` or through various configuration provided directly
to the provider or from the environment.

The provider however, did not authenticate using a service account
when running inside a Kubernetes pod. This commit provides support
for loading in-cluster configuration so that the provider can
be used inside a Kubernetes pod (with a service account) without
much additional configuration.

The use-case for this is running Terraform via Atlantis inside
a Kubernetes pod. But, outside of Atlantis, there may be cases where
we want to run some Terraform automation inside a pod (e.g. GitLab runner).