### PR TITLE
Break line before code block

### DIFF
--- a/website/docs/guides/getting-started.html.markdown
+++ b/website/docs/guides/getting-started.html.markdown
@@ -70,6 +70,7 @@ provider "kubernetes" {
 ```
 
 If you wish to configure the provider statically you can do so by providing TLS certificates:
+
 ```hcl
 provider "kubernetes" {
   load_config_file = "false"


### PR DESCRIPTION
The code block right below was missing formatting because of that

You can check it on [https://www.terraform.io/docs/providers/kubernetes/guides/getting-started.html](https://www.terraform.io/docs/providers/kubernetes/guides/getting-started.html)

![image](https://user-images.githubusercontent.com/116623/74593319-c1d2ce80-5008-11ea-8e7a-607df802409c.png)
