### PR TITLE
Allow 3s age gap between serviceaccount and secret

### DIFF
--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -337,7 +337,7 @@ func findDefaultServiceAccount(sa *api.ServiceAccount, conn *kubernetes.Clientse
 			continue
 		}
 
-		if secret.CreationTimestamp.Sub(sa.CreationTimestamp.Time) > (1 * time.Second) {
+		if secret.CreationTimestamp.Sub(sa.CreationTimestamp.Time) > (3 * time.Second) {
 			log.Printf("[DEBUG] Skipping %s as it wasn't created at the same time as the service account", saSecret.Name)
 			continue
 		}


### PR DESCRIPTION
Importing service accounts isn't always working on EKS clusters, which sometimes see secrets created more than one second after the service account, as reported in https://github.com/terraform-providers/terraform-provider-kubernetes/pull/377#issuecomment-540126765 and https://github.com/terraform-providers/terraform-provider-kubernetes/issues/268#issuecomment-578469711 

With some fields removed for clarity:
```
 {
  "kind": "ServiceAccount",
  "metadata": {
   "name": "coredns",
   "uid": "e2885307-37d7-11ea-9db3-1211528e452b",
   "resourceVersion": "201",
   "creationTimestamp": "2020-01-15T20:44:54Z",
  },
  "secrets": [ { "name": "coredns-token-8tdpj" } ]
 }
 {
  "kind": "Secret",
  "metadata": {
   "name": "coredns-token-8tdpj",
   "resourceVersion": "196",
   "creationTimestamp": "2020-01-15T20:44:56Z",
   "annotations": {
    "kubernetes.io/service-account.name": "coredns",
    "kubernetes.io/service-account.uid": "e2885307-37d7-11ea-9db3-1211528e452b"
   }
  },
  "type": "kubernetes.io/service-account-token"                                                                              
 }
```

It's not clear what could be causing this. In our case, the cluster was brand new at the time the account was created, as can be seen in the relatively low resourceVersions. Maybe it's load, maybe it's clock drift between API servers (where creationTimestamp is injected, AFAIK). No matter the cause, this is a real problem and it's stopping imports.
This is the simplest fix. A more comprehensive one could also double check that the annotations for SA name and the UID on the secret match with the account's. If more than one secret matches all criteria, perhaps the oldest one could be picked. But that's all better addressed separately.