### PR TITLE
New datasources: kubernetes_namespace & kubernetes_all_namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
--	[Go](https://golang.org/doc/install) 1.11.x (to build the provider plugin)
+-	[Go](https://golang.org/doc/install) 1.14.x (to build the provider plugin)
 
 ## Building The Provider
 

--- a/go.mod
+++ b/go.mod
@@ -40,4 +40,4 @@ replace (
 	k8s.io/client-go => k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90
 )
 
-go 1.13
+go 1.14

--- a/go.sum
+++ b/go.sum
@@ -759,7 +759,6 @@ howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCU
 k8s.io/api v0.0.0-20190918155943-95b840bb6a1f/go.mod h1:uWuOHnjmNrtQomJrvEBg0c0HRNyQ+8KTEERVsK0PW48=
 k8s.io/api v0.0.0-20191025225708-5524a3672fbb h1:XpnI7Pjlb0pMfI0hmHgWgaKqkp/JIL3JYYFN21AYCP8=
 k8s.io/api v0.0.0-20191025225708-5524a3672fbb/go.mod h1:NMIXwlJTrA+pXie6lv562GUPkluJ4oRGzQfqWBLaceY=
-k8s.io/api v0.18.1 h1:pnHr0LH69kvL29eHldoepUDKTuiOejNZI2A1gaxve3Q=
 k8s.io/apimachinery v0.0.0-20190204010555-a98ff070d70e/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655/go.mod h1:nL6pwRT8NgfF8TT68DBI8uEePRt89cSvoXUVqbkWHq4=
 k8s.io/apimachinery v0.0.0-20191025225532-af6325b3a843 h1:Ge6Np+ecN6pKYcAaFXR53I88+UL5ch+KpLxkKREpsJ4=
@@ -795,7 +794,6 @@ mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZI
 rsc.io/binaryregexp v0.2.0 h1:HfqmD5MEmC0zvwBuF187nq9mdnXjXsSivRiXN7SmRkE=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca h1:6dsH6AYQWbyZmtttJNe8Gq1cXOeS1BdV3eW37zHilAQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/kubernetes/data_source_kubernetes_all_namespaces.go
+++ b/kubernetes/data_source_kubernetes_all_namespaces.go
@@ -1,0 +1,56 @@
+package kubernetes
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func dataSourceKubernetesAllNamespaces() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceKubernetesAllNamespacesRead,
+		Schema: map[string]*schema.Schema{
+			"namespaces": {
+				Type:        schema.TypeList,
+				Description: "List of all namespaces in a cluster.",
+				Computed:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceKubernetesAllNamespacesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*KubeClientsets).MainClientset
+
+	log.Printf("[INFO] Listing namespaces")
+	nsRaw, err := conn.CoreV1().Namespaces().List(metav1.ListOptions{})
+	if err != nil {
+		log.Printf("[DEBUG] Received error: %#v", err)
+		return err
+	}
+	namespaces := make([]string, len(nsRaw.Items))
+	for i, v := range nsRaw.Items {
+		namespaces[i] = string(v.Name)
+	}
+	log.Printf("[INFO] Received namespaces: %#v", namespaces)
+	err = d.Set("namespaces", namespaces)
+	if err != nil {
+		return err
+	}
+	idsum := sha256.New()
+	for _, v := range namespaces {
+		_, err := idsum.Write([]byte(v))
+		if err != nil {
+			return err
+		}
+	}
+	id := fmt.Sprintf("%x", idsum.Sum(nil))
+	d.SetId(id)
+	return nil
+}

--- a/kubernetes/data_source_kubernetes_all_namespaces.go
+++ b/kubernetes/data_source_kubernetes_all_namespaces.go
@@ -26,7 +26,10 @@ func dataSourceKubernetesAllNamespaces() *schema.Resource {
 }
 
 func dataSourceKubernetesAllNamespacesRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Listing namespaces")
 	nsRaw, err := conn.CoreV1().Namespaces().List(metav1.ListOptions{})

--- a/kubernetes/data_source_kubernetes_all_namespaces_test.go
+++ b/kubernetes/data_source_kubernetes_all_namespaces_test.go
@@ -1,0 +1,33 @@
+package kubernetes
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccKubernetesDataSourceAllNamespaces_basic(t *testing.T) {
+	rxPosNum := regexp.MustCompile("^[1-9][0-9]*$")
+	nsName := regexp.MustCompile("^[a-zA-Z][-\\w]*$")
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesDataSourceAllNamespacesConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("data.kubernetes_all_namespaces.test", "namespaces.#", rxPosNum),
+					resource.TestCheckResourceAttrSet("data.kubernetes_all_namespaces.test", "namespaces.0"),
+					resource.TestMatchResourceAttr("data.kubernetes_all_namespaces.test", "namespaces.0", nsName),
+				),
+			},
+		},
+	})
+}
+
+func testAccKubernetesDataSourceAllNamespacesConfig_basic() string {
+	return `
+data "kubernetes_all_namespaces" "test" {}
+`
+}

