### PR TITLE
Fix sometimes deployment is not waited

### DIFF
--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -385,6 +385,8 @@ func waitForDeploymentReplicasFunc(conn *kubernetes.Clientset, ns, name string) 
 			if dply.Status.AvailableReplicas < dply.Status.UpdatedReplicas {
 				return resource.RetryableError(fmt.Errorf("Waiting for rollout to finish: %d of %d updated replicas are available...", dply.Status.AvailableReplicas, dply.Status.UpdatedReplicas))
 			}
+		} else if dply.Status.ObservedGeneration == 0 {
+			return resource.RetryableError(fmt.Errorf("Waiting for rollout to start"))
 		}
 		return nil
 	}


### PR DESCRIPTION
"Sometimes" the kubernetes provider doesn't wait for the deployment.
After debugging, I saw that's because the following condition is not respected:
```
dply.Generation <= dply.Status.ObservedGeneration
```
So the "wait" time is `0s`

When this condition is not respected, `dply.Generation = 1` and `dply.Status.ObservedGeneration = 0`.

So I just added an other test which handle when only `dply.Status.ObservedGeneration = 0`. Since then, I don't have this issue anymore.