### PR TITLE
Remove default value of Job template's spec.backoff_limit

### DIFF
--- a/kubernetes/schema_job_spec.go
+++ b/kubernetes/schema_job_spec.go
@@ -44,7 +44,6 @@ func jobSpecFields() map[string]*schema.Schema {
 			Type:         schema.TypeInt,
 			Optional:     true,
 			ForceNew:     true,
-			Default:      6,
 			ValidateFunc: validatePositiveInteger,
 			Description:  "Specifies the number of retries before marking this job failed. Defaults to 6",
 		},


### PR DESCRIPTION
This was documented as being "6" but the API doesn't enforce it when not set in config, so it causes a diff the tests to fail.

Tests after this change:
```
~/workspace/terraform-provider-kubernetes(master*) » TF_ACC=1 ./kubernetes.test -test.parallel 1 -test.v -test.run '^TestAccKubernetesCronJob_' -test.v                                    alex@alexs-macbook-3
=== RUN   TestAccKubernetesCronJob_basic
--- PASS: TestAccKubernetesCronJob_basic (30.97s)
=== RUN   TestAccKubernetesCronJob_extra
--- PASS: TestAccKubernetesCronJob_extra (33.03s)
PASS
------------------------------------------------------------
~/workspace/terraform-provider-kubernetes(master*) » TF_ACC=1 ./kubernetes.test -test.parallel 1 -test.v -test.run '^TestAccKubernetesJob_' -test.v                                        alex@alexs-macbook-3
=== RUN   TestAccKubernetesJob_basic
--- PASS: TestAccKubernetesJob_basic (8.80s)
PASS
```