--- a/kubernetes/data_source_kubernetes_namespace.go
+++ b/kubernetes/data_source_kubernetes_namespace.go
@@ -1,0 +1,73 @@
+package kubernetes
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func dataSourceKubernetesNamespace() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceKubernetesNamespaceRead,
+
+		Schema: map[string]*schema.Schema{
+			"metadata": metadataSchema("namespace", false),
+			"spec": {
+				Type:        schema.TypeList,
+				Description: "Spec defines the behavior of the Namespace.",
+				Computed:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"finalizers": {
+							Type:        schema.TypeList,
+							Description: "Finalizers is an opaque list of values that must be empty to permanently remove object from storage.",
+							Optional:    true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceKubernetesNamespaceRead(d *schema.ResourceData, meta interface{}) error {
+	name := d.Get("metadata.0.name").(string)
+	d.SetId(name)
+	conn := meta.(*KubeClientsets).MainClientset
+
+	log.Printf("[INFO] Reading namespace %s", name)
+	namespace, err := conn.CoreV1().Namespaces().Get(name, meta_v1.GetOptions{})
+	if err != nil {
+		log.Printf("[DEBUG] Received error: %#v", err)
+		return err
+	}
+	log.Printf("[INFO] Received namespace: %#v", namespace)
+	err = d.Set("metadata", flattenMetadata(namespace.ObjectMeta, d))
+	if err != nil {
+		return err
+	}
+	err = d.Set("spec", flattenNamespaceSpec(&namespace.Spec))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func flattenNamespaceSpec(in *v1.NamespaceSpec) []interface{} {
+	if in == nil || len(in.Finalizers) == 0 {
+		return []interface{}{}
+	}
+	spec := make(map[string]interface{})
+	fin := make([]string, len(in.Finalizers))
+	for i, f := range in.Finalizers {
+		fin[i] = string(f)
+	}
+	spec["finalizers"] = fin
+	return []interface{}{spec}
+}

--- a/kubernetes/data_source_kubernetes_namespace.go
+++ b/kubernetes/data_source_kubernetes_namespace.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"k8s.io/client-go/metadata"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -46,7 +45,6 @@ func dataSourceKubernetesNamespaceRead(d *schema.ResourceData, meta interface{})
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	d.SetId(metadata.Name)
 
-	log.Printf("[INFO] Reading namespace %s", name)
 	namespace, err := conn.CoreV1().Namespaces().Get(metadata.Name, meta_v1.GetOptions{})
 	if err != nil {
 		log.Printf("[DEBUG] Received error: %#v", err)

--- a/kubernetes/data_source_kubernetes_namespace_test.go
+++ b/kubernetes/data_source_kubernetes_namespace_test.go
@@ -1,0 +1,39 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccKubernetesDataSourceNamespace_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesDataSourceNamespaceConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.kubernetes_namespace.test", "metadata.0.name", "kube-system"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_namespace.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_namespace.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_namespace.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_namespace.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("data.kubernetes_namespace.test", "spec.#", "1"),
+					resource.TestCheckResourceAttr("data.kubernetes_namespace.test", "spec.0.finalizers.#", "1"),
+					resource.TestCheckResourceAttr("data.kubernetes_namespace.test", "spec.0.finalizers.0", "kubernetes"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKubernetesDataSourceNamespaceConfig_basic() string {
+	return `
+data "kubernetes_namespace" "test" {
+	metadata {
+		name = "kube-system"
+	}
+}
+`
+}

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -137,10 +137,10 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"kubernetes_all_namespaces": dataSourceKubernetesAllNamespaces(),
+			"kubernetes_all_namespaces":  dataSourceKubernetesAllNamespaces(),
 			"kubernetes_config_map":      dataSourceKubernetesConfigMap(),
 			"kubernetes_ingress":         dataSourceKubernetesIngress(),
-			"kubernetes_namespace":     dataSourceKubernetesNamespace(),
+			"kubernetes_namespace":       dataSourceKubernetesNamespace(),
 			"kubernetes_secret":          dataSourceKubernetesSecret(),
 			"kubernetes_service":         dataSourceKubernetesService(),
 			"kubernetes_service_account": dataSourceKubernetesServiceAccount(),

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -139,6 +139,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"kubernetes_config_map":      dataSourceKubernetesConfigMap(),
 			"kubernetes_ingress":         dataSourceKubernetesIngress(),
+			"kubernetes_namespace":     dataSourceKubernetesNamespace(),
 			"kubernetes_secret":          dataSourceKubernetesSecret(),
 			"kubernetes_service":         dataSourceKubernetesService(),
 			"kubernetes_service_account": dataSourceKubernetesServiceAccount(),

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -137,6 +137,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"kubernetes_all_namespaces": dataSourceKubernetesAllNamespaces(),
 			"kubernetes_config_map":      dataSourceKubernetesConfigMap(),
 			"kubernetes_ingress":         dataSourceKubernetesIngress(),
 			"kubernetes_namespace":     dataSourceKubernetesNamespace(),

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -14,9 +14,11 @@ cloud.google.com/go/bigtable/internal/option
 # cloud.google.com/go/storage v1.0.0
 cloud.google.com/go/storage
 # github.com/Azure/go-autorest/autorest v0.9.2
+## explicit
 github.com/Azure/go-autorest/autorest
 github.com/Azure/go-autorest/autorest/azure
 # github.com/Azure/go-autorest/autorest/adal v0.8.1-0.20191028180845-3492b2aff503
+## explicit
 github.com/Azure/go-autorest/autorest/adal
 # github.com/Azure/go-autorest/autorest/date v0.2.0
 github.com/Azure/go-autorest/autorest/date
@@ -216,11 +218,14 @@ github.com/davecgh/go-spew/spew
 github.com/dgrijalva/jwt-go
 # github.com/fatih/color v1.7.0
 github.com/fatih/color
+# github.com/frankban/quicktest v1.4.2
+## explicit
 # github.com/gammazero/deque v0.0.0-20180920172122-f6adf94963e4
 github.com/gammazero/deque
 # github.com/gammazero/workerpool v0.0.0-20181230203049-86a96b5d5d92
 github.com/gammazero/workerpool
 # github.com/gogo/protobuf v1.3.0
+## explicit
 github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/sortkeys
 # github.com/golang/protobuf v1.3.2
@@ -240,6 +245,7 @@ github.com/golang/protobuf/ptypes/wrappers
 # github.com/golang/snappy v0.0.1
 github.com/golang/snappy
 # github.com/google/go-cmp v0.3.1
+## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
@@ -252,10 +258,12 @@ github.com/google/uuid
 # github.com/googleapis/gax-go/v2 v2.0.5
 github.com/googleapis/gax-go/v2
 # github.com/googleapis/gnostic v0.2.0
+## explicit
 github.com/googleapis/gnostic/OpenAPIv2
 github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 # github.com/gophercloud/gophercloud v0.3.1-0.20190807175045-25a84d593c97
+## explicit
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/openstack
 github.com/gophercloud/gophercloud/openstack/identity/v2/tenants
@@ -270,6 +278,7 @@ github.com/hashicorp/errwrap
 # github.com/hashicorp/go-cleanhttp v0.5.1
 github.com/hashicorp/go-cleanhttp
 # github.com/hashicorp/go-getter v1.4.2-0.20200106182914-9813cbd4eb02
+## explicit
 github.com/hashicorp/go-getter
 github.com/hashicorp/go-getter/helper/url
 # github.com/hashicorp/go-hclog v0.9.2
@@ -284,6 +293,7 @@ github.com/hashicorp/go-safetemp
 # github.com/hashicorp/go-uuid v1.0.1
 github.com/hashicorp/go-uuid
 # github.com/hashicorp/go-version v1.2.0
+## explicit
 github.com/hashicorp/go-version
 # github.com/hashicorp/golang-lru v0.5.1
 github.com/hashicorp/golang-lru/simplelru
@@ -298,6 +308,7 @@ github.com/hashicorp/hcl/json/parser
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
 # github.com/hashicorp/hcl/v2 v2.3.0
+## explicit
 github.com/hashicorp/hcl/v2
 github.com/hashicorp/hcl/v2/ext/customdecode
 github.com/hashicorp/hcl/v2/ext/dynblock
@@ -312,10 +323,12 @@ github.com/hashicorp/hcl/v2/json
 # github.com/hashicorp/logutils v1.0.0
 github.com/hashicorp/logutils
 # github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7
+## explicit
 github.com/hashicorp/terraform-config-inspect/tfconfig
 # github.com/hashicorp/terraform-json v0.4.0
 github.com/hashicorp/terraform-json
 # github.com/hashicorp/terraform-plugin-sdk v1.7.0
+## explicit
 github.com/hashicorp/terraform-plugin-sdk/acctest
 github.com/hashicorp/terraform-plugin-sdk/helper/acctest
 github.com/hashicorp/terraform-plugin-sdk/helper/customdiff
@@ -374,13 +387,17 @@ github.com/hashicorp/terraform-plugin-test
 github.com/hashicorp/terraform-svchost
 github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
+# github.com/hashicorp/vault v1.1.2
+## explicit
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
 # github.com/imdario/mergo v0.3.7
+## explicit
 github.com/imdario/mergo
 # github.com/jen20/awspolicyequivalence v1.0.0
 github.com/jen20/awspolicyequivalence
 # github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
+## explicit
 github.com/jinzhu/copier
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 github.com/jmespath/go-jmespath
@@ -391,6 +408,7 @@ github.com/jstemmer/go-junit-report
 github.com/jstemmer/go-junit-report/formatter
 github.com/jstemmer/go-junit-report/parser
 # github.com/keybase/go-crypto v0.0.0-20190416182011-b785b22cc757
+## explicit
 github.com/keybase/go-crypto/brainpool
 github.com/keybase/go-crypto/cast5
 github.com/keybase/go-crypto/curve25519
@@ -418,6 +436,7 @@ github.com/mitchellh/colorstring
 # github.com/mitchellh/copystructure v1.0.0
 github.com/mitchellh/copystructure
 # github.com/mitchellh/go-homedir v1.1.0
+## explicit
 github.com/mitchellh/go-homedir
 # github.com/mitchellh/go-testing-interface v1.0.0
 github.com/mitchellh/go-testing-interface
@@ -436,6 +455,7 @@ github.com/modern-go/reflect2
 # github.com/oklog/run v1.0.0
 github.com/oklog/run
 # github.com/pierrec/lz4 v2.3.0+incompatible
+## explicit
 github.com/pierrec/lz4
 github.com/pierrec/lz4/internal/xxh32
 # github.com/posener/complete v1.2.1
@@ -444,6 +464,7 @@ github.com/posener/complete/cmd
 github.com/posener/complete/cmd/install
 github.com/posener/complete/match
 # github.com/robfig/cron v1.2.0
+## explicit
 github.com/robfig/cron
 # github.com/spf13/afero v1.2.2
 github.com/spf13/afero
@@ -453,18 +474,24 @@ github.com/spf13/pflag
 # github.com/stoewer/go-strcase v1.0.2
 github.com/stoewer/go-strcase
 # github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20191010190908-1261a98537f2
+## explicit
 github.com/terraform-providers/terraform-provider-aws/aws
 github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap
 github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags
 # github.com/terraform-providers/terraform-provider-google v1.20.1-0.20191008212436-363f2d283518
+## explicit
 github.com/terraform-providers/terraform-provider-google/google
 github.com/terraform-providers/terraform-provider-google/version
+# github.com/terraform-providers/terraform-provider-random v1.3.2-0.20190925210718-83518d96ae4f
+## explicit
 # github.com/ulikunitz/xz v0.5.6
+## explicit
 github.com/ulikunitz/xz
 github.com/ulikunitz/xz/internal/hash
 github.com/ulikunitz/xz/internal/xlog
 github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v4.0.4+incompatible
+## explicit
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
 # github.com/zclconf/go-cty v1.2.1
@@ -715,6 +742,7 @@ honnef.co/go/tools/stylecheck
 honnef.co/go/tools/unused
 honnef.co/go/tools/version
 # k8s.io/api v0.0.0-20191025225708-5524a3672fbb
+## explicit
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
 k8s.io/api/apps/v1
@@ -754,6 +782,7 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apimachinery v0.0.0-20191025225532-af6325b3a843
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -793,6 +822,7 @@ k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/client-go v10.0.0+incompatible => k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/kubernetes
 k8s.io/client-go/kubernetes/scheme
@@ -864,6 +894,7 @@ k8s.io/client-go/util/keyutil
 # k8s.io/klog v1.0.0
 k8s.io/klog
 # k8s.io/kube-aggregator v0.0.0-20191025230902-aa872b06629d
+## explicit
 k8s.io/kube-aggregator/pkg/apis/apiregistration
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1
@@ -876,3 +907,5 @@ k8s.io/utils/integer
 k8s.io/utils/pointer
 # sigs.k8s.io/yaml v1.1.0
 sigs.k8s.io/yaml
+# github.com/Azure/go-autorest v11.1.2+incompatible => github.com/Azure/go-autorest v12.1.0+incompatible
+# k8s.io/client-go => k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90

--- a/website/docs/d/all_namespaces.html.markdown
+++ b/website/docs/d/all_namespaces.html.markdown
@@ -1,0 +1,29 @@
+---
+layout: "kubernetes"
+page_title: "Kubernetes: kubernetes_all_namespaces"
+sidebar_current: "docs-kubernetes-data-source-all-namespaces"
+description: |-
+  Lists all namespaces within a cluster.
+---
+
+# kubernetes_all_namespaces
+
+This data source provides a mechanism for listing the names of all available namespaces in a Kubernetes cluster.
+It can be used check for existence of a specific namespaces or to apply another resource to all or a subset of existing namespaces in a cluster.
+
+In Kubernetes, namespaces provide a scope for names and are intended as a way to divide cluster resources between multiple users.
+
+## Example Usage
+
+```hcl
+data "kubernetes_all_namespaces" "allns" {}
+
+output "all-ns" {
+  value = data.kubernetes_all_namespaces.allns.namespaces
+}
+
+output "ns-present" {
+  value = contains(data.kubernetes_all_namespaces.allns.namespaces, "kube-system")
+}
+
+```

--- a/website/docs/d/all_namespaces.html.markdown
+++ b/website/docs/d/all_namespaces.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # kubernetes_all_namespaces
 
 This data source provides a mechanism for listing the names of all available namespaces in a Kubernetes cluster.
-It can be used check for existence of a specific namespaces or to apply another resource to all or a subset of existing namespaces in a cluster.
+It can be used to check for existence of a specific namespaces or to apply another resource to all or a subset of existing namespaces in a cluster.
 
 In Kubernetes, namespaces provide a scope for names and are intended as a way to divide cluster resources between multiple users.
 

--- a/website/docs/d/namespace.html.markdown
+++ b/website/docs/d/namespace.html.markdown
@@ -1,0 +1,55 @@
+---
+layout: "kubernetes"
+page_title: "Kubernetes: kubernetes_namespace"
+sidebar_current: "docs-kubernetes-data-source-namespace"
+description: |-
+  Queries attributes of a Namespace within the cluster.
+---
+
+# kubernetes_namespace
+
+This data source provides a mechanism to query attributes of any specific namespace within a Kubernetes cluster.
+In Kubernetes, namespaces provide a scope for names and are intended as a way to divide cluster resources between multiple users.
+
+## Example Usage
+
+```hcl
+data "kubernetes_namespace" "example" {
+  metadata {
+    name = "kube-system"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `metadata` - (Required) Standard object metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
+
+## Nested Blocks
+
+### `metadata`
+
+#### Arguments
+
+* `name` - (Required) Name of the namespace, must be unique. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+
+#### Attributes
+
+* `annotations` - (Optional) An unstructured key value map stored with the namespace that may be used to store arbitrary metadata.
+**By default, the provider ignores any annotations whose key names end with *kubernetes.io*. This is necessary because such annotations can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such annotations in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/annotations)
+* `generation` - A sequence number representing a specific generation of the desired state.
+* `labels` - (Optional) Map of string keys and values that can be used to organize and categorize (scope and select) namespaces. May match selectors of replication controllers and services.
+**By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
+For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
+* `resource_version` - An opaque value that represents the internal version of this namespace that can be used by clients to determine when namespaces have changed. Read more about [concurrency control and consistency](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency).
+* `self_link` - A URL representing this namespace.
+* `uid` - The unique in time and space value for this namespace. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#uids)
+
+### `spec`
+
+#### Attributes
+
+* `finalizers` - An opaque list of values that must be empty to permanently remove object from storage. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/

--- a/website/kubernetes.erb
+++ b/website/kubernetes.erb
@@ -18,11 +18,16 @@
         <li<%= sidebar_current("docs-kubernetes-data-source") %>>
           <a href="#">Data Sources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-kubernetes-data-source-all-namespaces") %>>
+              <a href="/docs/providers/kubernetes/d/all_namespaces.html">kubernetes_all_namespaces</a>
+            </li>
             <li<%= sidebar_current("docs-kubernetes-data-source-config-map") %>>
               <a href="/docs/providers/kubernetes/d/config_map.html">kubernetes_config_map</a>
             </li>
             <li<%= sidebar_current("docs-kubernetes-data-source-ingress") %>>
               <a href="/docs/providers/kubernetes/d/ingress.html">kubernetes_ingress</a>
+            <li<%= sidebar_current("docs-kubernetes-data-source-namespace") %>>
+              <a href="/docs/providers/kubernetes/d/namespace.html">kubernetes_namespace</a>
             </li>
             <li<%= sidebar_current("docs-kubernetes-data-source-secret") %>>
               <a href="/docs/providers/kubernetes/d/secret.html">kubernetes_secret</a>


### PR DESCRIPTION
This change introduces a couple of new data sources for reading Kubernetes Namespace resources.
* `kubernetes_namespace` is a standard data source that exposes the attributes of a given namespace.
* `kubernetes_all_namespaces` is an enumerating data source that lists all available namespaces within a cluster. It can be used to test for the presence of a specific namespace or for applying a resource to all namespaces.


Test results:
```
» make testacc TESTARGS="-run '^TestAccKubernetes.*Namespace.*'"                                                             alex@MacBook-Pro-2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test "./kubernetes" -v -run '^TestAccKubernetes.*Namespace.*' -timeout 120m
=== RUN   TestAccKubernetesDataSourceAllNamespaces_basic
--- PASS: TestAccKubernetesDataSourceAllNamespaces_basic (0.75s)
=== RUN   TestAccKubernetesDataSourceNamespace_basic
--- PASS: TestAccKubernetesDataSourceNamespace_basic (0.54s)
=== RUN   TestAccKubernetesNamespace_basic
--- PASS: TestAccKubernetesNamespace_basic (10.48s)
=== RUN   TestAccKubernetesNamespace_importBasic
--- PASS: TestAccKubernetesNamespace_importBasic (7.93s)
=== RUN   TestAccKubernetesNamespace_generatedName
--- PASS: TestAccKubernetesNamespace_generatedName (7.76s)
=== RUN   TestAccKubernetesNamespace_withSpecialCharacters
--- PASS: TestAccKubernetesNamespace_withSpecialCharacters (7.53s)
=== RUN   TestAccKubernetesNamespace_importGeneratedName
--- PASS: TestAccKubernetesNamespace_importGeneratedName (7.68s)
=== RUN   TestAccKubernetesNamespace_deleteTimeout
--- PASS: TestAccKubernetesNamespace_deleteTimeout (7.61s)
PASS
ok  	github.com/terraform-providers/terraform-provider-kubernetes/kubernetes	52.597s
------------------------------------------------------------
```