### PR TITLE
Fix kubernetes_service documentation example

### DIFF
--- a/website/docs/guides/getting-started.html.markdown
+++ b/website/docs/guides/getting-started.html.markdown
@@ -153,7 +153,7 @@ resource "kubernetes_service" "nginx" {
     name = "nginx-example"
   }
   spec {
-    selector {
+    selector = {
       App = "${kubernetes_pod.nginx.metadata.0.labels.App}"
     }
     port {


### PR DESCRIPTION
Fix a typo in kubernetes_service documentation.

Additional documentation:
https://www.terraform.io/docs/providers/kubernetes/r/service.html