### PR TITLE
Fix namespacing on kubernetes_priority_class

### DIFF
--- a/kubernetes/resource_kubernetes_priority_class.go
+++ b/kubernetes/resource_kubernetes_priority_class.go
@@ -67,7 +67,7 @@ func resourceKubernetesPriorityClassCreate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Failed to create priority class: %s", err)
 	}
 	log.Printf("[INFO] Submitted new priority class: %#v", out)
-	d.SetId(buildId(out.ObjectMeta))
+	d.SetId(out.ObjectMeta.Name)
 
 	return resourceKubernetesPriorityClassRead(d, meta)
 }
@@ -75,10 +75,7 @@ func resourceKubernetesPriorityClassCreate(d *schema.ResourceData, meta interfac
 func resourceKubernetesPriorityClassRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*KubeClientsets).MainClientset
 
-	_, name, err := idParts(d.Id())
-	if err != nil {
-		return err
-	}
+	name := d.Id()
 
 	log.Printf("[INFO] Reading priority class %s", name)
 	priorityClass, err := conn.SchedulingV1().PriorityClasses().Get(name, meta_v1.GetOptions{})
@@ -114,10 +111,7 @@ func resourceKubernetesPriorityClassRead(d *schema.ResourceData, meta interface{
 func resourceKubernetesPriorityClassUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*KubeClientsets).MainClientset
 
-	_, name, err := idParts(d.Id())
-	if err != nil {
-		return err
-	}
+	name := d.Id()
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 
@@ -147,7 +141,7 @@ func resourceKubernetesPriorityClassUpdate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Failed to update priority class: %s", err)
 	}
 	log.Printf("[INFO] Submitted updated priority class: %#v", out)
-	d.SetId(buildId(out.ObjectMeta))
+	d.SetId(out.ObjectMeta.Name)
 
 	return resourceKubernetesPriorityClassRead(d, meta)
 }
@@ -155,13 +149,10 @@ func resourceKubernetesPriorityClassUpdate(d *schema.ResourceData, meta interfac
 func resourceKubernetesPriorityClassDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*KubeClientsets).MainClientset
 
-	_, name, err := idParts(d.Id())
-	if err != nil {
-		return err
-	}
+	name := d.Id()
 
 	log.Printf("[INFO] Deleting priority class: %#v", name)
-	err = conn.SchedulingV1().PriorityClasses().Delete(name, &meta_v1.DeleteOptions{})
+	err := conn.SchedulingV1().PriorityClasses().Delete(name, &meta_v1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -175,13 +166,10 @@ func resourceKubernetesPriorityClassDelete(d *schema.ResourceData, meta interfac
 func resourceKubernetesPriorityClassExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	conn := meta.(*KubeClientsets).MainClientset
 
-	_, name, err := idParts(d.Id())
-	if err != nil {
-		return false, err
-	}
+	name := d.Id()
 
 	log.Printf("[INFO] Checking priority class %s", name)
-	_, err = conn.SchedulingV1().PriorityClasses().Get(name, meta_v1.GetOptions{})
+	_, err := conn.SchedulingV1().PriorityClasses().Get(name, meta_v1.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return false, nil

--- a/kubernetes/resource_kubernetes_priority_class_test.go
+++ b/kubernetes/resource_kubernetes_priority_class_test.go
@@ -144,10 +144,7 @@ func testAccCheckKubernetesPriorityClassDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, name, err := idParts(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
+		name := rs.Primary.ID
 
 		resp, err := conn.SchedulingV1().PriorityClasses().Get(name, meta_v1.GetOptions{})
 		if err == nil {
@@ -169,10 +166,7 @@ func testAccCheckKubernetesPriorityClassExists(n string, obj *api.PriorityClass)
 
 		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
 
-		_, name, err := idParts(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
+		name := rs.Primary.ID
 
 		out, err := conn.SchedulingV1().PriorityClasses().Get(name, meta_v1.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
Fixes #680.

Although `kubernetes_priority_class` is a non-namespaced resource and it's schema correctly configures it like that, in the original implementation the CRUD functions where attempting to assemble a namespaced resource ID and this led to import functionality not behaving as expected.

**Tests pass.**
```
~/workspace/terraform-provider-kubernetes(priority-class-review*) » make testacc TESTARGS="-run '^TestAccKubernetesPriorityClass_'"                                                            alex@MacBook-Pro
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "./kubernetes" -v -run '^TestAccKubernetesPriorityClass_' -timeout 120m
=== RUN   TestAccKubernetesPriorityClass_basic
--- PASS: TestAccKubernetesPriorityClass_basic (1.32s)
=== RUN   TestAccKubernetesPriorityClass_generatedName
--- PASS: TestAccKubernetesPriorityClass_generatedName (0.56s)
=== RUN   TestAccKubernetesPriorityClass_importBasic
--- PASS: TestAccKubernetesPriorityClass_importBasic (0.67s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	7.937s
------------------------------------------------------------
```
**Import works**
```
~/test-680 » cat main.tf
resource "kubernetes_priority_class" "system-node-critical" {
  metadata {
    name = "system-node-critical"
  }
} 
------------------------------------------------------------
~/test-680 » terraform import kubernetes_priority_class.system-node-critical system-node-critical
kubernetes_priority_class.system-node-critical: Importing from ID "system-node-critical"...
kubernetes_priority_class.system-node-critical: Import prepared!
  Prepared kubernetes_priority_class for import
kubernetes_priority_class.system-node-critical: Refreshing state... [id=system-node-critical]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

------------------------------------------------------------
~/test-680 » terraform state show kubernetes_priority_class.system-node-critical
# kubernetes_priority_class.system-node-critical:
resource "kubernetes_priority_class" "system-node-critical" {
    description    = "Used for system critical pods that must not be moved from their current node."
    global_default = false
    id             = "system-node-critical"
    value          = 2000001000

    metadata {
        annotations      = {}
        generation       = 1
        labels           = {}
        name             = "system-node-critical"
        resource_version = "40"
        self_link        = "/apis/scheduling.k8s.io/v1/priorityclasses/system-node-critical"
        uid              = "ca8ed131-97fd-4657-9d4c-eca6f8af1eaa"
    }
}
------------------------------------------------------------