### PR TITLE
Fix broken links in kubernetes_cron_job documentation

### DIFF
--- a/website/docs/r/cron_job.html.markdown
+++ b/website/docs/r/cron_job.html.markdown
@@ -96,8 +96,8 @@ More info: http://kubernetes.io/docs/user-guide/labels
 
 #### Arguments
 
-* `metadata` - (Required) Standard object's metadata of the jobs created from this template. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
-* `spec` - (Required) Specification of the desired behavior of the job. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
+* `metadata` - (Required) Standard object's metadata of the jobs created from this template. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
+* `spec` - (Required) Specification of the desired behavior of the job. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 
 ### `spec`
 


### PR DESCRIPTION
Replace two broken links pointing to git.k8s.io in the README to their (working) github.com/kubernetes equivalent.  Links now tested and working.