### PR TITLE
Add mount_propagation to volume mount

### DIFF
--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -486,6 +486,7 @@ func TestAccKubernetesPod_with_volume_mount(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.0.name", "db"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.0.read_only", "false"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.0.sub_path", ""),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.0.mount_propagation", "HostToContainer"),
 				),
 			},
 		},
@@ -515,6 +516,7 @@ func TestAccKubernetesPod_with_cfg_map_volume_mount(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.0.name", "cfg"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.0.read_only", "false"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.0.sub_path", ""),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.0.mount_propagation", "None"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.1.mount_path", "/tmp/my_raw_path"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.1.name", "cfg-binary"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.1.read_only", "false"),
@@ -1174,8 +1176,9 @@ resource "kubernetes_pod" "test" {
       name  = "containername"
 
       volume_mount {
-        mount_path = "/tmp/my_path"
-        name       = "db"
+        mount_path        = "/tmp/my_path"
+        name              = "db"
+        mount_propagation = "HostToContainer"
       }
     }
 

--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -1,6 +1,9 @@
 package kubernetes
 
-import "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
 
 func handlerFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
@@ -190,6 +193,13 @@ func volumeMountFields() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: `Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).`,
+		},
+		"mount_propagation": {
+			Type:         schema.TypeString,
+			Description:  "Mount propagation mode. mount_propagation determines how mounts are propagated from the host to container and the other way around. Valid values are None (default), HostToContainer and Bidirectional.",
+			Optional:     true,
+			Default:      "None",
+			ValidateFunc: validation.StringInSlice([]string{"None", "HostToContainer", "Bidirectional"}, false),
 		},
 	}
 }

--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -280,6 +280,9 @@ func flattenContainerVolumeMounts(in []v1.VolumeMount) ([]interface{}, error) {
 		if v.SubPath != "" {
 			m["sub_path"] = v.SubPath
 		}
+		if v.MountPropagation != nil {
+			m["mount_propagation"] = string(*v.MountPropagation)
+		}
 		att[i] = m
 	}
 	return att, nil
@@ -723,6 +726,10 @@ func expandContainerVolumeMounts(in []interface{}) ([]v1.VolumeMount, error) {
 		}
 		if subPath, ok := p["sub_path"]; ok {
 			vmp[i].SubPath = subPath.(string)
+		}
+		if mountPropagation, ok := p["mount_propagation"]; ok {
+			mp := v1.MountPropagationMode(mountPropagation.(string))
+			vmp[i].MountPropagation = &mp
 		}
 	}
 	return vmp, nil

--- a/website/docs/r/daemonset.html.markdown
+++ b/website/docs/r/daemonset.html.markdown
@@ -789,6 +789,7 @@ The `items` block supports the following:
 * `name` - (Required) This must match the Name of a Volume.
 * `read_only` - (Optional) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 * `sub_path` - (Optional) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+* `mount_propagation` - (Optional) Mount propagation mode. Defaults to "None". For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation)
 
 ### `vsphere_volume`
 

--- a/website/docs/r/deployment.html.markdown
+++ b/website/docs/r/deployment.html.markdown
@@ -795,6 +795,7 @@ The `items` block supports the following:
 * `name` - (Required) This must match the Name of a Volume.
 * `read_only` - (Optional) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 * `sub_path` - (Optional) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+* `mount_propagation` - (Optional) Mount propagation mode. Defaults to "None". For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation)
 
 ### `vsphere_volume`
 

--- a/website/docs/r/pod.html.markdown
+++ b/website/docs/r/pod.html.markdown
@@ -845,6 +845,7 @@ The `items` block supports the following:
 * `name` - (Required) This must match the Name of a Volume.
 * `read_only` - (Optional) Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
 * `sub_path` - (Optional) Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+* `mount_propagation` - (Optional) Mount propagation mode. Defaults to "None". For more info see [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation)
 
 ### `vsphere_volume`
 


### PR DESCRIPTION
Mount propagation allows for sharing volumes mounted by a Container to
other Containers in the same Pod, or even to other Pods on the same
node. See [1]

MountPropagation has been GA since K8s 1.14.

[1] https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation