### PR TITLE
Add kubernetes_service_account data source

### DIFF
--- a/kubernetes/data_source_kubernetes_service_account.go
+++ b/kubernetes/data_source_kubernetes_service_account.go
@@ -1,0 +1,63 @@
+package kubernetes
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func dataSourceKubernetesServiceAccount() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceKubernetesServiceAccountRead,
+
+		Schema: map[string]*schema.Schema{
+			"metadata": namespacedMetadataSchema("service account", false),
+			"image_pull_secret": {
+				Type:        schema.TypeSet,
+				Description: "A list of references to secrets in the same namespace to use for pulling any images in pods that reference this Service Account. More info: http://kubernetes.io/docs/user-guide/secrets#manually-specifying-an-imagepullsecret",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Description: "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+							Computed:    true,
+						},
+					},
+				},
+			},
+			"secret": {
+				Type:        schema.TypeSet,
+				Description: "A list of secrets allowed to be used by pods running using this Service Account. More info: http://kubernetes.io/docs/user-guide/secrets",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Description: "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+							Computed:    true,
+						},
+					},
+				},
+			},
+			"automount_service_account_token": {
+				Type:        schema.TypeBool,
+				Description: "True to enable automatic mounting of the service account token",
+				Computed:    true,
+			},
+			"default_secret_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceKubernetesServiceAccountRead(d *schema.ResourceData, meta interface{}) error {
+	om := meta_v1.ObjectMeta{
+		Namespace: d.Get("metadata.0.namespace").(string),
+		Name:      d.Get("metadata.0.name").(string),
+	}
+	d.SetId(buildId(om))
+
+	return resourceKubernetesServiceAccountRead(d, meta)
+}

--- a/kubernetes/data_source_kubernetes_service_account.go
+++ b/kubernetes/data_source_kubernetes_service_account.go
@@ -55,12 +55,13 @@ func dataSourceKubernetesServiceAccount() *schema.Resource {
 }
 
 func dataSourceKubernetesServiceAccountRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
+	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 
-	namespace := d.Get("metadata.0.namespace").(string)
-	name := d.Get("metadata.0.name").(string)
-
-	sa, err := conn.CoreV1().ServiceAccounts(namespace).Get(name, metav1.GetOptions{})
+	sa, err := conn.CoreV1().ServiceAccounts(metadata.Namespace).Get(metadata.Name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("Unable to fetch service account from Kubernetes: %s", err)
 	}

--- a/kubernetes/data_source_kubernetes_service_account_test.go
+++ b/kubernetes/data_source_kubernetes_service_account_test.go
@@ -19,21 +19,13 @@ func TestAccKubernetesDataSourceServiceAccount_basic(t *testing.T) {
 			{
 				Config: testAccKubernetesDataSourceServiceAccountConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.annotations.%", "2"),
-					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.annotations.TestAnnotationOne", "one"),
-					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.annotations.TestAnnotationTwo", "two"),
-					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.labels.%", "3"),
-					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.labels.TestLabelOne", "one"),
-					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.labels.TestLabelTwo", "two"),
-					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.labels.TestLabelThree", "three"),
 					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.name", name),
-					resource.TestCheckResourceAttrSet("data.kubernetes_service_account.test", "metadata.0.generation"),
-					resource.TestCheckResourceAttrSet("data.kubernetes_service_account.test", "metadata.0.resource_version"),
-					resource.TestCheckResourceAttrSet("data.kubernetes_service_account.test", "metadata.0.self_link"),
-					resource.TestCheckResourceAttrSet("data.kubernetes_service_account.test", "metadata.0.uid"),
-					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "secret.#", "2"),
-					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "image_pull_secret.#", "2"),
+					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.annotations.TestAnnotation", "annotation"),
+					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.labels.TestLabel", "label"),
+					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "secret.0.name", name+"-secret"),
+					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "image_pull_secret.0.name", name+"-image-pull-secret"),
 					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "automount_service_account_token", "false"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_service_account.test", "default_secret_name"),
 				),
 			},
 		},
