### PR TITLE
Allow 0 for backoff_limit on kubernetes_job

### DIFF
--- a/kubernetes/schema_job_spec.go
+++ b/kubernetes/schema_job_spec.go
@@ -44,7 +44,7 @@ func jobSpecFields() map[string]*schema.Schema {
 			Type:         schema.TypeInt,
 			Optional:     true,
 			ForceNew:     true,
-			ValidateFunc: validatePositiveInteger,
+			ValidateFunc: validateNonNegativeInteger,
 			Description:  "Specifies the number of retries before marking this job failed. Defaults to 6",
 		},
 		"completions": {


### PR DESCRIPTION
0 is a valid value for backOff limit which means do not restart this job.