### PR TITLE
Add expansion logic for 'working_dir' attribute

### DIFF
--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -676,6 +676,7 @@ func TestAccKubernetesPod_config_container_working_dir(t *testing.T) {
 				Config: testAccKubernetesPodConfigWorkingDir(podName, imageName, "/www"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesPodExists("kubernetes_pod.test", &confPod),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.generation", "0"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.working_dir", "/www"),
 				),
 			},
@@ -683,6 +684,7 @@ func TestAccKubernetesPod_config_container_working_dir(t *testing.T) {
 				Config: testAccKubernetesPodConfigWorkingDir(podName, imageName, "/srv"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesPodExists("kubernetes_pod.test", &confPod),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "metadata.0.generation", "0"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.working_dir", "/srv"),
 				),
 			},

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -661,6 +661,35 @@ func TestAccKubernetesPod_config_with_automount_service_account_token(t *testing
 	})
 }
 
+func TestAccKubernetesPod_config_container_working_dir(t *testing.T) {
+	var confPod api.Pod
+
+	podName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	imageName := "nginx:1.7.9"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesPodDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesPodConfigWorkingDir(podName, imageName, "/www"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &confPod),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.working_dir", "/www"),
+				),
+			},
+			{
+				Config: testAccKubernetesPodConfigWorkingDir(podName, imageName, "/srv"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesPodExists("kubernetes_pod.test", &confPod),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.working_dir", "/srv"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckKubernetesPodDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*kubernetes.Clientset)
 
@@ -1480,4 +1509,22 @@ resource "kubernetes_pod" "test" {
   }
 }
 `, saName, podName, imageName)
+}
+
+func testAccKubernetesPodConfigWorkingDir(podName, imageName, val string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_pod" "test" {
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    container {
+      image = "%s"
+      name  = "containername"
+      working_dir = "%s"
+    }
+  }
+}
+`, podName, imageName, val)
 }

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -508,7 +508,7 @@ func expandContainers(ctrs []interface{}) ([]v1.Container, error) {
 			}
 		}
 
-		if v, ok := ctr["working_dir"].(string); ok && len(v) > 0 {
+		if v, ok := ctr["working_dir"].(string); ok && v != "" {
 			cs[i].WorkingDir = v
 		}
 	}

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -507,6 +507,10 @@ func expandContainers(ctrs []interface{}) ([]v1.Container, error) {
 				return cs, err
 			}
 		}
+
+		if v, ok := ctr["working_dir"].(string); ok && len(v) > 0 {
+			cs[i].WorkingDir = v
+		}
 	}
 	return cs, nil
 }


### PR DESCRIPTION
It appears that the `working_dir` attribute of a `container` block never actually worked as expected due to missing expander logic.

This change implement expansion of this attribute and introduces a test to assert the fix.

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "./kubernetes" -v -run '^TestAccKubernetesPod_config_container_working_dir' -timeout 120m
=== RUN   TestAccKubernetesPod_config_container_working_dir
--- PASS: TestAccKubernetesPod_config_container_working_dir (16.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	17.124s
```

Fixes https://github.com/terraform-providers/terraform-provider-kubernetes/issues/397