### PR TITLE
Do not force base64 encoding for the ca_bundle in the API Service resource

### DIFF
--- a/kubernetes/resource_kubernetes_api_service.go
+++ b/kubernetes/resource_kubernetes_api_service.go
@@ -33,10 +33,9 @@ func resourceKubernetesAPIService() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ca_bundle": {
-							Type:         schema.TypeString,
-							Description:  "CABundle is a PEM encoded CA bundle which will be used to validate an API server's serving certificate. If unspecified, system trust roots on the apiserver are used.",
-							Optional:     true,
-							ValidateFunc: validateBase64Encoded,
+							Type:        schema.TypeString,
+							Description: "CABundle is a PEM encoded CA bundle which will be used to validate an API server's serving certificate. If unspecified, system trust roots on the apiserver are used.",
+							Optional:    true,
 						},
 						"group": {
 							Type:        schema.TypeString,

--- a/kubernetes/resource_kubernetes_api_service_test.go
+++ b/kubernetes/resource_kubernetes_api_service_test.go
@@ -61,7 +61,7 @@ func TestAccKubernetesAPIService_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.group_priority_minimum", "100"),
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.version", version),
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.version_priority", "100"),
-					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.ca_bundle", "ZGF0YQ=="),
+					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.ca_bundle", "data"),
 					resource.TestCheckResourceAttr("kubernetes_api_service.test", "spec.0.insecure_skip_tls_verify", "false"),
 				),
 			},
@@ -241,7 +241,7 @@ func testAccKubernetesAPIServiceConfig_modified(name, group, version string) str
       version          = "%s"
       version_priority = 100
 
-      ca_bundle = "${base64encode("data")}"
+      ca_bundle = "data"
       insecure_skip_tls_verify = false
     }
   }


### PR DESCRIPTION
This PR removes the need for the `ca_bundle` property of the `kubernetes_api_service` resource to be in base64 format.

When we encode it before applying in terraform we see that the resource created has the bundle encoded 2 times.

According to the 14th point of the document [Setup an Extension API Server ](https://kubernetes.io/docs/tasks/access-kubernetes-api/setup-extension-api-server/#setup-an-extension-api-server-to-work-with-the-aggregation-layer) it is not necessary to encode the bundle when using the `kube-aggregator` API to create the APIService:
> If using the kube-aggregator API, only pass in the PEM encoded CA bundle because the base 64 encoding is done for you.