@@ -41,11 +33,44 @@ func TestAccKubernetesDataSourceServiceAccount_basic(t *testing.T) {
 }
 
 func testAccKubernetesDataSourceServiceAccountConfig_basic(name string) string {
-	return testAccKubernetesServiceAccountConfig_basic(name) + `
+	return fmt.Sprintf(`
+resource "kubernetes_service_account" "test" {
+  metadata {
+    annotations = {
+      TestAnnotation = "annotation"
+    }
+
+    labels = {
+      TestLabel   = "label"
+    }
+    name = "%s"
+  }
+
+  secret {
+    name = "${kubernetes_secret.secret.metadata.0.name}"
+  }
+
+  image_pull_secret {
+    name = "${kubernetes_secret.image_pull_secret.metadata.0.name}"
+  }
+}
+
+resource "kubernetes_secret" "secret" {
+  metadata {
+    name = "%s-secret"
+  }
+}
+
+resource "kubernetes_secret" "image_pull_secret" {
+  metadata {
+    name = "%s-image-pull-secret"
+  }
+}
+
 data "kubernetes_service_account" "test" {
 	metadata {
 		name = "${kubernetes_service_account.test.metadata.0.name}"
 	}
 }
-`
+`, name, name, name)
 }

--- a/kubernetes/data_source_kubernetes_service_account_test.go
+++ b/kubernetes/data_source_kubernetes_service_account_test.go
@@ -1,0 +1,51 @@
+package kubernetes
+
+import (
+	"fmt"
+	// "regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccKubernetesDataSourceServiceAccount_basic(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesDataSourceServiceAccountConfig_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.annotations.%", "2"),
+					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.annotations.TestAnnotationOne", "one"),
+					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.annotations.TestAnnotationTwo", "two"),
+					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.labels.%", "3"),
+					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.labels.TestLabelOne", "one"),
+					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.labels.TestLabelTwo", "two"),
+					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.labels.TestLabelThree", "three"),
+					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("data.kubernetes_service_account.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_service_account.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_service_account.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_service_account.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "secret.#", "2"),
+					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "image_pull_secret.#", "2"),
+					resource.TestCheckResourceAttr("data.kubernetes_service_account.test", "automount_service_account_token", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKubernetesDataSourceServiceAccountConfig_basic(name string) string {
+	return testAccKubernetesServiceAccountConfig_basic(name) + `
+data "kubernetes_service_account" "test" {
+	metadata {
+		name = "${kubernetes_service_account.test.metadata.0.name}"
+	}
+}
+`
+}

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -13,7 +13,6 @@ import (
 	apimachineryschema "k8s.io/apimachinery/pkg/runtime/schema"
 	kubernetes "k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/client-go/rest"
 	restclient "k8s.io/client-go/rest"
 
 	"k8s.io/client-go/tools/clientcmd"
@@ -137,10 +136,11 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"kubernetes_config_map":    dataSourceKubernetesConfigMap(),
-			"kubernetes_secret":        dataSourceKubernetesSecret(),
-			"kubernetes_service":       dataSourceKubernetesService(),
-			"kubernetes_storage_class": dataSourceKubernetesStorageClass(),
+			"kubernetes_config_map":      dataSourceKubernetesConfigMap(),
+			"kubernetes_secret":          dataSourceKubernetesSecret(),
+			"kubernetes_service":         dataSourceKubernetesService(),
+			"kubernetes_service_account": dataSourceKubernetesServiceAccount(),
+			"kubernetes_storage_class":   dataSourceKubernetesStorageClass(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -194,7 +194,7 @@ type KubeClientsets interface {
 }
 
 type kubeClientsets struct {
-	config              *rest.Config
+	config              *restclient.Config
 	mainClientset       *kubernetes.Clientset
 	aggregatorClientset *aggregator.Clientset
 }

--- a/website/docs/d/service_account.html.markdown
+++ b/website/docs/d/service_account.html.markdown
@@ -1,0 +1,69 @@
+---
+layout: "kubernetes"
+page_title: "Kubernetes: kubernetes_service_account"
+sidebar_current: "docs-kubernetes-data-source-service-account"
+description: |-
+  A service account provides an identity for processes that run in a Pod.
+---
+
+# kubernetes_service_account
+
+A service account provides an identity for processes that run in a Pod.
+
+Read more at [Kubernetes reference](https://kubernetes.io/docs/admin/service-accounts-admin/)
+
+## Example Usage
+
+```hcl
+data "kubernetes_service_account" "example" {
+  metadata {
+    name = "terraform-example"
+  }
+}
+
+data "kubernetes_secret" "example" {
+  metadata {
+    name = "${kubernetes_service_account.example.default_secret_name}"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `metadata` - (Required) Standard service account's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
+
+## Nested Blocks
+
+### `metadata`
+
+#### Arguments
+
+* `name` - (Required) Name of the service account, must be unique. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+* `namespace` - (Optional) Namespace defines the space within which name of the service account must be unique.
+
+#### Attributes
+
+* `generation` - A sequence number representing a specific generation of the desired state.
+* `resource_version` - An opaque value that represents the internal version of this service account that can be used by clients to determine when service account has changed. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency)
+* `self_link` - A URL representing this service account.
+* `uid` - The unique in time and space value for this service account. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#uids)
+
+## Attribute Reference
+
+* `image_pull_secret` - A list of image pull secrets associated with the service account
+* `secret` - A list of secrets associated with the service account
+* `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service.
+
+### `image_pull_secret`
+
+#### Attributes
+
+* `name` - Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+
+### `secret`
+
+#### Attributes
+
+* `name` - Name of the referent. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)

--- a/website/docs/d/service_account.html.markdown
+++ b/website/docs/d/service_account.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # kubernetes_service_account
 
-A service account provides an identity for processes that run in a Pod.
+A service account provides an identity for processes that run in a Pod.  This data source reads the service account and makes specific attributes available to Terraform.
 
 Read more at [Kubernetes reference](https://kubernetes.io/docs/admin/service-accounts-admin/)
 
@@ -23,7 +23,7 @@ data "kubernetes_service_account" "example" {
 
 data "kubernetes_secret" "example" {
   metadata {
-    name = "${kubernetes_service_account.example.default_secret_name}"
+    name = "${data.kubernetes_service_account.example.default_secret_name}"
   }
 }
 ```
@@ -52,8 +52,8 @@ The following arguments are supported:
 
 ## Attribute Reference
 
-* `image_pull_secret` - A list of image pull secrets associated with the service account
-* `secret` - A list of secrets associated with the service account
+* `image_pull_secret` - A list of image pull secrets associated with the service account.
+* `secret` - A list of secrets associated with the service account.
 * `default_secret_name` - Name of the default secret, containing service account token, created & managed by the service.
 
 ### `image_pull_secret`

--- a/website/docs/r/service_account.html.markdown
+++ b/website/docs/r/service_account.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 A service account provides an identity for processes that run in a Pod.
 
-Read more at [Kubernetes reference](https://kubernetes.io/docs/admin/service-accounts-admin)/
+Read more at [Kubernetes reference](https://kubernetes.io/docs/admin/service-accounts-admin/)
 
 ## Example Usage
 

--- a/website/kubernetes.erb
+++ b/website/kubernetes.erb
@@ -24,6 +24,9 @@
             <li<%= sidebar_current("docs-kubernetes-data-source-secret") %>>
               <a href="/docs/providers/kubernetes/d/secret.html">kubernetes_secret</a>
             </li>
+            <li<%= sidebar_current("docs-kubernetes-data-source-service-account") %>>
+              <a href="/docs/providers/kubernetes/d/service_account.html">kubernetes_service_account</a>
+            </li>
             <li<%= sidebar_current("docs-kubernetes-data-source-service") %>>
               <a href="/docs/providers/kubernetes/d/service.html">kubernetes_service</a>
             </li>


### PR DESCRIPTION
This PR adds support for the kubernetes service account datasource. 

This datasource makes it easy to get the auto-generated secret token from service accounts not directly managed by terraform (in our setup, we need to access a secret token created by a helm chart)