### PR TITLE
Parametrise all timeouts

### DIFF
--- a/kubernetes/resource_kubernetes_cron_job.go
+++ b/kubernetes/resource_kubernetes_cron_job.go
@@ -22,6 +22,11 @@ func resourceKubernetesCronJob() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(1 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"metadata": namespacedMetadataSchema("cronjob", true),
 			"spec": {
@@ -166,7 +171,7 @@ func resourceKubernetesCronJobDelete(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		_, err := conn.BatchV1beta1().CronJobs(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {

--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -23,6 +23,11 @@ func resourceKubernetesJob() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(1 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"metadata": jobMetadataSchema(),
 			"spec": {
@@ -162,7 +167,7 @@ func resourceKubernetesJobDelete(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Failed to delete Job! API error: %s", err)
 	}
 
-	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		_, err := conn.BatchV1().Jobs(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {

--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -25,6 +25,10 @@ func resourceKubernetesPersistentVolume() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		CustomizeDiff: func(diff *schema.ResourceDiff, meta interface{}) error {
 			if diff.Id() == "" {
 				// We only care about updates, not creation
@@ -160,7 +164,7 @@ func resourceKubernetesPersistentVolumeCreate(d *schema.ResourceData, meta inter
 	stateConf := &resource.StateChangeConf{
 		Target:  []string{"Available", "Bound"},
 		Pending: []string{"Pending"},
-		Timeout: 5 * time.Minute,
+		Timeout: d.Timeout(schema.TimeoutCreate),
 		Refresh: func() (interface{}, string, error) {
 			out, err := conn.CoreV1().PersistentVolumes().Get(metadata.Name, meta_v1.GetOptions{})
 			if err != nil {

--- a/kubernetes/resource_kubernetes_service.go
+++ b/kubernetes/resource_kubernetes_service.go
@@ -25,6 +25,10 @@ func resourceKubernetesService() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"metadata": namespacedMetadataSchema("service", true),
 			"spec": {
@@ -175,7 +179,7 @@ func resourceKubernetesServiceCreate(d *schema.ResourceData, meta interface{}) e
 	if out.Spec.Type == api.ServiceTypeLoadBalancer {
 		log.Printf("[DEBUG] Waiting for load balancer to assign IP/hostname")
 
-		err = resource.Retry(10*time.Minute, func() *resource.RetryError {
+		err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 			svc, err := conn.CoreV1().Services(out.Namespace).Get(out.Name, meta_v1.GetOptions{})
 			if err != nil {
 				log.Printf("[DEBUG] Received error: %#v", err)

--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -26,6 +26,10 @@ func resourceKubernetesServiceAccount() *schema.Resource {
 			State: resourceKubernetesServiceAccountImportState,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Second),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"metadata": namespacedMetadataSchema("service account", true),
 			"image_pull_secret": {
@@ -90,7 +94,7 @@ func resourceKubernetesServiceAccountCreate(d *schema.ResourceData, meta interfa
 	// Here we get the only chance to identify and store default secret name
 	// so we can avoid showing it in diff as it's not managed by Terraform
 	var svcAccTokens []api.Secret
-	err = resource.Retry(30*time.Second, func() *resource.RetryError {
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		resp, err := conn.CoreV1().ServiceAccounts(out.Namespace).Get(out.Name, metav1.GetOptions{})
 		if err != nil {
 			return resource.NonRetryableError(err)


### PR DESCRIPTION
Parametrised all resource timeouts.

In my case, creating a load balancer service is taking more than hardcoded 10 minutes. I decided to parametrise all timeouts which I've found in the code. I didn't change any value, so the provider is working as before, but we have more options to customise.