### PR TITLE
Enable HTTP requests/responses tracing in debug mode

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 
+	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/go-homedir"
@@ -244,6 +246,13 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 			return nil, fmt.Errorf("Failed to parse exec")
 		}
 		cfg.ExecProvider = exec
+	}
+
+	if logging.IsDebugOrHigher() {
+		log.Printf("[DEBUG] Enabling HTTP requests/responses tracing")
+		cfg.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+			return logging.NewTransport("Kubernetes", rt)
+		}
 	}
 
 	k, err := kubernetes.NewForConfig(cfg)


### PR DESCRIPTION
With this change:

```
# TF_LOG=debug make testacc TEST=./kubernetes TESTARGS='-run=TestAccKubernetesSecret_basic -count=1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./kubernetes -v -run=TestAccKubernetesSecret_basic -count=1 -timeout 120m
...

-----------------------------------------------------
2019/09/30 17:15:11 [INFO] Secret tf-acc-test-6cgib6lrq7 deleted
2019/09/30 17:15:11 [DEBUG] provider has no plugin.Client
2019/09/30 17:15:11 [DEBUG] New state was assigned lineage "8f92a3d4-1bab-653c-2899-2c997e6fa5db"
2019/09/30 17:15:11 [DEBUG] Kubernetes API Request Details:
---[ REQUEST ]---------------------------------------
GET /api/v1/namespaces/default/secrets/tf-acc-test-6cgib6lrq7 HTTP/1.1
Host: 192.168.39.115:8443
User-Agent: HashiCorp/1.0 Terraform/0.12.10-dev
Accept: application/json, */*
Accept-Encoding: gzip


-----------------------------------------------------
2019/09/30 17:15:11 [DEBUG] Kubernetes API Response Details:
---[ RESPONSE ]--------------------------------------
HTTP/2.0 404 Not Found
Content-Length: 218
Cache-Control: no-cache, private
Content-Type: application/json
Date: Mon, 30 Sep 2019 15:15:16 GMT

{
 "kind": "Status",
 "apiVersion": "v1",
 "metadata": {},
 "status": "Failure",
 "message": "secrets \"tf-acc-test-6cgib6lrq7\" not found",
 "reason": "NotFound",
 "details": {
  "name": "tf-acc-test-6cgib6lrq7",
  "kind": "secrets"
 },
 "code": 404
}

-----------------------------------------------------
2019/09/30 17:15:11 [INFO] terraform: building graph: GraphTypePlanDestroy
2019/09/30 17:15:11 [DEBUG] Starting graph walk: walkPlanDestroy
2019/09/30 17:15:11 [INFO] terraform: building graph: GraphTypeRefresh
2019/09/30 17:15:11 [DEBUG] Starting graph walk: walkRefresh
2019/09/30 17:15:11 [DEBUG] New state was assigned lineage "fa89fb07-79ed-a81b-43f9-28a87d149af4"
2019/09/30 17:15:11 [INFO] terraform: building graph: GraphTypePlanDestroy
2019/09/30 17:15:11 [DEBUG] Starting graph walk: walkPlanDestroy
--- PASS: TestAccKubernetesSecret_basic (1.63s)
PASS
ok      github.com/terraform-providers/terraform-provider-kubernetes/kubernetes 1.664s
```