### PR TITLE
Refactor kubernetes client config initialization and fix in-cluster config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ $ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-kubernetes
 $ make build
 ```
 
+Statically linking binaries can be required for testing development builds in containers not providing all dependencies, e.g.:
+
+```
+# CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"'
+```
+
 ## Developing the Provider
 
 ### Contributing Resources

--- a/_examples/cross-cluster/README.md
+++ b/_examples/cross-cluster/README.md
@@ -1,0 +1,27 @@
+# Example: Cross-cluster
+
+Running terraform in a kubernetes cluster but targetting another cluster, i.e. not using in-cluster config.
+
+## Prerequisites
+
+*This example uses syntax elements specific to Terraform version 0.12+.
+It will not work out-of-the-box with Terraform 0.11.x and lower.*
+
+
+Standard run:
+
+```
+# terraform apply \
+  -var "minikube_host_ip=$(minikube --profile kubernetes-1.16 ip)" \
+  -var "minikube_target_ip=$(minikube --profile kubernetes-1.15 ip)"
+```
+
+With a custom build:
+
+```
+# terraform apply \
+  -var "minikube_host_ip=$(minikube --profile kubernetes-1.16 ip)" \
+  -var "minikube_target_ip=$(minikube --profile kubernetes-1.15 ip)" \
+  -var "in_cluster_provider_version=v1.10.1-dev" \
+  -var "in_cluster_provider_url=https://storage.googleapis.com/my-custom-bucket/terraform-provider-kubernetes"
+```

--- a/_examples/cross-cluster/main.tf
+++ b/_examples/cross-cluster/main.tf
@@ -1,0 +1,94 @@
+variable "minikube_host_ip" {}
+variable "minikube_target_ip" {}
+
+variable "in_cluster_provider_version" {
+  default = "1.10.0"
+}
+variable "in_cluster_provider_url" {
+  default = ""
+}
+
+provider "kubernetes" {
+  version = "1.10.0"
+
+  host                   = "https://${var.minikube_host_ip}:8443"
+  client_certificate     = file("~/.minikube/client.crt")
+  client_key             = file("~/.minikube/client.key")
+  cluster_ca_certificate = file("~/.minikube/ca.crt")
+}
+
+resource "kubernetes_config_map" "terraform" {
+  metadata {
+    name = "terraform"
+  }
+
+  data = {
+    "main.tf" = <<-EOT
+      provider "kubernetes" {
+        version = "${var.in_cluster_provider_version}"
+
+        load_config_file = false
+      }
+
+      resource "kubernetes_namespace" "test" {
+        metadata {
+          name = "test"
+        }
+      }
+    EOT
+  }
+}
+
+resource "kubernetes_job" "terraform" {
+  metadata {
+    name = "terraform"
+  }
+  spec {
+    backoff_limit = 1
+    template {
+      metadata {}
+      spec {
+        container {
+          name  = "terraform"
+          image = "hashicorp/terraform:0.12.13"
+          command = [
+            "sh",
+            "-c",
+            "set && set -x && ${var.in_cluster_provider_url != "" ? "apk --no-cache add curl && mkdir -p ~/.terraform.d/plugins && curl ${var.in_cluster_provider_url} > ~/.terraform.d/plugins/terraform-provider-kubernetes_v${var.in_cluster_provider_version} && chmod +x ~/.terraform.d/plugins/* &&" : "&&"} mkdir /tf && cd /tf && cp /configuration/main.tf . && terraform init && TF_LOG=debug terraform plan && TF_LOG=debug terraform apply -auto-approve && sleep 10 && terraform destroy -auto-approve"
+          ]
+
+          env {
+            name  = "KUBE_HOST"
+            value = "https://${var.minikube_target_ip}:8443"
+          }
+          env {
+            name  = "KUBE_CLIENT_CERT_DATA"
+            value = file("~/.minikube/client.crt")
+          }
+          env {
+            name  = "KUBE_CLIENT_KEY_DATA"
+            value = file("~/.minikube/client.key")
+          }
+          env {
+            name  = "KUBE_CLUSTER_CA_CERT_DATA"
+            value = file("~/.minikube/ca.crt")
+          }
+
+          volume_mount {
+            name       = "configuration"
+            mount_path = "/configuration"
+          }
+        }
+
+        restart_policy = "Never"
+
+        volume {
+          name = "configuration"
+          config_map {
+            name = kubernetes_config_map.terraform.metadata[0].name
+          }
+        }
+      }
+    }
+  }
+}

--- a/_examples/cross-cluster/main.tf
+++ b/_examples/cross-cluster/main.tf
@@ -54,7 +54,7 @@ resource "kubernetes_job" "terraform" {
           command = [
             "sh",
             "-c",
-            "set && set -x && ${var.in_cluster_provider_url != "" ? "apk --no-cache add curl && mkdir -p ~/.terraform.d/plugins && curl ${var.in_cluster_provider_url} > ~/.terraform.d/plugins/terraform-provider-kubernetes_v${var.in_cluster_provider_version} && chmod +x ~/.terraform.d/plugins/* &&" : "&&"} mkdir /tf && cd /tf && cp /configuration/main.tf . && terraform init && TF_LOG=debug terraform plan && TF_LOG=debug terraform apply -auto-approve && sleep 10 && terraform destroy -auto-approve"
+            "set && set -x && ${var.in_cluster_provider_url != "" ? "apk --no-cache add curl && mkdir -p ~/.terraform.d/plugins && curl ${var.in_cluster_provider_url} > ~/.terraform.d/plugins/terraform-provider-kubernetes_v${var.in_cluster_provider_version} && chmod +x ~/.terraform.d/plugins/* &&" : ""} mkdir /tf && cd /tf && cp /configuration/main.tf . && terraform init && TF_LOG=debug terraform plan && TF_LOG=debug terraform apply -auto-approve && sleep 10 && terraform destroy -auto-approve"
           ]
 
           env {

--- a/_examples/google-gke-cluster/README.md
+++ b/_examples/google-gke-cluster/README.md
@@ -5,7 +5,7 @@ to create one from scratch is to use GKE (Google Container Service).
 
 You can read more about GKE at https://cloud.google.com/container-engine/
 
-## Prerequsities
+## Prerequisites
 
 *This example uses syntax elements specific to Terraform version 0.12+.
 It will not work out-of-the-box with Terraform 0.11.x and lower.*

--- a/_examples/http-nginx/README.md
+++ b/_examples/http-nginx/README.md
@@ -10,7 +10,7 @@ which is exposed to the internet through a load balancer (provisioned automatica
  - `kubernetes_replication_controller`
  - `kubernetes_service`
 
-## Prerequsites
+## Prerequisites
 
 *This example uses syntax elements specific to Terraform version 0.12+.
 It will not work out-of-the-box with Terraform 0.11.x and lower.*

--- a/_examples/in-cluster/README.md
+++ b/_examples/in-cluster/README.md
@@ -1,0 +1,25 @@
+# Example: In-cluster
+
+Running terraform in a kubernetes cluster and using in-cluster config.
+
+## Prerequisites
+
+*This example uses syntax elements specific to Terraform version 0.12+.
+It will not work out-of-the-box with Terraform 0.11.x and lower.*
+
+
+Standard run:
+
+```
+# terraform apply \
+  -var "minikube_host_ip=$(minikube --profile kubernetes-1.16 ip)"
+```
+
+With a custom build:
+
+```
+# terraform apply \
+  -var "minikube_host_ip=$(minikube --profile kubernetes-1.16 ip)" \
+  -var "in_cluster_provider_version=v1.10.1-dev" \
+  -var "in_cluster_provider_url=https://storage.googleapis.com/my-custom-bucket/terraform-provider-kubernetes"
+```

--- a/_examples/in-cluster/main.tf
+++ b/_examples/in-cluster/main.tf
@@ -82,7 +82,7 @@ resource "kubernetes_job" "terraform" {
           command = [
             "sh",
             "-c",
-            "set && set -x && ${var.in_cluster_provider_url != "" ? "apk --no-cache add curl && mkdir -p ~/.terraform.d/plugins && curl ${var.in_cluster_provider_url} > ~/.terraform.d/plugins/terraform-provider-kubernetes_v${var.in_cluster_provider_version} && chmod +x ~/.terraform.d/plugins/* &&" : "&&"} mkdir /tf && cd /tf && cp /configuration/main.tf . && terraform init && TF_LOG=debug terraform plan && TF_LOG=debug terraform apply -auto-approve && sleep 10 && terraform destroy -auto-approve"
+            "set && set -x && ${var.in_cluster_provider_url != "" ? "apk --no-cache add curl && mkdir -p ~/.terraform.d/plugins && curl ${var.in_cluster_provider_url} > ~/.terraform.d/plugins/terraform-provider-kubernetes_v${var.in_cluster_provider_version} && chmod +x ~/.terraform.d/plugins/* &&" : ""} mkdir /tf && cd /tf && cp /configuration/main.tf . && terraform init && TF_LOG=debug terraform plan && TF_LOG=debug terraform apply -auto-approve && sleep 10 && terraform destroy -auto-approve"
           ]
 
           volume_mount {

--- a/_examples/in-cluster/main.tf
+++ b/_examples/in-cluster/main.tf
@@ -1,0 +1,76 @@
+variable "minikube_host_ip" {}
+
+variable "in_cluster_provider_version" {
+  default = "1.10.0"
+}
+variable "in_cluster_provider_url" {
+  default = ""
+}
+
+provider "kubernetes" {
+  version = "1.10.0"
+
+  host                   = "https://${var.minikube_host_ip}:8443"
+  client_certificate     = file("~/.minikube/client.crt")
+  client_key             = file("~/.minikube/client.key")
+  cluster_ca_certificate = file("~/.minikube/ca.crt")
+}
+
+resource "kubernetes_config_map" "terraform" {
+  metadata {
+    name = "terraform"
+  }
+
+  data = {
+    "main.tf" = <<-EOT
+      provider "kubernetes" {
+        version = "${var.in_cluster_provider_version}"
+
+        load_config_file = false
+      }
+
+      resource "kubernetes_namespace" "test" {
+        metadata {
+          name = "test"
+        }
+      }
+    EOT
+  }
+}
+
+resource "kubernetes_job" "terraform" {
+  metadata {
+    name = "terraform"
+  }
+  spec {
+    backoff_limit = 1
+    template {
+      metadata {}
+      spec {
+        container {
+          name  = "terraform"
+          image = "hashicorp/terraform:0.12.13"
+          command = [
+            "sh",
+            "-c",
+            "set && set -x && ${var.in_cluster_provider_url != "" ? "apk --no-cache add curl && mkdir -p ~/.terraform.d/plugins && curl ${var.in_cluster_provider_url} > ~/.terraform.d/plugins/terraform-provider-kubernetes_v${var.in_cluster_provider_version} && chmod +x ~/.terraform.d/plugins/* &&" : "&&"} mkdir /tf && cd /tf && cp /configuration/main.tf . && terraform init && TF_LOG=debug terraform plan && TF_LOG=debug terraform apply -auto-approve && sleep 10 && terraform destroy -auto-approve"
+          ]
+
+          volume_mount {
+            name       = "configuration"
+            mount_path = "/configuration"
+          }
+        }
+
+        restart_policy = "Never"
+
+        volume {
+          name = "configuration"
+          config_map {
+            name = kubernetes_config_map.terraform.metadata[0].name
+          }
+        }
+      }
+    }
+  }
+}

--- a/_examples/ingress/README.md
+++ b/_examples/ingress/README.md
@@ -1,6 +1,6 @@
 # Example: Ingress
 
-## Prerequsites
+## Prerequisites
 
 *This example uses syntax elements specific to Terraform version 0.12+.
 It will not work out-of-the-box with Terraform 0.11.x and lower.*

--- a/_examples/wordpress-mysql-gce-pv/README.md
+++ b/_examples/wordpress-mysql-gce-pv/README.md
@@ -19,7 +19,7 @@ and [MySQL](https://www.mysql.com/) on Kubernetes.
 
  - `google_compute_disk`
 
-## Prerequsites
+## Prerequisites
 
 *This example uses syntax elements specific to Terraform version 0.12+.
 It will not work out-of-the-box with Terraform 0.11.x and lower.*

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -229,11 +229,13 @@ func initializeConfiguration(d *schema.ResourceData) (*restclient.Config, error)
 	loader := &clientcmd.ClientConfigLoadingRules{}
 
 	if d.Get("load_config_file").(bool) {
+		log.Printf("[DEBUG] Trying to load configuration from file")
 		if configPath, ok := d.GetOk("config_path"); ok && configPath.(string) != "" {
 			path, err := homedir.Expand(configPath.(string))
 			if err != nil {
 				return nil, err
 			}
+			log.Printf("[DEBUG] Configuration file is: %s", path)
 			loader.ExplicitPath = path
 
 			ctxSuffix := "; default context"

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -203,16 +203,7 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 		return nil, err
 	}
 	if cfg == nil {
-		// Attempt to load in-cluster config
-		cfg, err = restclient.InClusterConfig()
-		if err != nil {
-			// Fallback to standard config if we are not running inside a cluster
-			if err == restclient.ErrNotInCluster {
-				cfg = &restclient.Config{}
-			} else {
-				return nil, fmt.Errorf("Failed to configure: %s", err)
-			}
-		}
+		cfg = &restclient.Config{}
 	}
 
 	// Overriding with static configuration

--- a/website/docs/guides/getting-started.html.markdown
+++ b/website/docs/guides/getting-started.html.markdown
@@ -53,17 +53,28 @@ orchestration with Terraform presents a few benefits.
 ## Provider Setup
 
 The easiest way to configure the provider is by creating/generating a config
-in a default location (`~/.kube/config`). That allows you to leave the
-provider block completely empty.
+in a default location (`~/.kube/config`). That allows you
+to leave the provider block completely empty.
 
 ```hcl
 provider "kubernetes" {}
