### PR TITLE
Align validation of names of Role and ClusterRole to K8s

### DIFF
--- a/kubernetes/resource_kubernetes_cluster_role.go
+++ b/kubernetes/resource_kubernetes_cluster_role.go
@@ -24,7 +24,7 @@ func resourceKubernetesClusterRole() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"metadata": metadataSchema("clusterRole", false),
+			"metadata": metadataSchemaClusterRole(),
 			"rule": {
 				Type:        schema.TypeList,
 				Description: "List of PolicyRules for this ClusterRole",

--- a/kubernetes/resource_kubernetes_cluster_role_test.go
+++ b/kubernetes/resource_kubernetes_cluster_role_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccKubernetesClusterRole_basic(t *testing.T) {
 	var conf api.ClusterRole
-	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	name := fmt.Sprintf("tf-acc-test:%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "kubernetes_cluster_role.test",
@@ -58,7 +58,7 @@ func TestAccKubernetesClusterRole_basic(t *testing.T) {
 }
 func TestAccKubernetesClusterRole_importBasic(t *testing.T) {
 	resourceName := "kubernetes_cluster_role.test"
-	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	name := fmt.Sprintf("tf-acc-test:%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/kubernetes/resource_kubernetes_role.go
+++ b/kubernetes/resource_kubernetes_role.go
@@ -23,7 +23,7 @@ func resourceKubernetesRole() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"metadata": namespacedMetadataSchema("role", true),
+			"metadata": metadataSchemaRole(),
 			"rule": {
 				Type:        schema.TypeList,
 				Description: "Rule defining a set of permissions for the role",

--- a/kubernetes/resource_kubernetes_role_test.go
+++ b/kubernetes/resource_kubernetes_role_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestAccKubernetesRole_basic(t *testing.T) {
 	var conf api.Role
-	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	name := fmt.Sprintf("tf-acc-test:%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -78,7 +78,7 @@ func TestAccKubernetesRole_basic(t *testing.T) {
 
 func TestAccKubernetesRole_importBasic(t *testing.T) {
 	resourceName := "kubernetes_role.test"
-	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	name := fmt.Sprintf("tf-acc-test:%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -101,7 +101,7 @@ func TestAccKubernetesRole_importBasic(t *testing.T) {
 
 func TestAccKubernetesRole_generatedName(t *testing.T) {
 	var conf api.Role
-	prefix := "tf-acc-test-gen-"
+	prefix := "tf-acc-test-gen:"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },

--- a/vendor/k8s.io/apimachinery/pkg/api/validation/path/name.go
+++ b/vendor/k8s.io/apimachinery/pkg/api/validation/path/name.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package path
+
+import (
+	"fmt"
+	"strings"
+)
+
+// NameMayNotBe specifies strings that cannot be used as names specified as path segments (like the REST API or etcd store)
+var NameMayNotBe = []string{".", ".."}
+
+// NameMayNotContain specifies substrings that cannot be used in names specified as path segments (like the REST API or etcd store)
+var NameMayNotContain = []string{"/", "%"}
+
+// IsValidPathSegmentName validates the name can be safely encoded as a path segment
+func IsValidPathSegmentName(name string) []string {
+	for _, illegalName := range NameMayNotBe {
+		if name == illegalName {
+			return []string{fmt.Sprintf(`may not be '%s'`, illegalName)}
+		}
+	}
+
+	var errors []string
+	for _, illegalContent := range NameMayNotContain {
+		if strings.Contains(name, illegalContent) {
+			errors = append(errors, fmt.Sprintf(`may not contain '%s'`, illegalContent))
+		}
+	}
+
+	return errors
+}
+
+// IsValidPathSegmentPrefix validates the name can be used as a prefix for a name which will be encoded as a path segment
+// It does not check for exact matches with disallowed names, since an arbitrary suffix might make the name valid
+func IsValidPathSegmentPrefix(name string) []string {
+	var errors []string
+	for _, illegalContent := range NameMayNotContain {
+		if strings.Contains(name, illegalContent) {
+			errors = append(errors, fmt.Sprintf(`may not contain '%s'`, illegalContent))
+		}
+	}
+
+	return errors
+}
+
+// ValidatePathSegmentName validates the name can be safely encoded as a path segment
+func ValidatePathSegmentName(name string, prefix bool) []string {
+	if prefix {
+		return IsValidPathSegmentPrefix(name)
+	} else {
+		return IsValidPathSegmentName(name)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -677,6 +677,7 @@ k8s.io/api/storage/v1beta1
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/api/validation
+k8s.io/apimachinery/pkg/api/validation/path
 k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/fields
 k8s.io/apimachinery/pkg/types


### PR DESCRIPTION
This change allows Role and ClusterRole resource names to contain characters like `:` aligning with Kubernetes rules.

Tests pass
```
make testacc TESTARGS="-run '^TestAccKubernetes.*Role'"                                                                alex@alexs-macbook-3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "./kubernetes" -v -run '^TestAccKubernetes.*Role' -timeout 120m
=== RUN   TestAccKubernetesClusterRoleBinding
--- PASS: TestAccKubernetesClusterRoleBinding (0.52s)
=== RUN   TestAccKubernetesClusterRoleBinding_serviceaccount_subject
--- PASS: TestAccKubernetesClusterRoleBinding_serviceaccount_subject (0.29s)
=== RUN   TestAccKubernetesClusterRoleBinding_group_subject
--- PASS: TestAccKubernetesClusterRoleBinding_group_subject (0.29s)
=== RUN   TestAccKubernetesClusterRoleBinding_importBasic
--- PASS: TestAccKubernetesClusterRoleBinding_importBasic (0.36s)
=== RUN   TestAccKubernetesClusterRole_basic
--- PASS: TestAccKubernetesClusterRole_basic (0.49s)
=== RUN   TestAccKubernetesClusterRole_importBasic
--- PASS: TestAccKubernetesClusterRole_importBasic (0.36s)
=== RUN   TestAccKubernetesRoleBinding_basic
--- PASS: TestAccKubernetesRoleBinding_basic (0.47s)
=== RUN   TestAccKubernetesRoleBinding_importBasic
--- PASS: TestAccKubernetesRoleBinding_importBasic (0.37s)
=== RUN   TestAccKubernetesRoleBinding_sa_subject
--- PASS: TestAccKubernetesRoleBinding_sa_subject (0.28s)
=== RUN   TestAccKubernetesRoleBinding_group_subject
--- PASS: TestAccKubernetesRoleBinding_group_subject (0.28s)
=== RUN   TestAccKubernetesRole_basic
--- PASS: TestAccKubernetesRole_basic (0.49s)
=== RUN   TestAccKubernetesRole_importBasic
--- PASS: TestAccKubernetesRole_importBasic (0.38s)
=== RUN   TestAccKubernetesRole_generatedName
--- PASS: TestAccKubernetesRole_generatedName (0.28s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	7.441s
------------------------------------------------------------
```