### PR TITLE
Fix getting-started documentation code bloc formatting

### DIFF
--- a/website/docs/guides/getting-started.html.markdown
+++ b/website/docs/guides/getting-started.html.markdown
@@ -70,6 +70,7 @@ provider "kubernetes" {
 ```
 
 If you wish to configure the provider statically you can do so by providing TLS certificates:
+
 ```hcl
 provider "kubernetes" {
   load_config_file = "false"


### PR DESCRIPTION
The markdown rendering on terraform.io/docs/ seems to differ from the one in github: after `:\n` we need an extra empty line to start a code bock.