### PR TITLE
Fix kubernetes_service field spec.port.port is not required

### DIFF
--- a/kubernetes/resource_kubernetes_service.go
+++ b/kubernetes/resource_kubernetes_service.go
@@ -97,7 +97,7 @@ func resourceKubernetesService() *schema.Resource {
 									"port": {
 										Type:        schema.TypeInt,
 										Description: "The port that will be exposed by this service.",
-										Required:    true,
+										Optional:    true,
 									},
 									"protocol": {
 										Type:        schema.TypeString,


### PR DESCRIPTION
Field spec.port is Optional but spec.port.port is Required and it's a mistake. I use next service and it work fine 
```yaml
apiVersion: v1
kind: Service
metadata:
  name: browsers
  namespace: moon
spec:
  selector:
    moon: browser
  clusterIP: None
  publishNotReadyAddresses: true
```

As a result:
```
 $ kubectl get services --namespace=moon
NAME       TYPE           CLUSTER-IP     EXTERNAL-IP    PORT(S)                         AGE
browsers   ClusterIP      None           <none>         <none>                          43s
```