### PR TITLE
 Only try in-cluster configuration with service account token if no other configuration was provided

### DIFF
--- a/_examples/in-cluster/README.md
+++ b/_examples/in-cluster/README.md
@@ -9,3 +9,10 @@ It will not work out-of-the-box with Terraform 0.11.x and lower.*
 ```
 # terraform apply -var "minikube_host_ip=$(minikube --profile kubernetes-1.16 ip)" -var "minikube_target_ip=$(minikube --profile kubernetes-1.15 ip)"
 ```
+
+
+Note: development builds need to be statically linked:
+
+```
+# CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"'
+```

--- a/_examples/in-cluster/README.md
+++ b/_examples/in-cluster/README.md
@@ -1,0 +1,11 @@
+# Example: In-cluster
+
+## Prerequisites
+
+*This example uses syntax elements specific to Terraform version 0.12+.
+It will not work out-of-the-box with Terraform 0.11.x and lower.*
+
+
+```
+# terraform apply -var "minikube_host_ip=$(minikube --profile kubernetes-1.16 ip)" -var "minikube_target_ip=$(minikube --profile kubernetes-1.15 ip)"
+```

--- a/_examples/in-cluster/main.tf
+++ b/_examples/in-cluster/main.tf
@@ -1,0 +1,81 @@
+variable "minikube_host_ip" {}
+variable "minikube_target_ip" {}
+
+provider "kubernetes" {
+  version = "1.10.0"
+
+  host                   = "https://${var.minikube_host_ip}:8443"
+  client_certificate     = file("~/.minikube/client.crt")
+  client_key             = file("~/.minikube/client.key")
+  cluster_ca_certificate = file("~/.minikube/ca.crt")
+}
+
+resource "kubernetes_config_map" "terraform" {
+  metadata {
+    name = "terraform"
+  }
+
+  data = {
+    "main.tf" = <<-EOT
+      provider "kubernetes" {
+        version = "1.10"
+      }
+
+      resource "kubernetes_namespace" "test" {
+        metadata {
+          name = "test"
+        }
+      }
+    EOT
+  }
+}
+
+resource "kubernetes_job" "terraform" {
+  metadata {
+    name = "terraform"
+  }
+  spec {
+    backoff_limit = 1
+    template {
+      metadata {}
+      spec {
+        container {
+          name    = "terraform"
+          image   = "hashicorp/terraform:0.12.13"
+          command = ["sh", "-c", "mkdir /tf && cd /tf && cp /configuration/* . && KUBERNETES_SERVICE_HOST= && terraform init && terraform plan && terraform apply -auto-approve && sleep 10 && terraform destroy -auto-approve"]
+
+          env {
+            name  = "KUBE_HOST"
+            value = "https://${var.minikube_target_ip}:8443"
+          }
+          env {
+            name  = "KUBE_CLIENT_CERT_DATA"
+            value = file("~/.minikube/client.crt")
+          }
+          env {
+            name  = "KUBE_CLIENT_KEY_DATA"
+            value = file("~/.minikube/client.key")
+          }
+          env {
+            name  = "KUBE_CLUSTER_CA_CERT_DATA"
+            value = file("~/.minikube/ca.crt")
+          }
+
+          volume_mount {
+            name       = "configuration"
+            mount_path = "/configuration"
+          }
+        }
+
+        restart_policy = "Never"
+
+        volume {
+          name = "configuration"
+          config_map {
+            name = kubernetes_config_map.terraform.metadata[0].name
+          }
+        }
+      }
+    }
+  }
+}

--- a/_examples/in-cluster/main.tf
+++ b/_examples/in-cluster/main.tf
@@ -18,7 +18,7 @@ resource "kubernetes_config_map" "terraform" {
   data = {
     "main.tf" = <<-EOT
       provider "kubernetes" {
-        version = "1.10"
+        version = "1.10.1-dev"
       }
 
       resource "kubernetes_namespace" "test" {
@@ -40,9 +40,13 @@ resource "kubernetes_job" "terraform" {
       metadata {}
       spec {
         container {
-          name    = "terraform"
-          image   = "hashicorp/terraform:0.12.13"
-          command = ["sh", "-c", "mkdir /tf && cd /tf && cp /configuration/* . && KUBERNETES_SERVICE_HOST= && terraform init && terraform plan && terraform apply -auto-approve && sleep 10 && terraform destroy -auto-approve"]
+          name  = "terraform"
+          image = "hashicorp/terraform:0.12.13"
+          command = [
+            "sh",
+            "-c",
+            "set -x && apk --no-cache add curl && mkdir /tf && cd /tf && cp /configuration/main.tf . && mkdir -p ~/.terraform.d/plugins && curl https://storage.googleapis.com/pdecat-builds/terraform-provider-kubernetes_v1.10.1-dev > ~/.terraform.d/plugins/terraform-provider-kubernetes_v1.10.1-dev && chmod +x ~/.terraform.d/plugins/* && terraform init && terraform plan && terraform apply -auto-approve && sleep 10 && terraform destroy -auto-approve"
+          ]
 
           env {
             name  = "KUBE_HOST"

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -244,6 +244,7 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 	if v, ok := d.GetOk("token"); ok {
 		hasConfig = true
 		cfg.BearerToken = v.(string)
+		cfg.BearerTokenFile = ""
 	}
 
 	if v, ok := d.GetOk("exec"); ok {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -88,9 +88,14 @@ provider "kubernetes" {
 }
 ```
 
-
 If you have **both** valid configuration in a config file and static configuration, the static one is used as override.
 i.e. any static field will override its counterpart loaded from the config.
+
+### In-cluster service account token
+
+As a last resort, if no other configuration is available, and when it detects it is running in a kubernetes pod, the provider will try to use the service account token from the `/var/run/secrets/kubernetes.io/serviceaccount/token` path. Detection of in-cluster execution is based on the sole availability of the `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` environment variables, with non empty values.
+
+If you have any of valid configuration in a config file or static configuration, in-cluster service account token will not be tried.
 
 ## Argument Reference
 


### PR DESCRIPTION
This PR should fix #679.

I've added an example to easily test the issue with two local minikube instances.

When no service account is declared on the pod running terraform, the error is:

```
Error: Failed to configure: open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory

  on main.tf line 1, in provider "kubernetes":
   1: provider "kubernetes" {
```

An alternative may be to implement a new provider configuration option named `load_in_cluster_config` as suggested in https://github.com/terraform-providers/terraform-provider-kubernetes/issues/679#issuecomment-553151777. It should default to `false`.