### PR TITLE
calico also annotates pods automatically, triggering a diff

### DIFF
--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -158,7 +158,7 @@ func isKeyInMap(key string, d map[string]interface{}) bool {
 
 func isInternalKey(annotationKey string) bool {
 	u, err := url.Parse("//" + annotationKey)
-	if err == nil && strings.HasSuffix(u.Hostname(), "kubernetes.io") {
+	if err == nil && (strings.HasSuffix(u.Hostname(), "kubernetes.io") || strings.HasSuffix(u.Hostname(), "projectcalico.org")) {
 		return true
 	}
 


### PR DESCRIPTION
```
  # kubernetes_pod.nginx will be updated in-place
  ~ resource "kubernetes_pod" "nginx" {
        id = "hugh/nginx-example"

      ~ metadata {
          ~ annotations      = {
              - "cni.projectcalico.org/podIP" = "10.1.10.200/32" -> null
            }
```