+```
+
+If running in-cluster with an appropriate service account token available, you 
+just need to disable config file loading:
+
+```hcl
+provider "kubernetes" {
+  load_config_file = "false"
+}
 ```
 
 If you wish to configure the provider statically you can do so by providing TLS certificates:
 
 ```hcl
 provider "kubernetes" {
+  load_config_file = "false"
+
   host = "https://104.196.242.174"
 
   client_certificate     = file("~/.kube/client-cert.pem")
@@ -76,6 +87,8 @@ or by providing username and password (HTTP Basic Authorization):
 
 ```hcl
 provider "kubernetes" {
+  load_config_file = "false"
+
   host = "https://104.196.242.174"
 
   username = "ClusterMaster"
@@ -93,7 +106,7 @@ Initializing the backend...
 
 Initializing provider plugins...
 - Checking for available provider plugins...
-- Downloading plugin for provider "kubernetes" (terraform-providers/kubernetes) 1.8.0...
+- Downloading plugin for provider "kubernetes" (terraform-providers/kubernetes) 1.10.1...
 
 The following providers do not have any version constraints in configuration,
 so the latest version was installed.
@@ -103,7 +116,7 @@ changes, it is recommended to add version = "..." constraints to the
 corresponding provider blocks in configuration, with the constraint strings
 suggested below.
 
-* provider.kubernetes: version = "~> 1.8"
+* provider.kubernetes: version = "~> 1.10.1"
 
 Terraform has been successfully initialized!
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -63,12 +63,29 @@ kubectl config use-context default-system
 
 Read [more about `kubectl` in the official docs](https://kubernetes.io/docs/user-guide/kubectl-overview/).
 
-### Statically defined credentials
+### In-cluster service account token
 
-The other way is **statically** define TLS certificate credentials:
+If no other configuration is specified, and when it detects it is running in a kubernetes pod,
+the provider will try to use the service account token from the `/var/run/secrets/kubernetes.io/serviceaccount/token` path.
+Detection of in-cluster execution is based on the sole availability both of the `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` environment variables,
+with non empty values.
 
 ```hcl
 provider "kubernetes" {
+  load_config_file = "false"
+}
+```
+
+If you have any other static configuration setting specifiedin a config file or static configuration, in-cluster service account token will not be tried.
+
+### Statically defined credentials
+
+An other way is **statically** define TLS certificate credentials:
+
+```hcl
+provider "kubernetes" {
+  load_config_file = "false"
+
   host = "https://104.196.242.174"
 
   client_certificate     = "${file("~/.kube/client-cert.pem")}"
@@ -81,6 +98,8 @@ or username and password (HTTP Basic Authorization):
 
 ```hcl
 provider "kubernetes" {
+  load_config_file = "false"
+
   host = "https://104.196.242.174"
 
   username = "username"
@@ -96,7 +115,7 @@ i.e. any static field will override its counterpart loaded from the config.
 
 The following arguments are supported:
 
-* `host` - (Optional) The hostname (in form of URI) of Kubernetes master. Can be sourced from `KUBE_HOST`. Defaults to `https://localhost`.
+* `host` - (Optional) The hostname (in form of URI) of Kubernetes master. Can be sourced from `KUBE_HOST`.
 * `username` - (Optional) The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint. Can be sourced from `KUBE_USER`.
 * `password` - (Optional) The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint. Can be sourced from `KUBE_PASSWORD`.
 * `insecure` - (Optional) Whether server should be accessed without verifying the TLS certificate. Can be sourced from `KUBE_INSECURE`. Defaults to `false`.
@@ -108,7 +127,7 @@ The following arguments are supported:
 * `config_context_auth_info` - (Optional) Authentication info context of the kube config (name of the kubeconfig user, `--user` flag in `kubectl`). Can be sourced from `KUBE_CTX_AUTH_INFO`.
 * `config_context_cluster` - (Optional) Cluster context of the kube config (name of the kubeconfig cluster, `--cluster` flag in `kubectl`). Can be sourced from `KUBE_CTX_CLUSTER`.
 * `token` - (Optional) Token of your service account.  Can be sourced from `KUBE_TOKEN`.
-* `load_config_file` - (Optional) By default the local config is loaded when you use this provider. This option at false disables this behaviour which is desired when statically specifying the configuration or relying on in-cluster config. Can be sourced from `KUBE_LOAD_CONFIG_FILE`.
+* `load_config_file` - (Optional) By default the local config (~/.kube/config) is loaded when you use this provider. This option at false disables this behaviour which is desired when statically specifying the configuration or relying on in-cluster config. Can be sourced from `KUBE_LOAD_CONFIG_FILE`.
 * `exec` - (Optional) Configuration block to use an [exec-based credential plugin] (https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins), e.g. call an external command to receive user credentials.
   * `api_version` - (Required) API version to use when decoding the ExecCredentials resource, e.g. `client.authentication.k8s.io/v1beta1`.
   * `command` - (Required) Command to execute.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -108,7 +108,7 @@ The following arguments are supported:
 * `config_context_auth_info` - (Optional) Authentication info context of the kube config (name of the kubeconfig user, `--user` flag in `kubectl`). Can be sourced from `KUBE_CTX_AUTH_INFO`.
 * `config_context_cluster` - (Optional) Cluster context of the kube config (name of the kubeconfig cluster, `--cluster` flag in `kubectl`). Can be sourced from `KUBE_CTX_CLUSTER`.
 * `token` - (Optional) Token of your service account.  Can be sourced from `KUBE_TOKEN`.
-* `load_config_file` - (Optional) By default the local config (~/.kube/config) is loaded when you use this provider. This option at false disable this behaviour. Can be sourced from `KUBE_LOAD_CONFIG_FILE`.
+* `load_config_file` - (Optional) By default the local config is loaded when you use this provider. This option at false disables this behaviour which is desired when statically specifying the configuration or relying on in-cluster config. Can be sourced from `KUBE_LOAD_CONFIG_FILE`.
 * `exec` - (Optional) Configuration block to use an [exec-based credential plugin] (https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins), e.g. call an external command to receive user credentials.
   * `api_version` - (Required) API version to use when decoding the ExecCredentials resource, e.g. `client.authentication.k8s.io/v1beta1`.
   * `command` - (Required) Command to execute.


### PR DESCRIPTION
This PR is an alternative to #686 that intends to:
- cleanup client config initialization a bit,
- make sure cross-cluster works (resolve #679),
- make sure in-cluster config works without needing extra work like #497.