### PR TITLE
Adapt all documentation examples to terraform 0.12

### DIFF
--- a/website/docs/guides/getting-started.html.markdown
+++ b/website/docs/guides/getting-started.html.markdown
@@ -124,7 +124,7 @@ to the exposed port.
 resource "kubernetes_pod" "nginx" {
   metadata {
     name = "nginx-example"
-    labels {
+    labels = {
       App = "nginx"
     }
   }

--- a/website/docs/r/cluster_role.html.markdown
+++ b/website/docs/r/cluster_role.html.markdown
@@ -14,15 +14,15 @@ A ClusterRole creates a role at the cluster level and in all namespaces.
 
 ```hcl
 resource "kubernetes_cluster_role" "example" {
-    metadata {
-        name = "terraform-example"
-    }
+  metadata {
+    name = "terraform-example"
+  }
 
-    rule {
-        api_groups = [""]
-        resources  = ["namespaces", "pods"]
-        verbs      = ["get", "list", "watch"]
-    }
+  rule {
+    api_groups = [""]
+    resources  = ["namespaces", "pods"]
+    verbs      = ["get", "list", "watch"]
+  }
 }
 ```
 

--- a/website/docs/r/cluster_role_binding.html.markdown
+++ b/website/docs/r/cluster_role_binding.html.markdown
@@ -15,29 +15,29 @@ A ClusterRoleBinding may be used to grant permission at the cluster level and in
 
 ```hcl
 resource "kubernetes_cluster_role_binding" "example" {
-	metadata {
-		name = "terraform-example"
-	}
-	role_ref {
-		api_group = "rbac.authorization.k8s.io"
-		kind = "ClusterRole"
-		name = "cluster-admin"
-	}
-	subject {
-		kind = "User"
-		name = "admin"
-		api_group = "rbac.authorization.k8s.io"
-	}
-	subject {
-		kind = "ServiceAccount"
-		name = "default"
-		namespace = "kube-system"
-	}
-	subject {
-		kind = "Group"
-		name = "system:masters"
-		api_group = "rbac.authorization.k8s.io"
-	}
+  metadata {
+    name = "terraform-example"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "cluster-admin"
+  }
+  subject {
+    kind      = "User"
+    name      = "admin"
+    api_group = "rbac.authorization.k8s.io"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = "default"
+    namespace = "kube-system"
+  }
+  subject {
+    kind      = "Group"
+    name      = "system:masters"
+    api_group = "rbac.authorization.k8s.io"
+  }
 }
 ```
 

--- a/website/docs/r/config_map.html.markdown
+++ b/website/docs/r/config_map.html.markdown
@@ -19,16 +19,14 @@ resource "kubernetes_config_map" "example" {
     name = "my-config"
   }
 
-  data {
-    api_host = "myhost:443"
-    db_host  = "dbhost:5432"
-  }
-  data {
-    my_config_file.yml = "${file("${path.module}/my_config_file.yml")}"
+  data = {
+    api_host             = "myhost:443"
+    db_host              = "dbhost:5432"
+    "my_config_file.yml" = "${file("${path.module}/my_config_file.yml")}"
   }
 
-  binary_data {
-    my_payload.bin = "${filebase64("${path.module}/my_payload.bin")}"
+  binary_data = {
+    "my_payload.bin" = "${filebase64("${path.module}/my_payload.bin")}"
   }
 }
 ```

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -15,24 +15,23 @@ A DaemonSet ensures that all (or some) Nodes run a copy of a Pod. As nodes are a
 ```hcl
 resource "kubernetes_daemonset" "example" {
   metadata {
-    name = "terraform-example"
+    name      = "terraform-example"
     namespace = "something"
-    labels {
+    labels = {
       test = "MyExampleApp"
     }
   }
 
   spec {
     selector {
-      match_labels {
+      match_labels = {
         test = "MyExampleApp"
       }
     }
 
     template {
       metadata {
-        namespace = "something"
-        labels {
+        labels = {
           test = "MyExampleApp"
         }
       }
@@ -42,12 +41,12 @@ resource "kubernetes_daemonset" "example" {
           image = "nginx:1.7.8"
           name  = "example"
 
-          resources{
-            limits{
+          resources {
+            limits {
               cpu    = "0.5"
               memory = "512Mi"
             }
-            requests{
+            requests {
               cpu    = "250m"
               memory = "50Mi"
             }

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -17,7 +17,7 @@ A Deployment ensures that a specified number of pod “replicas” are running a
 resource "kubernetes_deployment" "example" {
   metadata {
     name = "terraform-example"
-    labels {
+    labels = {
       test = "MyExampleApp"
     }
   }
@@ -26,14 +26,14 @@ resource "kubernetes_deployment" "example" {
     replicas = 3
 
     selector {
-      match_labels {
+      match_labels = {
         test = "MyExampleApp"
       }
     }
 
     template {
       metadata {
-        labels {
+        labels = {
           test = "MyExampleApp"
         }
       }
@@ -43,12 +43,12 @@ resource "kubernetes_deployment" "example" {
           image = "nginx:1.7.8"
           name  = "example"
 
-          resources{
-            limits{
+          resources {
+            limits {
               cpu    = "0.5"
               memory = "512Mi"
             }
-            requests{
+            requests {
               cpu    = "250m"
               memory = "50Mi"
             }

--- a/website/docs/r/ingress.html.markdown
+++ b/website/docs/r/ingress.html.markdown
@@ -56,7 +56,7 @@ resource "kubernetes_ingress" "example_ingress" {
 resource "kubernetes_pod" "example" {
   metadata {
     name = "terraform-example"
-    labels {
+    labels = {
       app = "MyApp1"
     }
   }
@@ -65,17 +65,18 @@ resource "kubernetes_pod" "example" {
     container {
       image = "nginx:1.7.9"
       name  = "example"
-    }
-    port {
-      container_port = 8080
+
+      port {
+        container_port = 8080
+      }
     }
   }
 }
 
-resource "kubernetes_pod" "example" {
+resource "kubernetes_pod" "example2" {
   metadata {
-    name = "terraform-example"
-    labels {
+    name = "terraform-example2"
+    labels = {
       app = "MyApp2"
     }
   }
@@ -84,9 +85,10 @@ resource "kubernetes_pod" "example" {
     container {
       image = "nginx:1.7.9"
       name  = "example"
-    }
-    port {
-      container_port = 8080
+
+      port {
+        container_port = 8080
+      }
     }
   }
 }

--- a/website/docs/r/limit_range.html.markdown
+++ b/website/docs/r/limit_range.html.markdown
@@ -17,31 +17,31 @@ Read more in [the official docs](https://kubernetes.io/docs/tasks/configure-pod-
 
 ```hcl
 resource "kubernetes_limit_range" "example" {
-	metadata {
-		name = "terraform-example"
-	}
-	spec {
-		limit {
-			type = "Pod"
-			max {
-				cpu = "200m"
-				memory = "1024M"
-			}
-		}
-		limit {
-			type = "PersistentVolumeClaim"
-			min {
-				storage = "24M"
-			}
-		}
-		limit {
-			type = "Container"
-			default {
-				cpu = "50m"
-				memory = "24M"
-			}
-		}
-	}
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    limit {
+      type = "Pod"
+      max = {
+        cpu    = "200m"
+        memory = "1024M"
+      }
+    }
+    limit {
+      type = "PersistentVolumeClaim"
+      min = {
+        storage = "24M"
+      }
+    }
+    limit {
+      type = "Container"
+      default = {
+        cpu    = "50m"
+        memory = "24M"
+      }
+    }
+  }
 }
 ```
 

--- a/website/docs/r/namespace.html.markdown
+++ b/website/docs/r/namespace.html.markdown
@@ -16,18 +16,17 @@ Read more about namespaces at [Kubernetes reference](https://kubernetes.io/docs/
 ```hcl
 resource "kubernetes_namespace" "example" {
   metadata {
-    annotations {
+    annotations = {
       name = "example-annotation"
     }
 
-    labels {
+    labels = {
       mylabel = "label-value"
     }
 
     name = "terraform-example-namespace"
   }
 }
-
 ```
 
 ## Argument Reference

--- a/website/docs/r/network_policy.html.markdown
+++ b/website/docs/r/network_policy.html.markdown
@@ -31,41 +31,36 @@ resource "kubernetes_network_policy" "example" {
       }
     }
 
-    ingress = [
-      {
-        ports = [
-          {
-            port     = "http"
-            protocol = "TCP"
-          },
-          {
-            port     = "8125"
-            protocol = "UDP"
-          },
-        ]
+    ingress {
+      ports {
+        port     = "http"
+        protocol = "TCP"
+      }
+      ports {
+        port     = "8125"
+        protocol = "UDP"
+      }
 
-        from = [
-          {
-            namespace_selector {
-              match_labels = {
-                name = "default"
-              }
-            }
-          },
-          {
-            ip_block {
-              cidr = "10.0.0.0/8"
-              except = [
-                "10.0.0.0/24",
-                "10.0.1.0/24",
-              ]
-            }
-          },
-        ]
-      },
-    ]
+      from {
+        namespace_selector {
+          match_labels = {
+            name = "default"
+          }
+        }
+      }
 
-    egress = [{}] # single empty rule to allow all egress traffic
+      from {
+        ip_block {
+          cidr = "10.0.0.0/8"
+          except = [
+            "10.0.0.0/24",
+            "10.0.1.0/24",
+          ]
+        }
+      }
+    }
+
+    egress {} # single empty rule to allow all egress traffic
 
     policy_types = ["Ingress", "Egress"]
   }

--- a/website/docs/r/persistent_volume.html.markdown
+++ b/website/docs/r/persistent_volume.html.markdown
@@ -16,20 +16,20 @@ For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/sto
 
 ```hcl
 resource "kubernetes_persistent_volume" "example" {
-	metadata {
-		name = "terraform-example"
-	}
-	spec {
-		capacity = {
-			storage = "2Gi"
-		}
-		access_modes = ["ReadWriteMany"]
-		persistent_volume_source {
-			vsphere_volume {
-				volume_path = "/absolute/path"
-			}
-		}
-	}
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    capacity = {
+      storage = "2Gi"
+    }
+    access_modes = ["ReadWriteMany"]
+    persistent_volume_source {
+      vsphere_volume {
+        volume_path = "/absolute/path"
+      }
+    }
+  }
 }
 ```
 

--- a/website/docs/r/persistent_volume_claim.html.markdown
+++ b/website/docs/r/persistent_volume_claim.html.markdown
@@ -20,7 +20,7 @@ resource "kubernetes_persistent_volume_claim" "example" {
   spec {
     access_modes = ["ReadWriteMany"]
     resources {
-      requests {
+      requests = {
         storage = "5Gi"
       }
     }
@@ -33,7 +33,7 @@ resource "kubernetes_persistent_volume" "example" {
     name = "examplevolumename"
   }
   spec {
-    capacity {
+    capacity = {
       storage = "10Gi"
     }
     access_modes = ["ReadWriteMany"]

--- a/website/docs/r/replication_controller.html.markdown
+++ b/website/docs/r/replication_controller.html.markdown
@@ -18,25 +18,26 @@ A Replication Controller ensures that a specified number of pod “replicas” a
 resource "kubernetes_replication_controller" "example" {
   metadata {
     name = "terraform-example"
-    labels {
+    labels = {
       test = "MyExampleApp"
     }
   }
 
   spec {
-    selector {
+    selector = {
       test = "MyExampleApp"
     }
     template {
-      spec {
-        metadata {
-          labels {
-            test = "MyExampleApp"
-          }
-          annotations {
-            "key1" = "value1"
-          }
+      metadata {
+        labels = {
+          test = "MyExampleApp"
         }
+        annotations = {
+          "key1" = "value1"
+        }
+      }
+
+      spec {
         container {
           image = "nginx:1.7.8"
           name  = "example"
@@ -56,12 +57,12 @@ resource "kubernetes_replication_controller" "example" {
             period_seconds        = 3
           }
 
-          resources{
-            limits{
+          resources {
+            limits {
               cpu    = "0.5"
               memory = "512Mi"
             }
-            requests{
+            requests {
               cpu    = "250m"
               memory = "50Mi"
             }

--- a/website/docs/r/resource_quota.html.markdown
+++ b/website/docs/r/resource_quota.html.markdown
@@ -19,7 +19,7 @@ resource "kubernetes_resource_quota" "example" {
     name = "terraform-example"
   }
   spec {
-    hard {
+    hard = {
       pods = 10
     }
     scopes = ["BestEffort"]

--- a/website/docs/r/role.html.markdown
+++ b/website/docs/r/role.html.markdown
@@ -17,21 +17,21 @@ A role contains rules that represent a set of permissions. Permissions are purel
 resource "kubernetes_role" "example" {
   metadata {
     name = "terraform-example"
-    labels {
+    labels = {
       test = "MyRole"
     }
   }
 
   rule {
-    api_groups = [""]
-    resources = ["pods"]
+    api_groups     = [""]
+    resources      = ["pods"]
     resource_names = ["foo"]
-    verbs = ["get", "list", "watch"]
+    verbs          = ["get", "list", "watch"]
   }
   rule {
     api_groups = ["apps"]
-    resources = ["deployments"]
-    verbs = ["get", "list"]
+    resources  = ["deployments"]
+    verbs      = ["get", "list"]
   }
 }
 ```

--- a/website/docs/r/role_binding.html.markdown
+++ b/website/docs/r/role_binding.html.markdown
@@ -14,30 +14,30 @@ A RoleBinding may be used to grant permission at the namespace level
 
 ```hcl
 resource "kubernetes_role_binding" "example" {
-	metadata {
-		name = "terraform-example"
-		namespace = "default"
-	}
-	role_ref {
-		api_group = "rbac.authorization.k8s.io"
-		kind = "Role"
-		name = "admin"
-	}
-	subject {
-		kind = "User"
-		name = "admin"
-		api_group = "rbac.authorization.k8s.io"
-	}
-	subject {
-		kind = "ServiceAccount"
-		name = "default"
-		namespace = "kube-system"
-	}
-	subject {
-		kind = "Group"
-		name = "system:masters"
-		api_group = "rbac.authorization.k8s.io"
-	}
+  metadata {
+    name      = "terraform-example"
+    namespace = "default"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = "admin"
+  }
+  subject {
+    kind      = "User"
+    name      = "admin"
+    api_group = "rbac.authorization.k8s.io"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = "default"
+    namespace = "kube-system"
+  }
+  subject {
+    kind      = "Group"
+    name      = "system:masters"
+    api_group = "rbac.authorization.k8s.io"
+  }
 }
 ```
 

--- a/website/docs/r/secret.html.markdown
+++ b/website/docs/r/secret.html.markdown
@@ -24,7 +24,7 @@ resource "kubernetes_secret" "example" {
     name = "basic-auth"
   }
 
-  data {
+  data = {
     username = "admin"
     password = "P4ssw0rd"
   }
@@ -41,11 +41,25 @@ resource "kubernetes_secret" "example" {
     name = "docker-cfg"
   }
 
-  data {
+  data = {
     ".dockerconfigjson" = "${file("${path.module}/.docker/config.json")}"
   }
 
   type = "kubernetes.io/dockerconfigjson"
+}
+```
+
+## Example Usage (Service account token)
+
+```hcl
+resource "kubernetes_secret" "example" {
+  metadata {
+    annotations = {
+      "kubernetes.io/service-account.name" = "my-service-account"
+    }
+  }
+
+  type = "kubernetes.io/service-account-token"
 }
 ```
 

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -19,12 +19,12 @@ resource "kubernetes_service" "example" {
     name = "terraform-example"
   }
   spec {
-    selector {
+    selector = {
       app = "${kubernetes_pod.example.metadata.0.labels.app}"
     }
     session_affinity = "ClientIP"
     port {
-      port = 8080
+      port        = 8080
       target_port = 80
     }
 
@@ -35,7 +35,7 @@ resource "kubernetes_service" "example" {
 resource "kubernetes_pod" "example" {
   metadata {
     name = "terraform-example"
-    labels {
+    labels = {
       app = "MyApp"
     }
   }

--- a/website/docs/r/stateful_set.html.markdown
+++ b/website/docs/r/stateful_set.html.markdown
@@ -25,11 +25,11 @@ necessary updates to get there from the current state.
 ```hcl
 resource "kubernetes_stateful_set" "prometheus" {
   metadata {
-    annotations {
+    annotations = {
       SomeAnnotation = "foobar"
     }
 
-    labels {
+    labels = {
       k8s-app                           = "prometheus"
       "kubernetes.io/cluster-service"   = "true"
       "addonmanager.kubernetes.io/mode" = "Reconcile"
@@ -45,7 +45,7 @@ resource "kubernetes_stateful_set" "prometheus" {
     revision_history_limit = 5
 
     selector {
-      match_labels {
+      match_labels = {
         k8s-app = "prometheus"
       }
     }
@@ -54,11 +54,11 @@ resource "kubernetes_stateful_set" "prometheus" {
 
     template {
       metadata {
-        labels {
+        labels = {
           k8s-app = "prometheus"
         }
 
-        annotations {}
+        annotations = {}
       }
 
       spec {
@@ -158,8 +158,8 @@ resource "kubernetes_stateful_set" "prometheus" {
 
           liveness_probe {
             http_get {
-              path = "/-/healthy"
-              port = 9090
+              path   = "/-/healthy"
+              port   = 9090
               scheme = "HTTPS"
             }
 
@@ -198,7 +198,7 @@ resource "kubernetes_stateful_set" "prometheus" {
         storage_class_name = "standard"
 
         resources {
-          requests {
+          requests = {
             storage = "16Gi"
           }
         }

--- a/website/docs/r/storage_class.html.markdown
+++ b/website/docs/r/storage_class.html.markdown
@@ -20,9 +20,9 @@ resource "kubernetes_storage_class" "example" {
     name = "terraform-example"
   }
   storage_provisioner = "kubernetes.io/gce-pd"
-  reclaim_policy = "Retain"
-  parameters {
-  	type = "pd-standard"
+  reclaim_policy      = "Retain"
+  parameters = {
+    type = "pd-standard"
   }
 }
 ```


### PR DESCRIPTION
This PR adapts all configuration examples from markdown documentation to terraform 0.12 syntax.

Each example was formatted with `terraform fmt` and tested with `terraform validate`.