### PR TITLE
Fix (cluster-)role bindings and rules updates

### DIFF
--- a/kubernetes/resource_kubernetes_cluster_role_binding_test.go
+++ b/kubernetes/resource_kubernetes_cluster_role_binding_test.go
@@ -214,6 +214,34 @@ func TestAccKubernetesClusterRoleBindingBug(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.1.kind", "User"),
 				),
 			},
+			{
+				Config: testAccKubernetesClusterRoleBindingConfigBug_step_3(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesClusterRoleBindingExists("kubernetes_cluster_role_binding.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_cluster_role_binding.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_cluster_role_binding.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_cluster_role_binding.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_cluster_role_binding.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "role_ref.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "role_ref.0.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "role_ref.0.kind", "ClusterRole"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "role_ref.0.name", "cluster-admin"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.#", "4"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.0.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.0.name", "notauser0"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.0.kind", "User"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.1.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.1.name", "notauser1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.1.kind", "User"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.2.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.2.name", "notauser2"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.2.kind", "User"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.3.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.3.name", "notauser3"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.3.kind", "User"),
+				),
+			},
 		},
 	})
 }
@@ -360,7 +388,7 @@ func testAccKubernetesClusterRoleBindingConfigBug_step_1(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_cluster_role_binding" "test" {
     metadata {
-        name             = "%s"
+        name = "%s"
     }
 
     role_ref {
@@ -392,7 +420,7 @@ func testAccKubernetesClusterRoleBindingConfigBug_step_2(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_cluster_role_binding" "test" {
     metadata {
-        name             = "%s"
+        name = "%s"
     }
 
     role_ref {
@@ -410,6 +438,43 @@ resource "kubernetes_cluster_role_binding" "test" {
         api_group = "rbac.authorization.k8s.io"
         kind      = "User"
         name      = "notauser4"
+    }
+}
+`, name)
+}
+
+func testAccKubernetesClusterRoleBindingConfigBug_step_3(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_cluster_role_binding" "test" {
+    metadata {
+        name = "%s"
+    }
+
+    role_ref {
+        api_group = "rbac.authorization.k8s.io"
+        kind      = "ClusterRole"
+        name      = "cluster-admin"
+    }
+
+    subject {
+        api_group = "rbac.authorization.k8s.io"
+        kind      = "User"
+        name      = "notauser0"
+    }
+    subject {
+        api_group = "rbac.authorization.k8s.io"
+        kind      = "User"
+        name      = "notauser1"
+    }
+    subject {
+        api_group = "rbac.authorization.k8s.io"
+        kind      = "User"
+        name      = "notauser2"
+    }
+    subject {
+        api_group = "rbac.authorization.k8s.io"
+        kind      = "User"
+        name      = "notauser3"
     }
 }
 `, name)

--- a/kubernetes/resource_kubernetes_cluster_role_binding_test.go
+++ b/kubernetes/resource_kubernetes_cluster_role_binding_test.go
@@ -168,7 +168,7 @@ func TestAccKubernetesClusterRoleBindingBug(t *testing.T) {
 		CheckDestroy:  testAccCheckKubernetesClusterRoleBindingDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesClusterRoleBindingConfigBug_step_1(name),
+				Config: testAccKubernetesClusterRoleBindingConfigBug_step_0(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesClusterRoleBindingExists("kubernetes_cluster_role_binding.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "metadata.0.name", name),
@@ -193,7 +193,7 @@ func TestAccKubernetesClusterRoleBindingBug(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesClusterRoleBindingConfigBug_step_2(name),
+				Config: testAccKubernetesClusterRoleBindingConfigBug_step_1(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesClusterRoleBindingExists("kubernetes_cluster_role_binding.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "metadata.0.name", name),
@@ -215,7 +215,7 @@ func TestAccKubernetesClusterRoleBindingBug(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesClusterRoleBindingConfigBug_step_3(name),
+				Config: testAccKubernetesClusterRoleBindingConfigBug_step_2(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesClusterRoleBindingExists("kubernetes_cluster_role_binding.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "metadata.0.name", name),
@@ -384,7 +384,7 @@ resource "kubernetes_cluster_role_binding" "test" {
 `, name)
 }
 
-func testAccKubernetesClusterRoleBindingConfigBug_step_1(name string) string {
+func testAccKubernetesClusterRoleBindingConfigBug_step_0(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_cluster_role_binding" "test" {
     metadata {
@@ -416,7 +416,7 @@ resource "kubernetes_cluster_role_binding" "test" {
 `, name)
 }
 
-func testAccKubernetesClusterRoleBindingConfigBug_step_2(name string) string {
+func testAccKubernetesClusterRoleBindingConfigBug_step_1(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_cluster_role_binding" "test" {
     metadata {
@@ -443,7 +443,7 @@ resource "kubernetes_cluster_role_binding" "test" {
 `, name)
 }
 
-func testAccKubernetesClusterRoleBindingConfigBug_step_3(name string) string {
+func testAccKubernetesClusterRoleBindingConfigBug_step_2(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_cluster_role_binding" "test" {
     metadata {

--- a/kubernetes/resource_kubernetes_cluster_role_binding_test.go
+++ b/kubernetes/resource_kubernetes_cluster_role_binding_test.go
@@ -66,6 +66,58 @@ func TestAccKubernetesClusterRoleBinding(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.2.kind", "Group"),
 				),
 			},
+			{
+				Config: testAccKubernetesClusterRoleBindingConfig_modified_role_ref(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesClusterRoleBindingExists("kubernetes_cluster_role_binding.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_cluster_role_binding.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_cluster_role_binding.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_cluster_role_binding.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_cluster_role_binding.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "role_ref.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "role_ref.0.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "role_ref.0.kind", "ClusterRole"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "role_ref.0.name", "admin"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.#", "3"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.0.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.0.name", "notauser"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.0.kind", "User"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.1.namespace", "kube-system"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.1.name", "default"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.1.kind", "ServiceAccount"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.1.api_group", ""),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.2.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.2.name", "system:masters"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.2.kind", "Group"),
+				),
+			},
+			{
+				Config: testAccKubernetesClusterRoleBindingConfig_modified(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesClusterRoleBindingExists("kubernetes_cluster_role_binding.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_cluster_role_binding.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_cluster_role_binding.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_cluster_role_binding.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_cluster_role_binding.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "role_ref.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "role_ref.0.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "role_ref.0.kind", "ClusterRole"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "role_ref.0.name", "cluster-admin"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.#", "3"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.0.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.0.name", "notauser"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.0.kind", "User"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.1.namespace", "kube-system"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.1.name", "default"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.1.kind", "ServiceAccount"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.1.api_group", ""),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.2.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.2.name", "system:masters"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role_binding.test", "subject.2.kind", "Group"),
+				),
+			},
 		},
 	})
 }
@@ -317,6 +369,43 @@ resource "kubernetes_cluster_role_binding" "test" {
     api_group = "rbac.authorization.k8s.io"
     kind      = "ClusterRole"
     name      = "cluster-admin"
+  }
+
+  subject {
+    kind      = "User"
+    name      = "notauser"
+    api_group = "rbac.authorization.k8s.io"
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = "default"
+    api_group = ""
+    namespace = "kube-system"
+  }
+
+  subject {
+    kind      = "Group"
+    name      = "system:masters"
+    api_group = "rbac.authorization.k8s.io"
+  }
+}
+`, name)
+}
+
+func testAccKubernetesClusterRoleBindingConfig_modified_role_ref(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_cluster_role_binding" "test" {
+  metadata {
+    name = "%s"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+	# The kind field only accepts this value, anything else returns an error:
+	# roleRef.kind: Unsupported value: "Role": supported values: "ClusterRole"
+	kind      = "ClusterRole"
+    name      = "admin"
   }
 
   subject {

--- a/kubernetes/resource_kubernetes_cluster_role_binding_test.go
+++ b/kubernetes/resource_kubernetes_cluster_role_binding_test.go
@@ -209,7 +209,7 @@ func TestAccKubernetesClusterRoleBinding_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesClusterRoleBindingBug(t *testing.T) {
+func TestAccKubernetesClusterRoleBindingUpdatePatchOperationsOrderWithRemovals(t *testing.T) {
 	var conf api.ClusterRoleBinding
 	name := fmt.Sprintf("tf-acc-test:%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 

--- a/kubernetes/resource_kubernetes_cluster_role_test.go
+++ b/kubernetes/resource_kubernetes_cluster_role_test.go
@@ -77,7 +77,7 @@ func TestAccKubernetesClusterRole_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesClusterRoleBug(t *testing.T) {
+func TestAccKubernetesClusterRoleUpdatePatchOperationsOrderWithRemovals(t *testing.T) {
 	var conf api.ClusterRole
 	name := fmt.Sprintf("tf-acc-test:%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	resource.Test(t, resource.TestCase{

--- a/kubernetes/resource_kubernetes_cluster_role_test.go
+++ b/kubernetes/resource_kubernetes_cluster_role_test.go
@@ -55,6 +55,7 @@ func TestAccKubernetesClusterRole_basic(t *testing.T) {
 		},
 	})
 }
+
 func TestAccKubernetesClusterRole_importBasic(t *testing.T) {
 	resourceName := "kubernetes_cluster_role.test"
 	name := fmt.Sprintf("tf-acc-test:%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
@@ -75,6 +76,80 @@ func TestAccKubernetesClusterRole_importBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccKubernetesClusterRoleBug(t *testing.T) {
+	var conf api.ClusterRole
+	name := fmt.Sprintf("tf-acc-test:%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "kubernetes_cluster_role.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesClusterRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesClusterRoleConfigBug_step_0(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesClusterRoleExists("kubernetes_cluster_role.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.#", "3"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.0.resources.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.0.resources.0", "pods"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.0.verbs.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.0.verbs.0", "get"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.1.resources.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.1.resources.0", "deployments"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.1.verbs.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.1.verbs.0", "list"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.2.non_resource_urls.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.2.non_resource_urls.0", "/metrics"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.2.verbs.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.2.verbs.0", "get"),
+				),
+			},
+			{
+				Config: testAccKubernetesClusterRoleConfigBug_step_1(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesClusterRoleExists("kubernetes_cluster_role.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.0.resources.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.0.resources.0", "deployments"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.0.verbs.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.0.verbs.0", "get"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.0.verbs.1", "list"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.1.api_groups.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.1.resources.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.1.resources.0", "jobs"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.1.verbs.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.1.verbs.0", "get"),
+				),
+			},
+			{
+				Config: testAccKubernetesClusterRoleConfigBug_step_2(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesClusterRoleExists("kubernetes_cluster_role.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.#", "4"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.0.resources.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.0.resources.0", "pods"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.0.verbs.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.0.verbs.0", "list"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.1.resources.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.1.resources.0", "deployments"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.1.verbs.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.1.verbs.0", "list"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.2.non_resource_urls.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.2.non_resource_urls.0", "/metrics"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.2.verbs.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.2.verbs.0", "get"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.3.api_groups.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.3.resources.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.3.resources.0", "jobs"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.3.verbs.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cluster_role.test", "rule.3.verbs.0", "get"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckKubernetesClusterRoleDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
 	for _, rs := range s.RootModule().Resources {
@@ -90,6 +165,7 @@ func testAccCheckKubernetesClusterRoleDestroy(s *terraform.State) error {
 	}
 	return nil
 }
+
 func testAccCheckKubernetesClusterRoleExists(n string, obj *api.ClusterRole) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -105,6 +181,7 @@ func testAccCheckKubernetesClusterRoleExists(n string, obj *api.ClusterRole) res
 		return nil
 	}
 }
+
 func testAccKubernetesClusterRoleConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_cluster_role" "test" {
@@ -117,7 +194,7 @@ resource "kubernetes_cluster_role" "test" {
 
     name = "%s"
   }
-  
+
   rule {
     api_groups = [""]
     resources  = ["pods", "pods/log"]
@@ -126,6 +203,7 @@ resource "kubernetes_cluster_role" "test" {
 }
 `, name)
 }
+
 func testAccKubernetesClusterRoleConfig_modified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_cluster_role" "test" {
@@ -153,6 +231,88 @@ resource "kubernetes_cluster_role" "test" {
   rule {
     non_resource_urls = ["/metrics"]
     verbs = ["get"]
+  }
+}
+`, name)
+}
+
+func testAccKubernetesClusterRoleConfigBug_step_0(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_cluster_role" "test" {
+  metadata {
+    name = "%s"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["pods"]
+    verbs      = ["get"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["deployments"]
+    verbs      = ["list"]
+  }
+
+  rule {
+    non_resource_urls = ["/metrics"]
+    verbs             = ["get"]
+  }
+}
+`, name)
+}
+
+func testAccKubernetesClusterRoleConfigBug_step_1(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_cluster_role" "test" {
+  metadata {
+    name = "%s"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["deployments"]
+    verbs      = ["get", "list"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["jobs"]
+    verbs      = ["get"]
+  }
+}
+`, name)
+}
+
+func testAccKubernetesClusterRoleConfigBug_step_2(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_cluster_role" "test" {
+  metadata {
+    name = "%s"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["pods"]
+    verbs      = ["list"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["deployments"]
+    verbs      = ["list"]
+  }
+
+  rule {
+    non_resource_urls = ["/metrics"]
+    verbs             = ["get"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["jobs"]
+    verbs      = ["get"]
   }
 }
 `, name)

--- a/kubernetes/resource_kubernetes_role_binding_test.go
+++ b/kubernetes/resource_kubernetes_role_binding_test.go
@@ -158,6 +158,95 @@ func TestAccKubernetesRoleBinding_group_subject(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesRoleBindingBug(t *testing.T) {
+	var conf api.RoleBinding
+	name := fmt.Sprintf("tf-acc-test:%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "kubernetes_role_binding.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesRoleBindingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesRoleBindingConfigBug_step_1(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesRoleBindingExists("kubernetes_role_binding.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.0.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.0.kind", "Role"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.0.name", "admin"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.#", "3"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.0.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.0.name", "notauser1"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.0.kind", "User"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.1.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.1.name", "notauser2"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.1.kind", "User"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.2.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.2.name", "notauser3"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.2.kind", "User"),
+				),
+			},
+			{
+				Config: testAccKubernetesRoleBindingConfigBug_step_2(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesRoleBindingExists("kubernetes_role_binding.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.0.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.0.kind", "Role"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.0.name", "admin"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.0.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.0.name", "notauser2"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.0.kind", "User"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.1.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.1.name", "notauser4"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.1.kind", "User"),
+				),
+			},
+			{
+				Config: testAccKubernetesRoleBindingConfigBug_step_3(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesRoleBindingExists("kubernetes_role_binding.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.0.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.0.kind", "Role"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.0.name", "admin"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.#", "4"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.0.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.0.name", "notauser0"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.0.kind", "User"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.1.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.1.name", "notauser1"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.1.kind", "User"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.2.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.2.name", "notauser2"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.2.kind", "User"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.3.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.3.name", "notauser3"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.3.kind", "User"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckKubernetesRoleBindingDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
 
@@ -303,6 +392,105 @@ resource "kubernetes_role_binding" "test" {
     name      = "somegroup"
     api_group = "rbac.authorization.k8s.io"
   }
+}
+`, name)
+}
+
+func testAccKubernetesRoleBindingConfigBug_step_1(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_role_binding" "test" {
+    metadata {
+		name      = "%s"
+		namespace = "default"
+    }
+
+    role_ref {
+        api_group = "rbac.authorization.k8s.io"
+        kind      = "Role"
+        name      = "admin"
+    }
+
+    subject {
+        api_group = "rbac.authorization.k8s.io"
+        kind      = "User"
+        name      = "notauser1"
+    }
+    subject {
+        api_group = "rbac.authorization.k8s.io"
+        kind      = "User"
+        name      = "notauser2"
+    }
+    subject {
+        api_group = "rbac.authorization.k8s.io"
+        kind      = "User"
+        name      = "notauser3"
+    }
+}
+`, name)
+}
+
+func testAccKubernetesRoleBindingConfigBug_step_2(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_role_binding" "test" {
+    metadata {
+		name      = "%s"
+		namespace = "default"
+    }
+
+    role_ref {
+        api_group = "rbac.authorization.k8s.io"
+        kind      = "Role"
+        name      = "admin"
+    }
+
+    subject {
+        api_group = "rbac.authorization.k8s.io"
+        kind      = "User"
+        name      = "notauser2"
+    }
+    subject {
+        api_group = "rbac.authorization.k8s.io"
+        kind      = "User"
+        name      = "notauser4"
+    }
+}
+`, name)
+}
+
+func testAccKubernetesRoleBindingConfigBug_step_3(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_role_binding" "test" {
+    metadata {
+		name      = "%s"
+		namespace = "default"
+    }
+
+    role_ref {
+        api_group = "rbac.authorization.k8s.io"
+        kind      = "Role"
+        name      = "admin"
+    }
+
+    subject {
+        api_group = "rbac.authorization.k8s.io"
+        kind      = "User"
+        name      = "notauser0"
+    }
+    subject {
+        api_group = "rbac.authorization.k8s.io"
+        kind      = "User"
+        name      = "notauser1"
+    }
+    subject {
+        api_group = "rbac.authorization.k8s.io"
+        kind      = "User"
+        name      = "notauser2"
+    }
+    subject {
+        api_group = "rbac.authorization.k8s.io"
+        kind      = "User"
+        name      = "notauser3"
+    }
 }
 `, name)
 }

--- a/kubernetes/resource_kubernetes_role_binding_test.go
+++ b/kubernetes/resource_kubernetes_role_binding_test.go
@@ -66,6 +66,58 @@ func TestAccKubernetesRoleBinding_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.2.kind", "Group"),
 				),
 			},
+			{
+				Config: testAccKubernetesRoleBindingConfig_modified_role_ref(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesRoleBindingExists("kubernetes_role_binding.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.0.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.0.kind", "ClusterRole"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.0.name", "cluster-admin"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.#", "3"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.0.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.0.name", "notauser"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.0.kind", "User"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.1.namespace", "kube-system"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.1.name", "default"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.1.kind", "ServiceAccount"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.1.api_group", ""),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.2.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.2.name", "system:masters"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.2.kind", "Group"),
+				),
+			},
+			{
+				Config: testAccKubernetesRoleBindingConfig_modified(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesRoleBindingExists("kubernetes_role_binding.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_role_binding.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.0.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.0.kind", "Role"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "role_ref.0.name", "admin"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.#", "3"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.0.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.0.name", "notauser"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.0.kind", "User"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.1.namespace", "kube-system"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.1.name", "default"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.1.kind", "ServiceAccount"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.1.api_group", ""),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.2.api_group", "rbac.authorization.k8s.io"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.2.name", "system:masters"),
+					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "subject.2.kind", "Group"),
+				),
+			},
 		},
 	})
 }
@@ -328,6 +380,41 @@ resource "kubernetes_role_binding" "test" {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Role"
     name      = "admin"
+  }
+
+  subject {
+    kind      = "User"
+    name      = "notauser"
+    api_group = "rbac.authorization.k8s.io"
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = "default"
+    api_group = ""
+    namespace = "kube-system"
+  }
+
+  subject {
+    kind      = "Group"
+    name      = "system:masters"
+    api_group = "rbac.authorization.k8s.io"
+  }
+}
+`, name)
+}
+
+func testAccKubernetesRoleBindingConfig_modified_role_ref(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_role_binding" "test" {
+  metadata {
+    name = "%s"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "cluster-admin"
   }
 
   subject {

--- a/kubernetes/resource_kubernetes_role_binding_test.go
+++ b/kubernetes/resource_kubernetes_role_binding_test.go
@@ -169,7 +169,7 @@ func TestAccKubernetesRoleBindingBug(t *testing.T) {
 		CheckDestroy:  testAccCheckKubernetesRoleBindingDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesRoleBindingConfigBug_step_1(name),
+				Config: testAccKubernetesRoleBindingConfigBug_step_0(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesRoleBindingExists("kubernetes_role_binding.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "metadata.0.name", name),
@@ -194,7 +194,7 @@ func TestAccKubernetesRoleBindingBug(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesRoleBindingConfigBug_step_2(name),
+				Config: testAccKubernetesRoleBindingConfigBug_step_1(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesRoleBindingExists("kubernetes_role_binding.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "metadata.0.name", name),
@@ -216,7 +216,7 @@ func TestAccKubernetesRoleBindingBug(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesRoleBindingConfigBug_step_3(name),
+				Config: testAccKubernetesRoleBindingConfigBug_step_2(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKubernetesRoleBindingExists("kubernetes_role_binding.test", &conf),
 					resource.TestCheckResourceAttr("kubernetes_role_binding.test", "metadata.0.name", name),
@@ -396,7 +396,7 @@ resource "kubernetes_role_binding" "test" {
 `, name)
 }
 
-func testAccKubernetesRoleBindingConfigBug_step_1(name string) string {
+func testAccKubernetesRoleBindingConfigBug_step_0(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_role_binding" "test" {
     metadata {
@@ -429,7 +429,7 @@ resource "kubernetes_role_binding" "test" {
 `, name)
 }
 
-func testAccKubernetesRoleBindingConfigBug_step_2(name string) string {
+func testAccKubernetesRoleBindingConfigBug_step_1(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_role_binding" "test" {
     metadata {
@@ -457,7 +457,7 @@ resource "kubernetes_role_binding" "test" {
 `, name)
 }
 
-func testAccKubernetesRoleBindingConfigBug_step_3(name string) string {
+func testAccKubernetesRoleBindingConfigBug_step_2(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_role_binding" "test" {
     metadata {

--- a/kubernetes/resource_kubernetes_role_test.go
+++ b/kubernetes/resource_kubernetes_role_test.go
@@ -128,6 +128,79 @@ func TestAccKubernetesRole_generatedName(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesRoleBug(t *testing.T) {
+	var conf api.Role
+	name := fmt.Sprintf("tf-acc-test:%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "kubernetes_role.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesRoleConfigBug_step_0(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesRoleExists("kubernetes_role.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.#", "3"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.0.resources.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.0.resources.3245178296", "pods"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.0.verbs.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.0.verbs.4248514160", "get"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.1.resources.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.1.resources.926696405", "deployments"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.1.verbs.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.1.verbs.1154021400", "list"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.2.resources.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.2.resources.382107465", "cronjobs"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.2.verbs.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.2.verbs.1154021400", "list"),
+				),
+			},
+			{
+				Config: testAccKubernetesRoleConfigBug_step_1(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesRoleExists("kubernetes_role.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.0.resources.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.0.resources.926696405", "deployments"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.0.verbs.#", "2"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.0.verbs.4248514160", "get"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.0.verbs.1154021400", "list"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.1.api_groups.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.1.resources.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.1.resources.2828234181", "jobs"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.1.verbs.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.1.verbs.4248514160", "get"),
+				),
+			},
+			{
+				Config: testAccKubernetesRoleConfigBug_step_2(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesRoleExists("kubernetes_role.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.#", "4"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.0.resources.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.0.resources.3245178296", "pods"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.0.verbs.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.0.verbs.1154021400", "list"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.1.resources.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.1.resources.926696405", "deployments"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.1.verbs.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.1.verbs.1154021400", "list"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.2.resources.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.2.resources.382107465", "cronjobs"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.2.verbs.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.2.verbs.1154021400", "list"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.3.api_groups.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.3.resources.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.3.resources.2828234181", "jobs"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.3.verbs.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_role.test", "rule.3.verbs.4248514160", "get"),
+				),
+			},
+		},
+	})
+}
+
 func testAccKubernetesRoleConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_role" "test" {
@@ -249,4 +322,91 @@ func testAccCheckKubernetesRoleDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccKubernetesRoleConfigBug_step_0(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_role" "test" {
+  metadata {
+	name      = "%s"
+	namespace = "default"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["pods"]
+    verbs      = ["get"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["deployments"]
+    verbs      = ["list"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["cronjobs"]
+    verbs      = ["list"]
+  }
+}
+`, name)
+}
+
+func testAccKubernetesRoleConfigBug_step_1(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_role" "test" {
+  metadata {
+	name      = "%s"
+	namespace = "default"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["deployments"]
+    verbs      = ["get", "list"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["jobs"]
+    verbs      = ["get"]
+  }
+}
+`, name)
+}
+
+func testAccKubernetesRoleConfigBug_step_2(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_role" "test" {
+  metadata {
+	name      = "%s"
+	namespace = "default"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["pods"]
+    verbs      = ["list"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["deployments"]
+    verbs      = ["list"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["cronjobs"]
+    verbs      = ["list"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["jobs"]
+    verbs      = ["get"]
+  }
+}
+`, name)
 }

--- a/kubernetes/schema_rbac.go
+++ b/kubernetes/schema_rbac.go
@@ -44,17 +44,20 @@ func rbacRoleRefSchema() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Description:  "The API group of the user. The only value possible at the moment is `rbac.authorization.k8s.io`.",
 			Required:     true,
+			ForceNew:     true,
 			ValidateFunc: validation.StringInSlice([]string{"rbac.authorization.k8s.io"}, false),
 		},
 		"kind": {
 			Type:         schema.TypeString,
 			Description:  "The kind of resource.",
 			Required:     true,
+			ForceNew:     true,
 			ValidateFunc: validation.StringInSlice([]string{"Role", "ClusterRole"}, false),
 		},
 		"name": {
 			Type:        schema.TypeString,
 			Description: "The name of the User to bind to.",
+			ForceNew:    true,
 			Required:    true,
 		},
 	}

--- a/kubernetes/structures_rbac.go
+++ b/kubernetes/structures_rbac.go
@@ -132,18 +132,18 @@ func patchRbacSubject(d *schema.ResourceData) PatchOperations {
 	if common > len(oldsubjects) {
 		common = len(oldsubjects)
 	}
-	for i, v := range newsubjects[:common] {
-		ops = append(ops, &ReplaceOperation{
-			Path:  "/subjects/" + strconv.Itoa(i),
-			Value: v,
-		})
-	}
 	if len(oldsubjects) > len(newsubjects) {
 		for i := len(newsubjects); i < len(oldsubjects); i++ {
 			ops = append(ops, &RemoveOperation{
 				Path: "/subjects/" + strconv.Itoa(len(oldsubjects)-i),
 			})
 		}
+	}
+	for i, v := range newsubjects[:common] {
+		ops = append(ops, &ReplaceOperation{
+			Path:  "/subjects/" + strconv.Itoa(i),
+			Value: v,
+		})
 	}
 	if len(newsubjects) > len(oldsubjects) {
 		for i, v := range newsubjects[common:] {

--- a/kubernetes/structures_rbac.go
+++ b/kubernetes/structures_rbac.go
@@ -166,18 +166,18 @@ func patchRbacRule(d *schema.ResourceData) PatchOperations {
 	if common > len(oldrules) {
 		common = len(oldrules)
 	}
-	for i, v := range newrules[:common] {
-		ops = append(ops, &ReplaceOperation{
-			Path:  "/rules/" + strconv.Itoa(i),
-			Value: v,
-		})
-	}
 	if len(oldrules) > len(newrules) {
 		for i := len(newrules); i < len(oldrules); i++ {
 			ops = append(ops, &RemoveOperation{
 				Path: "/rules/" + strconv.Itoa(len(oldrules)-i),
 			})
 		}
+	}
+	for i, v := range newrules[:common] {
+		ops = append(ops, &ReplaceOperation{
+			Path:  "/rules/" + strconv.Itoa(i),
+			Value: v,
+		})
 	}
 	if len(newrules) > len(oldrules) {
 		for i, v := range newrules[common:] {


### PR DESCRIPTION
This PR builds on https://github.com/terraform-providers/terraform-provider-kubernetes/pull/712 and fixes the issue (#713) revealed by the test case it provides.

It works by processing remove operations, which shifts elements in the subjects list, before replacing the remaining items.

The same issue affects cluster role rules: https://github.com/terraform-providers/terraform-provider-kubernetes/blob/v1.10.0/kubernetes/structures_rbac.go#L169-L181

Also, this PR resolves #650 by forcing (cluster)-role binding replacement on `role_ref` changes.