### PR TITLE
Migrate test infra to TF 0.12

### DIFF
--- a/kubernetes/test-infra/aks/main.tf
+++ b/kubernetes/test-infra/aks/main.tf
@@ -1,13 +1,14 @@
 locals {
   random_prefix = "${var.prefix}-${random_id.tf-k8s-acc.hex}"
 }
+
 provider "azurerm" {
   version = "~> 1.28.0"
 }
 
 data "azurerm_kubernetes_service_versions" "current" {
-  location       = "${var.location}"
-  version_prefix = "${var.kubernetes_version}"
+  location       = var.location
+  version_prefix = var.kubernetes_version
 }
 
 resource "random_id" "tf-k8s-acc" {
@@ -16,13 +17,13 @@ resource "random_id" "tf-k8s-acc" {
 
 resource "azurerm_resource_group" "tf-k8s-acc" {
   name     = "${local.random_prefix}-rsg"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_route_table" "tf-k8s-acc" {
   name                = "${local.random_prefix}-rt"
-  location            = "${azurerm_resource_group.tf-k8s-acc.location}"
-  resource_group_name = "${azurerm_resource_group.tf-k8s-acc.name}"
+  location            = azurerm_resource_group.tf-k8s-acc.location
+  resource_group_name = azurerm_resource_group.tf-k8s-acc.name
 
   route {
     name                   = "default"
@@ -34,32 +35,32 @@ resource "azurerm_route_table" "tf-k8s-acc" {
 
 resource "azurerm_virtual_network" "tf-k8s-acc" {
   name                = "${local.random_prefix}-network"
-  location            = "${azurerm_resource_group.tf-k8s-acc.location}"
-  resource_group_name = "${azurerm_resource_group.tf-k8s-acc.name}"
+  location            = azurerm_resource_group.tf-k8s-acc.location
+  resource_group_name = azurerm_resource_group.tf-k8s-acc.name
   address_space       = ["10.1.0.0/16"]
 }
 
 resource "azurerm_subnet" "tf-k8s-acc" {
   name                 = "${local.random_prefix}-internal"
-  resource_group_name  = "${azurerm_resource_group.tf-k8s-acc.name}"
+  resource_group_name  = azurerm_resource_group.tf-k8s-acc.name
   address_prefix       = "10.1.0.0/24"
-  virtual_network_name = "${azurerm_virtual_network.tf-k8s-acc.name}"
+  virtual_network_name = azurerm_virtual_network.tf-k8s-acc.name
 
   # this field is deprecated and will be removed in 2.0 - but is required until then
-  route_table_id = "${azurerm_route_table.tf-k8s-acc.id}"
+  route_table_id = azurerm_route_table.tf-k8s-acc.id
 }
 
 resource "azurerm_subnet_route_table_association" "tf-k8s-acc" {
-  subnet_id      = "${azurerm_subnet.tf-k8s-acc.id}"
-  route_table_id = "${azurerm_route_table.tf-k8s-acc.id}"
+  subnet_id      = azurerm_subnet.tf-k8s-acc.id
+  route_table_id = azurerm_route_table.tf-k8s-acc.id
 }
 
 resource "azurerm_kubernetes_cluster" "tf-k8s-acc" {
   name                = "${local.random_prefix}-cluster"
-  resource_group_name = "${azurerm_resource_group.tf-k8s-acc.name}"
-  location            = "${azurerm_resource_group.tf-k8s-acc.location}"
+  resource_group_name = azurerm_resource_group.tf-k8s-acc.name
+  location            = azurerm_resource_group.tf-k8s-acc.location
   dns_prefix          = "${local.random_prefix}-cluster"
-  kubernetes_version  = "${data.azurerm_kubernetes_service_versions.current.latest_version}"
+  kubernetes_version  = data.azurerm_kubernetes_service_versions.current.latest_version
 
   # Uncomment to enable SSH access to nodes
   #
@@ -72,18 +73,18 @@ resource "azurerm_kubernetes_cluster" "tf-k8s-acc" {
 
   agent_pool_profile {
     name            = "agentpool"
-    count           = "${var.workers_count}"
-    vm_size         = "${var.workers_type}"
+    count           = var.workers_count
+    vm_size         = var.workers_type
     os_type         = "Linux"
     os_disk_size_gb = 30
 
     # Required for advanced networking
-    vnet_subnet_id = "${azurerm_subnet.tf-k8s-acc.id}"
+    vnet_subnet_id = azurerm_subnet.tf-k8s-acc.id
   }
 
   service_principal {
-    client_id     = "${var.aks_client_id}"
-    client_secret = "${var.aks_client_secret}"
+    client_id     = var.aks_client_id
+    client_secret = var.aks_client_secret
   }
 
   role_based_access_control {
@@ -96,6 +97,7 @@ resource "azurerm_kubernetes_cluster" "tf-k8s-acc" {
 }
 
 resource "local_file" "kubeconfig" {
-  content  = "${azurerm_kubernetes_cluster.tf-k8s-acc.kube_config_raw}"
+  content  = azurerm_kubernetes_cluster.tf-k8s-acc.kube_config_raw
   filename = "${path.module}/kubeconfig"
 }
+

--- a/kubernetes/test-infra/aks/outputs.tf
+++ b/kubernetes/test-infra/aks/outputs.tf
@@ -1,3 +1,4 @@
 output "kubeconfig_path" {
-  value = "${local_file.kubeconfig.filename}"
+  value = local_file.kubeconfig.filename
 }
+

--- a/kubernetes/test-infra/aks/variables.tf
+++ b/kubernetes/test-infra/aks/variables.tf
@@ -9,16 +9,16 @@ variable "location" {
 }
 
 variable "kubernetes_version" {
-  type = "string"
+  type = string
 }
 
 variable "workers_count" {
-  type    = "string"
+  type    = string
   default = 2
 }
 
 variable "workers_type" {
-  type    = "string"
+  type    = string
   default = "Standard_DS4_v2"
 }
 

--- a/kubernetes/test-infra/aks/versions.tf
+++ b/kubernetes/test-infra/aks/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/kubernetes/test-infra/eks/main.tf
+++ b/kubernetes/test-infra/eks/main.tf
@@ -6,16 +6,16 @@ module "cluster" {
   source  = "terraform-aws-modules/eks/aws"
   version = "2.2.0"
 
-  vpc_id  = "${module.vpc.vpc_id}"
-  subnets = ["${module.vpc.subnets}"]
+  vpc_id  = module.vpc.vpc_id
+  subnets = [module.vpc.subnets]
 
-  cluster_name    = "${module.vpc.cluster_name}"
-  cluster_version = "${var.kubernetes_version}"
+  cluster_name    = module.vpc.cluster_name
+  cluster_version = var.kubernetes_version
 
   worker_groups = [
     {
-      instance_type        = "${var.workers_type}"
-      asg_desired_capacity = "${var.workers_count}"
+      instance_type        = var.workers_type
+      asg_desired_capacity = var.workers_count
       asg_max_size         = "10"
     },
   ]
@@ -32,8 +32,9 @@ module "cluster" {
 module "node-config" {
   source = "./node-config"
 
-  k8s_node_role_arn = ["${list(module.cluster.worker_iam_role_arn)}"]
-  cluster_ca        = "${module.cluster.cluster_certificate_authority_data}"
-  cluster_endpoint  = "${module.cluster.cluster_endpoint}"
-  kubeconfig        = "${module.cluster.kubeconfig}"
+  k8s_node_role_arn = [[module.cluster.worker_iam_role_arn]]
+  cluster_ca        = module.cluster.cluster_certificate_authority_data
+  cluster_endpoint  = module.cluster.cluster_endpoint
+  kubeconfig        = module.cluster.kubeconfig
 }
+

--- a/kubernetes/test-infra/eks/main.tf
+++ b/kubernetes/test-infra/eks/main.tf
@@ -4,10 +4,10 @@ module "vpc" {
 
 module "cluster" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "2.2.0"
+  version = "v5.0.0"
 
   vpc_id  = module.vpc.vpc_id
-  subnets = [module.vpc.subnets]
+  subnets = module.vpc.subnets
 
   cluster_name    = module.vpc.cluster_name
   cluster_version = var.kubernetes_version
@@ -32,7 +32,7 @@ module "cluster" {
 module "node-config" {
   source = "./node-config"
 
-  k8s_node_role_arn = [[module.cluster.worker_iam_role_arn]]
+  k8s_node_role_arn = list(module.cluster.worker_iam_role_arn)
   cluster_ca        = module.cluster.cluster_certificate_authority_data
   cluster_endpoint  = module.cluster.cluster_endpoint
   kubeconfig        = module.cluster.kubeconfig

--- a/kubernetes/test-infra/eks/node-config/config.tf
+++ b/kubernetes/test-infra/eks/node-config/config.tf
@@ -21,17 +21,20 @@ MAPPEDROLE
 
 resource "local_file" "cluster_ca" {
   content = base64decode(var.cluster_ca)
-  filename = "${path.module}/cluster_ca"
+  filename = "${path.root}/cluster_ca"
 }
 
 resource "null_resource" "wait_for_api" {
   depends_on = [local_file.cluster_ca]
 
   provisioner "local-exec" {
-
-    working_dir = path.module
+    working_dir = path.root
+    environment = {
+      K8S_CA_FILE = abspath(local_file.cluster_ca.filename)
+      K8S_ENDPOINT = var.cluster_endpoint
+    }
     command = <<CMDEOF
-while ! curl -s --cacert ./cluster_ca ${var.cluster_endpoint}/version > /dev/null; do 
+while ! curl -s --cacert $K8S_CA_FILE $K8S_ENDPOINT/version; do 
   echo "Waiting for the cluster API to come online..."
   sleep 3
 done

--- a/kubernetes/test-infra/eks/node-config/config.tf
+++ b/kubernetes/test-infra/eks/node-config/config.tf
@@ -1,10 +1,10 @@
 provider "kubernetes" {
-  config_path      = "${local_file.kubeconfig.filename}"
+  config_path      = local_file.kubeconfig.filename
   load_config_file = true
 }
 
 resource "local_file" "kubeconfig" {
-  content  = "${var.kubeconfig}"
+  content  = var.kubeconfig
   filename = "${path.module}/kubeconfig"
 }
 
@@ -16,37 +16,42 @@ locals {
     - system:bootstrappers
     - system:nodes
 MAPPEDROLE
+
 }
 
 resource "local_file" "cluster_ca" {
-  content  = "${base64decode(var.cluster_ca)}"
+  content = base64decode(var.cluster_ca)
   filename = "${path.module}/cluster_ca"
 }
 
 resource "null_resource" "wait_for_api" {
-  depends_on = ["local_file.cluster_ca"]
+  depends_on = [local_file.cluster_ca]
 
   provisioner "local-exec" {
+
+    working_dir = path.module
     command = <<CMDEOF
-while ! curl -s --cacert ${local_file.cluster_ca.filename} ${var.cluster_endpoint}/version > /dev/null; do 
+while ! curl -s --cacert ./cluster_ca ${var.cluster_endpoint}/version > /dev/null; do 
   echo "Waiting for the cluster API to come online..."
   sleep 3
 done
 CMDEOF
 
-    working_dir = "${path.module}"
   }
 }
 
 resource "kubernetes_config_map" "name" {
-  depends_on = ["null_resource.wait_for_api"]
+  depends_on = [null_resource.wait_for_api]
 
   metadata {
     name      = "aws-auth"
     namespace = "kube-system"
   }
 
-  data {
-    mapRoles = "${join("\n", formatlist(local.mapped_role_format, var.k8s_node_role_arn))}"
+  data = {
+    mapRoles = join(
+      "\n",
+      formatlist(local.mapped_role_format, var.k8s_node_role_arn),
+    )
   }
 }

--- a/kubernetes/test-infra/eks/node-config/variables.tf
+++ b/kubernetes/test-infra/eks/node-config/variables.tf
@@ -1,15 +1,16 @@
 variable "k8s_node_role_arn" {
-  type = "list"
+  type = list(string)
 }
 
 variable "kubeconfig" {
-  type = "string"
+  type = string
 }
 
 variable "cluster_ca" {
-  type = "string"
+  type = string
 }
 
 variable "cluster_endpoint" {
-  type = "string"
+  type = string
 }
+

--- a/kubernetes/test-infra/eks/node-config/versions.tf
+++ b/kubernetes/test-infra/eks/node-config/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/kubernetes/test-infra/eks/output.tf
+++ b/kubernetes/test-infra/eks/output.tf
@@ -1,3 +1,4 @@
 output "kubeconfig_path" {
   value = "${local.kubeconfig_path}/${local.kubeconfig_name}"
 }
+

--- a/kubernetes/test-infra/eks/output.tf
+++ b/kubernetes/test-infra/eks/output.tf
@@ -1,4 +1,4 @@
 output "kubeconfig_path" {
-  value = "${local.kubeconfig_path}/${local.kubeconfig_name}"
+  value = abspath("${local.kubeconfig_path}/${local.kubeconfig_name}")
 }
 

--- a/kubernetes/test-infra/eks/variables.tf
+++ b/kubernetes/test-infra/eks/variables.tf
@@ -3,11 +3,11 @@
 #
 variable "region" {
   default = "us-west-1"
-  type    = "string"
+  type    = string
 }
 
 variable "kubernetes_version" {
-  type    = "string"
+  type    = string
   default = "1.11"
 }
 
@@ -16,11 +16,12 @@ variable "workers_count" {
 }
 
 variable "workers_type" {
-  type    = "string"
+  type    = string
   default = "m4.large"
 }
 
 locals {
   kubeconfig_name = "kubeconfig_${module.vpc.cluster_name}"
-  kubeconfig_path = "${path.root}"
+  kubeconfig_path = path.root
 }
+

--- a/kubernetes/test-infra/eks/versions.tf
+++ b/kubernetes/test-infra/eks/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/kubernetes/test-infra/eks/vpc/outputs.tf
+++ b/kubernetes/test-infra/eks/vpc/outputs.tf
@@ -1,11 +1,12 @@
 output "vpc_id" {
-  value = "${aws_vpc.k8s-acc.id}"
+  value = aws_vpc.k8s-acc.id
 }
 
 output "subnets" {
-  value = ["${aws_subnet.k8s-acc.*.id}"]
+  value = aws_subnet.k8s-acc.*.id
 }
 
 output "cluster_name" {
-  value = "${random_id.cluster_name.hex}"
+  value = random_id.cluster_name.hex
 }
+

--- a/kubernetes/test-infra/eks/vpc/versions.tf
+++ b/kubernetes/test-infra/eks/vpc/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/kubernetes/test-infra/eks/vpc/vpc.tf
+++ b/kubernetes/test-infra/eks/vpc/vpc.tf
@@ -7,15 +7,18 @@
 #
 # Using these data sources allows the configuration to be
 # generic for any region.
-data "aws_region" "current" {}
+data "aws_region" "current" {
+}
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+}
 
 # Not required: currently used in conjuction with using
 # icanhazip.com to determine local workstation external IP
 # to open EC2 Security Group access to the Kubernetes cluster.
 # See workstation-external-ip.tf for additional information.
-provider "http" {}
+provider "http" {
+}
 
 resource "random_id" "cluster_name" {
   byte_length = 2
@@ -26,50 +29,47 @@ resource "aws_vpc" "k8s-acc" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true
-  tags = "${
-    map(
-      "Name", "terraform-eks-k8s-acc-node",
-      "kubernetes.io/cluster/${random_id.cluster_name.hex}", "shared",
-    )
-  }"
+  tags = {
+    "Name"                                                = "terraform-eks-k8s-acc-node"
+    "kubernetes.io/cluster/${random_id.cluster_name.hex}" = "shared"
+  }
 }
 
 resource "aws_subnet" "k8s-acc" {
   count = 2
 
-  availability_zone       = "${data.aws_availability_zones.available.names[count.index]}"
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
   cidr_block              = "10.0.${count.index}.0/24"
-  vpc_id                  = "${aws_vpc.k8s-acc.id}"
+  vpc_id                  = aws_vpc.k8s-acc.id
   map_public_ip_on_launch = true
 
-  tags = "${
-    map(
-      "Name", "terraform-eks-k8s-acc-node",
-      "kubernetes.io/cluster/${random_id.cluster_name.hex}", "shared",
-    )
-  }"
+  tags = {
+    "Name"                                                = "terraform-eks-k8s-acc-node"
+    "kubernetes.io/cluster/${random_id.cluster_name.hex}" = "shared"
+  }
 }
 
 resource "aws_internet_gateway" "k8s-acc" {
-  vpc_id = "${aws_vpc.k8s-acc.id}"
+  vpc_id = aws_vpc.k8s-acc.id
 
-  tags {
+  tags = {
     Name = "terraform-eks-k8s-acc"
   }
 }
 
 resource "aws_route_table" "k8s-acc" {
-  vpc_id = "${aws_vpc.k8s-acc.id}"
+  vpc_id = aws_vpc.k8s-acc.id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.k8s-acc.id}"
+    gateway_id = aws_internet_gateway.k8s-acc.id
   }
 }
 
 resource "aws_route_table_association" "k8s-acc" {
   count = 2
 
-  subnet_id      = "${aws_subnet.k8s-acc.*.id[count.index]}"
-  route_table_id = "${aws_route_table.k8s-acc.id}"
+  subnet_id      = aws_subnet.k8s-acc[count.index].id
+  route_table_id = aws_route_table.k8s-acc.id
 }
+

--- a/kubernetes/test-infra/gke/main.tf
+++ b/kubernetes/test-infra/gke/main.tf
@@ -2,7 +2,8 @@ provider "google" {
   // Provider settings to be provided via ENV variables
 }
 
-data "google_compute_zones" "available" {}
+data "google_compute_zones" "available" {
+}
 
 resource "random_id" "cluster_name" {
   byte_length = 10
@@ -25,24 +26,24 @@ variable "workers_count" {
 }
 
 data "google_container_engine_versions" "supported" {
-  zone           = "${data.google_compute_zones.available.names[0]}"
-  version_prefix = "${var.kubernetes_version}"
+  zone           = data.google_compute_zones.available.names[0]
+  version_prefix = var.kubernetes_version
 }
 
 resource "google_container_cluster" "primary" {
   name               = "tf-acc-test-${random_id.cluster_name.hex}"
-  zone               = "${data.google_compute_zones.available.names[0]}"
-  initial_node_count = "${var.workers_count}"
-  node_version       = "${data.google_container_engine_versions.supported.latest_node_version}"
-  min_master_version = "${data.google_container_engine_versions.supported.latest_master_version}"
+  zone               = data.google_compute_zones.available.names[0]
+  initial_node_count = var.workers_count
+  node_version       = data.google_container_engine_versions.supported.latest_node_version
+  min_master_version = data.google_container_engine_versions.supported.latest_master_version
 
   additional_zones = [
-    "${data.google_compute_zones.available.names[1]}",
+    data.google_compute_zones.available.names[1],
   ]
 
   master_auth {
-    username = "${random_id.username.hex}"
-    password = "${random_id.password.hex}"
+    username = random_id.username.hex
+    password = random_id.password.hex
   }
 
   node_config {
@@ -58,32 +59,33 @@ resource "google_container_cluster" "primary" {
 }
 
 data "template_file" "kubeconfig" {
-  template = "${file("${path.module}/kubeconfig-template.yaml")}"
+  template = file("${path.module}/kubeconfig-template.yaml")
 
-  vars {
-    cluster_name    = "${google_container_cluster.primary.name}"
-    user_name       = "${google_container_cluster.primary.master_auth.0.username}"
-    user_password   = "${google_container_cluster.primary.master_auth.0.password}"
-    endpoint        = "${google_container_cluster.primary.endpoint}"
-    cluster_ca      = "${google_container_cluster.primary.master_auth.0.cluster_ca_certificate}"
-    client_cert     = "${google_container_cluster.primary.master_auth.0.client_certificate}"
-    client_cert_key = "${google_container_cluster.primary.master_auth.0.client_key}"
+  vars = {
+    cluster_name    = google_container_cluster.primary.name
+    user_name       = google_container_cluster.primary.master_auth[0].username
+    user_password   = google_container_cluster.primary.master_auth[0].password
+    endpoint        = google_container_cluster.primary.endpoint
+    cluster_ca      = google_container_cluster.primary.master_auth[0].cluster_ca_certificate
+    client_cert     = google_container_cluster.primary.master_auth[0].client_certificate
+    client_cert_key = google_container_cluster.primary.master_auth[0].client_key
   }
 }
 
 resource "local_file" "kubeconfig" {
-  content  = "${data.template_file.kubeconfig.rendered}"
+  content  = data.template_file.kubeconfig.rendered
   filename = "${path.module}/kubeconfig"
 }
 
 output "google_zone" {
-  value = "${data.google_compute_zones.available.names[0]}"
+  value = data.google_compute_zones.available.names[0]
 }
 
 output "node_version" {
-  value = "${google_container_cluster.primary.node_version}"
+  value = google_container_cluster.primary.node_version
 }
 
 output "kubeconfig_path" {
-  value = "${local_file.kubeconfig.filename}"
+  value = local_file.kubeconfig.filename
 }
+

--- a/kubernetes/test-infra/gke/versions.tf
+++ b/kubernetes/test-infra/gke/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This change is the result of running `terraform 0.12upgrade` command inside each of the test-infra configurations.

I will update with TC results as the runs complete.