### PR TITLE
Correct validation of RoleBinding and ClusterRoleBinding

### DIFF
--- a/kubernetes/resource_kubernetes_cluster_role.go
+++ b/kubernetes/resource_kubernetes_cluster_role.go
@@ -24,7 +24,7 @@ func resourceKubernetesClusterRole() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"metadata": metadataSchemaClusterRole(),
+			"metadata": metadataSchemaRBAC("clusterRole", false, false),
 			"rule": {
 				Type:        schema.TypeList,
 				Description: "List of PolicyRules for this ClusterRole",

--- a/kubernetes/resource_kubernetes_cluster_role_binding.go
+++ b/kubernetes/resource_kubernetes_cluster_role_binding.go
@@ -24,7 +24,7 @@ func resourceKubernetesClusterRoleBinding() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"metadata": metadataSchema("clusterRoleBinding", false),
+			"metadata": metadataSchemaRBAC("clusterRoleBinding", false, false),
 			"role_ref": {
 				Type:        schema.TypeList,
 				Description: "RoleRef references the Cluster Role for this binding",

--- a/kubernetes/resource_kubernetes_cluster_role_binding_test.go
+++ b/kubernetes/resource_kubernetes_cluster_role_binding_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccKubernetesClusterRoleBinding(t *testing.T) {
 	var conf api.ClusterRoleBinding
-	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	name := fmt.Sprintf("tf-acc-test:%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -73,7 +73,7 @@ func TestAccKubernetesClusterRoleBinding(t *testing.T) {
 
 func TestAccKubernetesClusterRoleBinding_serviceaccount_subject(t *testing.T) {
 	var conf api.ClusterRoleBinding
-	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	name := fmt.Sprintf("tf-acc-test:%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -106,7 +106,7 @@ func TestAccKubernetesClusterRoleBinding_serviceaccount_subject(t *testing.T) {
 
 func TestAccKubernetesClusterRoleBinding_group_subject(t *testing.T) {
 	var conf api.ClusterRoleBinding
-	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	name := fmt.Sprintf("tf-acc-test:%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -139,7 +139,7 @@ func TestAccKubernetesClusterRoleBinding_group_subject(t *testing.T) {
 
 func TestAccKubernetesClusterRoleBinding_importBasic(t *testing.T) {
 	resourceName := "kubernetes_cluster_role_binding.test"
-	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	name := fmt.Sprintf("tf-acc-test:%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/kubernetes/resource_kubernetes_role.go
+++ b/kubernetes/resource_kubernetes_role.go
@@ -23,7 +23,7 @@ func resourceKubernetesRole() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"metadata": metadataSchemaRole(),
+			"metadata": metadataSchemaRBAC("role", true, true),
 			"rule": {
 				Type:        schema.TypeList,
 				Description: "Rule defining a set of permissions for the role",

--- a/kubernetes/resource_kubernetes_role_binding.go
+++ b/kubernetes/resource_kubernetes_role_binding.go
@@ -2,13 +2,14 @@ package kubernetes
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	api "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgApi "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"log"
 )
 
 func resourceKubernetesRoleBinding() *schema.Resource {
@@ -23,7 +24,7 @@ func resourceKubernetesRoleBinding() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"metadata": namespacedMetadataSchema("roleBinding", false),
+			"metadata": metadataSchemaRBAC("roleBinding", false, true),
 			"role_ref": {
 				Type:        schema.TypeList,
 				Description: "RoleRef references the Role for this binding",

--- a/kubernetes/resource_kubernetes_role_binding_test.go
+++ b/kubernetes/resource_kubernetes_role_binding_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccKubernetesRoleBinding_basic(t *testing.T) {
 	var conf api.RoleBinding
-	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	name := fmt.Sprintf("tf-acc-test:%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -73,7 +73,7 @@ func TestAccKubernetesRoleBinding_basic(t *testing.T) {
 
 func TestAccKubernetesRoleBinding_importBasic(t *testing.T) {
 	resourceName := "kubernetes_role_binding.test"
-	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	name := fmt.Sprintf("tf-acc-test:%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -95,7 +95,7 @@ func TestAccKubernetesRoleBinding_importBasic(t *testing.T) {
 
 func TestAccKubernetesRoleBinding_sa_subject(t *testing.T) {
 	var conf api.RoleBinding
-	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	name := fmt.Sprintf("tf-acc-test:%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -128,7 +128,7 @@ func TestAccKubernetesRoleBinding_sa_subject(t *testing.T) {
 
 func TestAccKubernetesRoleBinding_group_subject(t *testing.T) {
 	var conf api.RoleBinding
-	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	name := fmt.Sprintf("tf-acc-test:%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },

--- a/kubernetes/schema_rbac.go
+++ b/kubernetes/schema_rbac.go
@@ -8,18 +8,13 @@ import (
 	pathValidation "k8s.io/apimachinery/pkg/api/validation/path"
 )
 
-func metadataSchemaClusterRole() *schema.Schema {
-	m := metadataSchema("clusterRole", false)
-	metadataFields := (m.Elem.(*schema.Resource)).Schema
-	nameSchema := metadataFields["name"]
-	if nameSchema != nil {
-		nameSchema.ValidateFunc = validateRBACNameFunc
+func metadataSchemaRBAC(objectName string, generatableName bool, namespaced bool) *schema.Schema {
+	var m *schema.Schema
+	if namespaced {
+		m = namespacedMetadataSchema(objectName, generatableName)
+	} else {
+		m = metadataSchema(objectName, generatableName)
 	}
-	return m
-}
-
-func metadataSchemaRole() *schema.Schema {
-	m := namespacedMetadataSchema("role", true)
 	metadataFields := (m.Elem.(*schema.Resource)).Schema
 	nameSchema := metadataFields["name"]
 	if nameSchema != nil {


### PR DESCRIPTION
This change follows up on the basis of https://github.com/terraform-providers/terraform-provider-kubernetes/pull/551 and implements the same validation RBAC RoleBinding and ClusterRoleBinding resources.
This aligns all the RBAC resources' validation to Kubernetes' rules.

Tests pass
```
make testacc TESTARGS="-run '^TestAccKubernetes.*Role'"                                                                   alex@alexs-macbook-4
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "./kubernetes" -v -run '^TestAccKubernetes.*Role' -timeout 120m
=== RUN   TestAccKubernetesClusterRoleBinding
--- PASS: TestAccKubernetesClusterRoleBinding (0.53s)
=== RUN   TestAccKubernetesClusterRoleBinding_serviceaccount_subject
--- PASS: TestAccKubernetesClusterRoleBinding_serviceaccount_subject (0.30s)
=== RUN   TestAccKubernetesClusterRoleBinding_group_subject
--- PASS: TestAccKubernetesClusterRoleBinding_group_subject (0.35s)
=== RUN   TestAccKubernetesClusterRoleBinding_importBasic
--- PASS: TestAccKubernetesClusterRoleBinding_importBasic (0.42s)
=== RUN   TestAccKubernetesClusterRole_basic
--- PASS: TestAccKubernetesClusterRole_basic (0.50s)
=== RUN   TestAccKubernetesClusterRole_importBasic
--- PASS: TestAccKubernetesClusterRole_importBasic (0.37s)
=== RUN   TestAccKubernetesRoleBinding_basic
--- PASS: TestAccKubernetesRoleBinding_basic (0.50s)
=== RUN   TestAccKubernetesRoleBinding_importBasic
--- PASS: TestAccKubernetesRoleBinding_importBasic (0.37s)
=== RUN   TestAccKubernetesRoleBinding_sa_subject
--- PASS: TestAccKubernetesRoleBinding_sa_subject (0.30s)
=== RUN   TestAccKubernetesRoleBinding_group_subject
--- PASS: TestAccKubernetesRoleBinding_group_subject (0.29s)
=== RUN   TestAccKubernetesRole_basic
--- PASS: TestAccKubernetesRole_basic (0.50s)
=== RUN   TestAccKubernetesRole_importBasic
--- PASS: TestAccKubernetesRole_importBasic (0.37s)
=== RUN   TestAccKubernetesRole_generatedName
--- PASS: TestAccKubernetesRole_generatedName (0.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	6.105s
------------------------------------------------------------
```