### PR TITLE
Add support for kubernetes_api_service.spec.service.port

### DIFF
--- a/kubernetes/resource_kubernetes_api_service.go
+++ b/kubernetes/resource_kubernetes_api_service.go
@@ -73,6 +73,13 @@ func resourceKubernetesAPIService() *schema.Resource {
 										Description: "Namespace is the namespace of the service.",
 										Required:    true,
 									},
+									"port": {
+										Type:         schema.TypeInt,
+										Description:  "If specified, the port on the service that is hosting the service. Defaults to 443 for backward compatibility. Should be a valid port number (1-65535, inclusive).",
+										Optional:     true,
+										Default:      443,
+										ValidateFunc: validatePortNum,
+									},
 								},
 							},
 						},

--- a/kubernetes/resource_kubernetes_api_service_test.go
+++ b/kubernetes/resource_kubernetes_api_service_test.go
@@ -34,6 +34,7 @@ func TestAccKubernetesAPIService_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.service.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.service.0.name", "metrics-server"),
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.service.0.namespace", "kube-system"),
+					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.service.0.port", "443"),
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.group", group),
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.group_priority_minimum", "1"),
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.version", version),
@@ -55,6 +56,7 @@ func TestAccKubernetesAPIService_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.service.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.service.0.name", "metrics-server"),
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.service.0.namespace", "kube-system"),
+					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.service.0.port", "8443"),
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.group", group),
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.group_priority_minimum", "100"),
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.version", version),
@@ -95,6 +97,7 @@ func TestAccKubernetesAPIService_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.service.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.service.0.name", "metrics-server"),
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.service.0.namespace", "kube-system"),
+					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.service.0.port", "443"),
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.group", group),
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.group_priority_minimum", "1"),
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.version", version),
@@ -229,6 +232,7 @@ func testAccKubernetesAPIServiceConfig_modified(name, group, version string) str
       service {
         name        = "metrics-server"
         namespace   = "kube-system"
+        port        = 8443
       }
 
       group                  = "%s"

--- a/kubernetes/structure_api_service_spec.go
+++ b/kubernetes/structure_api_service_spec.go
@@ -18,6 +18,9 @@ func flattenAPIServiceSpec(in v1.APIServiceSpec) []interface{} {
 		m := make(map[string]interface{})
 		m["name"] = in.Service.Name
 		m["namespace"] = in.Service.Namespace
+		if in.Service.Port != nil {
+			m["port"] = *in.Service.Port
+		}
 		att["service"] = []interface{}{m}
 	}
 
@@ -53,6 +56,10 @@ func expandAPIServiceSpec(l []interface{}) v1.APIServiceSpec {
 		obj.Service = &v1.ServiceReference{
 			Name:      m["name"].(string),
 			Namespace: m["namespace"].(string),
+		}
+
+		if v, ok := m["port"].(int); ok && v > 0 {
+			obj.Service.Port = ptrToInt32(int32(v))
 		}
 	}
 	if v, ok := in["version"].(string); ok {

--- a/website/docs/r/api_service.html.markdown
+++ b/website/docs/r/api_service.html.markdown
@@ -81,6 +81,7 @@ For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/la
 
 * `name` - (Required) Name is the name of the service.
 * `namespace` - (Required) Namespace is the namespace of the service.
+* `port` - (Optional) If specified, the port on the service that is hosting the service. Defaults to 443 for backward compatibility. Should be a valid port number (1-65535, inclusive).
 
 ## Import
 


### PR DESCRIPTION
This PR adds support for kubernetes_api_service.spec.service.port and resolves #660