### PR TITLE
Honore load_config_file parameter

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -101,7 +101,7 @@ func Provider() terraform.ResourceProvider {
 			"load_config_file": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("KUBE_LOAD_CONFIG_FILE", true),
+				DefaultFunc: schema.EnvDefaultFunc("KUBE_LOAD_CONFIG_FILE", nil),
 				Description: "Load local kubeconfig.",
 			},
 			"exec": {
@@ -194,7 +194,8 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 
 	var cfg *restclient.Config
 	var err error
-	if d.Get("load_config_file").(bool) {
+
+	if v, ok := d.GetOk("load_config_file"); ok && v.(bool) {
 		// Config file loading
 		cfg, err = tryLoadingConfigFile(d)
 	}


### PR DESCRIPTION
This parameter could be defined either:
- via provider configuration file
- via an environment variable

Previous behavior when the environment variable is not define is to
default it to true, completly by-passing the provider configuration
file.

fix #752 