### PR TITLE
Defer client initialization to improve resilience

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -188,8 +188,8 @@ func Provider() terraform.ResourceProvider {
 }
 
 type KubeClientsets interface {
-	MainClientset() *kubernetes.Clientset
-	AggregatorClientset() *aggregator.Clientset
+	MainClientset() (*kubernetes.Clientset, error)
+	AggregatorClientset() (*aggregator.Clientset, error)
 }
 
 type kubeClientsets struct {
@@ -198,34 +198,32 @@ type kubeClientsets struct {
 	aggregatorClientset *aggregator.Clientset
 }
 
-func (k kubeClientsets) MainClientset() *kubernetes.Clientset {
+func (k kubeClientsets) MainClientset() (*kubernetes.Clientset, error) {
 	if k.mainClientset != nil {
-		return k.mainClientset
+		return k.mainClientset, nil
 	}
 	if k.config != nil {
 		kc, err := kubernetes.NewForConfig(k.config)
 		if err != nil {
-			log.Printf("[DEBUG] %s", fmt.Errorf("Failed to configure client: %s", err))
-			return nil
+			return nil, fmt.Errorf("Failed to configure client: %s", err)
 		}
 		k.mainClientset = kc
 	}
-	return k.mainClientset
+	return k.mainClientset, nil
 }
 
-func (k kubeClientsets) AggregatorClientset() *aggregator.Clientset {
+func (k kubeClientsets) AggregatorClientset() (*aggregator.Clientset, error) {
 	if k.aggregatorClientset != nil {
-		return k.aggregatorClientset
+		return k.aggregatorClientset, nil
 	}
 	if k.config != nil {
 		ac, err := aggregator.NewForConfig(k.config)
 		if err != nil {
-			log.Printf("[DEBUG] %s", fmt.Errorf("Failed to configure client: %s", err))
-			return nil
+			return nil, fmt.Errorf("Failed to configure client: %s", err)
 		}
 		k.aggregatorClientset = ac
 	}
-	return k.aggregatorClientset
+	return k.aggregatorClientset, nil
 }
 
 func providerConfigure(d *schema.ResourceData, terraformVersion string) (interface{}, error) {

--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -205,7 +205,7 @@ func getClusterVersion() (*gversion.Version, error) {
 		return nil, fmt.Errorf("Provider not initialized, unable to check cluster version")
 	}
 
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 	serverVersion, err := conn.ServerVersion()
 
 	if err != nil {
@@ -306,7 +306,7 @@ func getFirstNode() (api.Node, error) {
 	if meta == nil {
 		return api.Node{}, errors.New("Provider not initialized, unable to get cluster node")
 	}
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 	resp, err := conn.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
 		return api.Node{}, err

--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -204,7 +204,10 @@ func getClusterVersion() (*gversion.Version, error) {
 		return nil, fmt.Errorf("Provider not initialized, unable to check cluster version")
 	}
 
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 	serverVersion, err := conn.ServerVersion()
 
 	if err != nil {
@@ -305,7 +308,10 @@ func getFirstNode() (api.Node, error) {
 	if meta == nil {
 		return api.Node{}, errors.New("Provider not initialized, unable to get cluster node")
 	}
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 	resp, err := conn.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
 		return api.Node{}, err

--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -158,12 +158,11 @@ func testAccPreCheck(t *testing.T) {
 		os.Getenv("KUBE_CTX") != "" ||
 		os.Getenv("KUBECONFIG") != "" ||
 		os.Getenv("KUBE_CONFIG") != ""
+	hasUserCredentials := os.Getenv("KUBE_USER") != "" && os.Getenv("KUBE_PASSWORD") != ""
+	hasClientCert := os.Getenv("KUBE_CLIENT_CERT_DATA") != "" && os.Getenv("KUBE_CLIENT_KEY_DATA") != ""
 	hasStaticCfg := (os.Getenv("KUBE_HOST") != "" &&
-		os.Getenv("KUBE_USER") != "" &&
-		os.Getenv("KUBE_PASSWORD") != "" &&
-		os.Getenv("KUBE_CLIENT_CERT_DATA") != "" &&
-		os.Getenv("KUBE_CLIENT_KEY_DATA") != "" &&
-		os.Getenv("KUBE_CLUSTER_CA_CERT_DATA") != "")
+		os.Getenv("KUBE_CLUSTER_CA_CERT_DATA") != "") &&
+		(hasUserCredentials || hasClientCert || os.Getenv("KUBE_TOKEN") != "")
 
 	if !hasFileCfg && !hasStaticCfg {
 		t.Fatalf("File config (KUBE_CTX_AUTH_INFO and KUBE_CTX_CLUSTER) or static configuration"+

--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -206,7 +206,7 @@ func getClusterVersion() (*gversion.Version, error) {
 
 	conn, err := meta.(KubeClientsets).MainClientset()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	serverVersion, err := conn.ServerVersion()
 
@@ -310,8 +310,9 @@ func getFirstNode() (api.Node, error) {
 	}
 	conn, err := meta.(KubeClientsets).MainClientset()
 	if err != nil {
-		return err
+		return api.Node{}, err
 	}
+
 	resp, err := conn.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
 		return api.Node{}, err

--- a/kubernetes/resource_kubernetes_api_service.go
+++ b/kubernetes/resource_kubernetes_api_service.go
@@ -101,7 +101,10 @@ func resourceKubernetesAPIService() *schema.Resource {
 }
 
 func resourceKubernetesAPIServiceCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).AggregatorClientset()
+	conn, err := meta.(KubeClientsets).AggregatorClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	svc := v1.APIService{
@@ -120,7 +123,10 @@ func resourceKubernetesAPIServiceCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesAPIServiceRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).AggregatorClientset()
+	conn, err := meta.(KubeClientsets).AggregatorClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 
@@ -147,7 +153,10 @@ func resourceKubernetesAPIServiceRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceKubernetesAPIServiceUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).AggregatorClientset()
+	conn, err := meta.(KubeClientsets).AggregatorClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 
@@ -174,12 +183,15 @@ func resourceKubernetesAPIServiceUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesAPIServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).AggregatorClientset()
+	conn, err := meta.(KubeClientsets).AggregatorClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 
 	log.Printf("[INFO] Deleting API service: %#v", name)
-	err := conn.ApiregistrationV1().APIServices().Delete(name, &meta_v1.DeleteOptions{})
+	err = conn.ApiregistrationV1().APIServices().Delete(name, &meta_v1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -191,12 +203,15 @@ func resourceKubernetesAPIServiceDelete(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesAPIServiceExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).AggregatorClientset()
+	conn, err := meta.(KubeClientsets).AggregatorClientset()
+	if err != nil {
+		return false, err
+	}
 
 	name := d.Id()
 
 	log.Printf("[INFO] Checking API service %s", name)
-	_, err := conn.ApiregistrationV1().APIServices().Get(name, meta_v1.GetOptions{})
+	_, err = conn.ApiregistrationV1().APIServices().Get(name, meta_v1.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return false, nil

--- a/kubernetes/resource_kubernetes_api_service.go
+++ b/kubernetes/resource_kubernetes_api_service.go
@@ -101,7 +101,7 @@ func resourceKubernetesAPIService() *schema.Resource {
 }
 
 func resourceKubernetesAPIServiceCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).AggregatorClientset
+	conn := meta.(KubeClientsets).AggregatorClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	svc := v1.APIService{
@@ -120,7 +120,7 @@ func resourceKubernetesAPIServiceCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesAPIServiceRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).AggregatorClientset
+	conn := meta.(KubeClientsets).AggregatorClientset()
 
 	name := d.Id()
 
@@ -147,7 +147,7 @@ func resourceKubernetesAPIServiceRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceKubernetesAPIServiceUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).AggregatorClientset
+	conn := meta.(KubeClientsets).AggregatorClientset()
 
 	name := d.Id()
 
@@ -174,7 +174,7 @@ func resourceKubernetesAPIServiceUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesAPIServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).AggregatorClientset
+	conn := meta.(KubeClientsets).AggregatorClientset()
 
 	name := d.Id()
 
@@ -191,7 +191,7 @@ func resourceKubernetesAPIServiceDelete(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesAPIServiceExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).AggregatorClientset
+	conn := meta.(KubeClientsets).AggregatorClientset()
 
 	name := d.Id()
 

--- a/kubernetes/resource_kubernetes_api_service_test.go
+++ b/kubernetes/resource_kubernetes_api_service_test.go
@@ -136,7 +136,10 @@ func TestAccKubernetesAPIService_importBasic(t *testing.T) {
 }
 
 func testAccCheckKubernetesAPIServiceDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).AggregatorClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).AggregatorClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_api_service" {
@@ -163,11 +166,14 @@ func testAccCheckKubernetesAPIServiceExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).AggregatorClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).AggregatorClientset()
+		if err != nil {
+			return err
+		}
 
 		name := rs.Primary.ID
 
-		_, err := conn.ApiregistrationV1().APIServices().Get(name, meta_v1.GetOptions{})
+		_, err = conn.ApiregistrationV1().APIServices().Get(name, meta_v1.GetOptions{})
 		if err != nil {
 			return err
 		}

--- a/kubernetes/resource_kubernetes_api_service_test.go
+++ b/kubernetes/resource_kubernetes_api_service_test.go
@@ -136,7 +136,7 @@ func TestAccKubernetesAPIService_importBasic(t *testing.T) {
 }
 
 func testAccCheckKubernetesAPIServiceDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).AggregatorClientset
+	conn := testAccProvider.Meta().(KubeClientsets).AggregatorClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_api_service" {
@@ -163,7 +163,7 @@ func testAccCheckKubernetesAPIServiceExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).AggregatorClientset
+		conn := testAccProvider.Meta().(KubeClientsets).AggregatorClientset()
 
 		name := rs.Primary.ID
 

--- a/kubernetes/resource_kubernetes_cluster_role.go
+++ b/kubernetes/resource_kubernetes_cluster_role.go
@@ -38,7 +38,7 @@ func resourceKubernetesClusterRole() *schema.Resource {
 }
 
 func resourceKubernetesClusterRoleCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	cRole := api.ClusterRole{
@@ -57,7 +57,7 @@ func resourceKubernetesClusterRoleCreate(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesClusterRoleUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
@@ -81,7 +81,7 @@ func resourceKubernetesClusterRoleUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesClusterRoleRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 	log.Printf("[INFO] Reading cluster role %s", name)
@@ -105,7 +105,7 @@ func resourceKubernetesClusterRoleRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesClusterRoleDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 	log.Printf("[INFO] Deleting cluster role: %#v", name)
@@ -120,7 +120,7 @@ func resourceKubernetesClusterRoleDelete(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesClusterRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 	log.Printf("[INFO] Checking cluster role %s", name)

--- a/kubernetes/resource_kubernetes_cluster_role.go
+++ b/kubernetes/resource_kubernetes_cluster_role.go
@@ -38,7 +38,10 @@ func resourceKubernetesClusterRole() *schema.Resource {
 }
 
 func resourceKubernetesClusterRoleCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	cRole := api.ClusterRole{
@@ -57,7 +60,10 @@ func resourceKubernetesClusterRoleCreate(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesClusterRoleUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
@@ -81,7 +87,10 @@ func resourceKubernetesClusterRoleUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesClusterRoleRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 	log.Printf("[INFO] Reading cluster role %s", name)
@@ -105,11 +114,14 @@ func resourceKubernetesClusterRoleRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesClusterRoleDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 	log.Printf("[INFO] Deleting cluster role: %#v", name)
-	err := conn.RbacV1().ClusterRoles().Delete(name, &metav1.DeleteOptions{})
+	err = conn.RbacV1().ClusterRoles().Delete(name, &metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -120,11 +132,14 @@ func resourceKubernetesClusterRoleDelete(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesClusterRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	name := d.Id()
 	log.Printf("[INFO] Checking cluster role %s", name)
-	_, err := conn.RbacV1().ClusterRoles().Get(name, metav1.GetOptions{})
+	_, err = conn.RbacV1().ClusterRoles().Get(name, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return false, nil

--- a/kubernetes/resource_kubernetes_cluster_role_binding.go
+++ b/kubernetes/resource_kubernetes_cluster_role_binding.go
@@ -48,7 +48,7 @@ func resourceKubernetesClusterRoleBinding() *schema.Resource {
 }
 
 func resourceKubernetesClusterRoleBindingCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	binding := &api.ClusterRoleBinding{
@@ -69,7 +69,7 @@ func resourceKubernetesClusterRoleBindingCreate(d *schema.ResourceData, meta int
 }
 
 func resourceKubernetesClusterRoleBindingRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 	log.Printf("[INFO] Reading ClusterRoleBinding %s", name)
@@ -103,7 +103,7 @@ func resourceKubernetesClusterRoleBindingRead(d *schema.ResourceData, meta inter
 }
 
 func resourceKubernetesClusterRoleBindingUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 
@@ -128,7 +128,7 @@ func resourceKubernetesClusterRoleBindingUpdate(d *schema.ResourceData, meta int
 }
 
 func resourceKubernetesClusterRoleBindingDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 	log.Printf("[INFO] Deleting ClusterRoleBinding: %#v", name)
@@ -143,7 +143,7 @@ func resourceKubernetesClusterRoleBindingDelete(d *schema.ResourceData, meta int
 }
 
 func resourceKubernetesClusterRoleBindingExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 	log.Printf("[INFO] Checking ClusterRoleBinding %s", name)

--- a/kubernetes/resource_kubernetes_cluster_role_binding.go
+++ b/kubernetes/resource_kubernetes_cluster_role_binding.go
@@ -48,7 +48,10 @@ func resourceKubernetesClusterRoleBinding() *schema.Resource {
 }
 
 func resourceKubernetesClusterRoleBindingCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	binding := &api.ClusterRoleBinding{
@@ -57,7 +60,7 @@ func resourceKubernetesClusterRoleBindingCreate(d *schema.ResourceData, meta int
 		Subjects:   expandRBACSubjects(d.Get("subject").([]interface{})),
 	}
 	log.Printf("[INFO] Creating new ClusterRoleBinding: %#v", binding)
-	binding, err := conn.RbacV1().ClusterRoleBindings().Create(binding)
+	binding, err = conn.RbacV1().ClusterRoleBindings().Create(binding)
 
 	if err != nil {
 		return err
@@ -69,7 +72,10 @@ func resourceKubernetesClusterRoleBindingCreate(d *schema.ResourceData, meta int
 }
 
 func resourceKubernetesClusterRoleBindingRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 	log.Printf("[INFO] Reading ClusterRoleBinding %s", name)
@@ -103,7 +109,10 @@ func resourceKubernetesClusterRoleBindingRead(d *schema.ResourceData, meta inter
 }
 
 func resourceKubernetesClusterRoleBindingUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 
@@ -128,11 +137,14 @@ func resourceKubernetesClusterRoleBindingUpdate(d *schema.ResourceData, meta int
 }
 
 func resourceKubernetesClusterRoleBindingDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 	log.Printf("[INFO] Deleting ClusterRoleBinding: %#v", name)
-	err := conn.RbacV1().ClusterRoleBindings().Delete(name, &meta_v1.DeleteOptions{})
+	err = conn.RbacV1().ClusterRoleBindings().Delete(name, &meta_v1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -143,11 +155,14 @@ func resourceKubernetesClusterRoleBindingDelete(d *schema.ResourceData, meta int
 }
 
 func resourceKubernetesClusterRoleBindingExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	name := d.Id()
 	log.Printf("[INFO] Checking ClusterRoleBinding %s", name)
-	_, err := conn.RbacV1().ClusterRoleBindings().Get(name, meta_v1.GetOptions{})
+	_, err = conn.RbacV1().ClusterRoleBindings().Get(name, meta_v1.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return false, nil

--- a/kubernetes/resource_kubernetes_cluster_role_binding_test.go
+++ b/kubernetes/resource_kubernetes_cluster_role_binding_test.go
@@ -299,7 +299,7 @@ func TestAccKubernetesClusterRoleBindingUpdatePatchOperationsOrderWithRemovals(t
 }
 
 func testAccCheckKubernetesClusterRoleBindingDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_cluster_role_binding" {
@@ -324,7 +324,7 @@ func testAccCheckKubernetesClusterRoleBindingExists(n string, obj *api.ClusterRo
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 		name := rs.Primary.ID
 		resp, err := conn.RbacV1().ClusterRoleBindings().Get(name, meta_v1.GetOptions{})
 		if err != nil {

--- a/kubernetes/resource_kubernetes_cluster_role_binding_test.go
+++ b/kubernetes/resource_kubernetes_cluster_role_binding_test.go
@@ -299,7 +299,10 @@ func TestAccKubernetesClusterRoleBindingUpdatePatchOperationsOrderWithRemovals(t
 }
 
 func testAccCheckKubernetesClusterRoleBindingDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_cluster_role_binding" {
@@ -324,7 +327,11 @@ func testAccCheckKubernetesClusterRoleBindingExists(n string, obj *api.ClusterRo
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
+
 		name := rs.Primary.ID
 		resp, err := conn.RbacV1().ClusterRoleBindings().Get(name, meta_v1.GetOptions{})
 		if err != nil {

--- a/kubernetes/resource_kubernetes_cluster_role_test.go
+++ b/kubernetes/resource_kubernetes_cluster_role_test.go
@@ -151,7 +151,7 @@ func TestAccKubernetesClusterRoleUpdatePatchOperationsOrderWithRemovals(t *testi
 }
 
 func testAccCheckKubernetesClusterRoleDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_cluster_role" {
 			continue
@@ -172,7 +172,7 @@ func testAccCheckKubernetesClusterRoleExists(n string, obj *api.ClusterRole) res
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 		out, err := conn.RbacV1().ClusterRoles().Get(rs.Primary.ID, meta_v1.GetOptions{})
 		if err != nil {
 			return err

--- a/kubernetes/resource_kubernetes_cluster_role_test.go
+++ b/kubernetes/resource_kubernetes_cluster_role_test.go
@@ -151,7 +151,11 @@ func TestAccKubernetesClusterRoleUpdatePatchOperationsOrderWithRemovals(t *testi
 }
 
 func testAccCheckKubernetesClusterRoleDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
+
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_cluster_role" {
 			continue
@@ -172,7 +176,11 @@ func testAccCheckKubernetesClusterRoleExists(n string, obj *api.ClusterRole) res
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
+
 		out, err := conn.RbacV1().ClusterRoles().Get(rs.Primary.ID, meta_v1.GetOptions{})
 		if err != nil {
 			return err

--- a/kubernetes/resource_kubernetes_config_map.go
+++ b/kubernetes/resource_kubernetes_config_map.go
@@ -40,7 +40,10 @@ func resourceKubernetesConfigMap() *schema.Resource {
 }
 
 func resourceKubernetesConfigMapCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	cfgMap := api.ConfigMap{
@@ -60,7 +63,10 @@ func resourceKubernetesConfigMapCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesConfigMapRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -85,7 +91,10 @@ func resourceKubernetesConfigMapRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesConfigMapUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -122,7 +131,10 @@ func resourceKubernetesConfigMapUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesConfigMapDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -141,7 +153,10 @@ func resourceKubernetesConfigMapDelete(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesConfigMapExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_config_map.go
+++ b/kubernetes/resource_kubernetes_config_map.go
@@ -40,7 +40,7 @@ func resourceKubernetesConfigMap() *schema.Resource {
 }
 
 func resourceKubernetesConfigMapCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	cfgMap := api.ConfigMap{
@@ -60,7 +60,7 @@ func resourceKubernetesConfigMapCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesConfigMapRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -85,7 +85,7 @@ func resourceKubernetesConfigMapRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesConfigMapUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -122,7 +122,7 @@ func resourceKubernetesConfigMapUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesConfigMapDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -141,7 +141,7 @@ func resourceKubernetesConfigMapDelete(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesConfigMapExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_config_map_test.go
+++ b/kubernetes/resource_kubernetes_config_map_test.go
@@ -235,7 +235,7 @@ func testAccCheckConfigMapData(m *api.ConfigMap, expected map[string]string) res
 }
 
 func testAccCheckKubernetesConfigMapDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_config_map" {
@@ -263,7 +263,7 @@ func testAccCheckKubernetesConfigMapExists(n string, obj *api.ConfigMap) resourc
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/kubernetes/resource_kubernetes_config_map_test.go
+++ b/kubernetes/resource_kubernetes_config_map_test.go
@@ -235,7 +235,10 @@ func testAccCheckConfigMapData(m *api.ConfigMap, expected map[string]string) res
 }
 
 func testAccCheckKubernetesConfigMapDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_config_map" {
@@ -263,7 +266,11 @@ func testAccCheckKubernetesConfigMapExists(n string, obj *api.ConfigMap) resourc
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
+
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/kubernetes/resource_kubernetes_cron_job.go
+++ b/kubernetes/resource_kubernetes_cron_job.go
@@ -43,7 +43,10 @@ func resourceKubernetesCronJob() *schema.Resource {
 }
 
 func resourceKubernetesCronJobCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandCronJobSpec(d.Get("spec").([]interface{}))
@@ -70,7 +73,10 @@ func resourceKubernetesCronJobCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesCronJobUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, _, err := idParts(d.Id())
 	if err != nil {
@@ -102,7 +108,10 @@ func resourceKubernetesCronJobUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesCronJobRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -158,7 +167,10 @@ func resourceKubernetesCronJobRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceKubernetesCronJobDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -194,7 +206,10 @@ func resourceKubernetesCronJobDelete(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesCronJobExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_cron_job.go
+++ b/kubernetes/resource_kubernetes_cron_job.go
@@ -43,7 +43,7 @@ func resourceKubernetesCronJob() *schema.Resource {
 }
 
 func resourceKubernetesCronJobCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandCronJobSpec(d.Get("spec").([]interface{}))
@@ -70,7 +70,7 @@ func resourceKubernetesCronJobCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesCronJobUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, _, err := idParts(d.Id())
 	if err != nil {
@@ -102,7 +102,7 @@ func resourceKubernetesCronJobUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesCronJobRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -158,7 +158,7 @@ func resourceKubernetesCronJobRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceKubernetesCronJobDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -194,7 +194,7 @@ func resourceKubernetesCronJobDelete(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesCronJobExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_cron_job_test.go
+++ b/kubernetes/resource_kubernetes_cron_job_test.go
@@ -112,7 +112,7 @@ func TestAccKubernetesCronJob_extra(t *testing.T) {
 }
 
 func testAccCheckKubernetesCronJobDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_cron_job" {
@@ -142,7 +142,7 @@ func testAccCheckKubernetesCronJobExists(n string, obj *v1beta1.CronJob) resourc
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_cron_job_test.go
+++ b/kubernetes/resource_kubernetes_cron_job_test.go
@@ -112,7 +112,10 @@ func TestAccKubernetesCronJob_extra(t *testing.T) {
 }
 
 func testAccCheckKubernetesCronJobDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_cron_job" {
@@ -142,7 +145,10 @@ func testAccCheckKubernetesCronJobExists(n string, obj *v1beta1.CronJob) resourc
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_daemonset.go
+++ b/kubernetes/resource_kubernetes_daemonset.go
@@ -117,7 +117,7 @@ func resourceKubernetesDaemonSet() *schema.Resource {
 }
 
 func resourceKubernetesDaemonSetCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandDaemonSetSpec(d.Get("spec").([]interface{}))
@@ -145,7 +145,7 @@ func resourceKubernetesDaemonSetCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesDaemonSetUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -187,7 +187,7 @@ func resourceKubernetesDaemonSetUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesDaemonSetRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -225,7 +225,7 @@ func resourceKubernetesDaemonSetRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesDaemonSetDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -245,7 +245,7 @@ func resourceKubernetesDaemonSetDelete(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesDaemonSetExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_daemonset.go
+++ b/kubernetes/resource_kubernetes_daemonset.go
@@ -117,7 +117,10 @@ func resourceKubernetesDaemonSet() *schema.Resource {
 }
 
 func resourceKubernetesDaemonSetCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandDaemonSetSpec(d.Get("spec").([]interface{}))
@@ -145,7 +148,10 @@ func resourceKubernetesDaemonSetCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesDaemonSetUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -187,7 +193,10 @@ func resourceKubernetesDaemonSetUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesDaemonSetRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -225,7 +234,10 @@ func resourceKubernetesDaemonSetRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesDaemonSetDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -245,7 +257,10 @@ func resourceKubernetesDaemonSetDelete(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesDaemonSetExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_daemonset_test.go
+++ b/kubernetes/resource_kubernetes_daemonset_test.go
@@ -266,7 +266,10 @@ func TestAccKubernetesDaemonSet_with_tolerations_unset_toleration_seconds(t *tes
 }
 
 func testAccCheckKubernetesDaemonSetDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_daemonset" {
@@ -296,7 +299,10 @@ func testAccCheckKubernetesDaemonSetExists(n string, obj *appsv1.DaemonSet) reso
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_daemonset_test.go
+++ b/kubernetes/resource_kubernetes_daemonset_test.go
@@ -266,7 +266,7 @@ func TestAccKubernetesDaemonSet_with_tolerations_unset_toleration_seconds(t *tes
 }
 
 func testAccCheckKubernetesDaemonSetDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_daemonset" {
@@ -296,7 +296,7 @@ func testAccCheckKubernetesDaemonSetExists(n string, obj *appsv1.DaemonSet) reso
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -195,7 +195,10 @@ func resourceKubernetesDeployment() *schema.Resource {
 }
 
 func resourceKubernetesDeploymentCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandDeploymentSpec(d.Get("spec").([]interface{}))
@@ -231,7 +234,10 @@ func resourceKubernetesDeploymentCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesDeploymentUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -272,7 +278,10 @@ func resourceKubernetesDeploymentUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesDeploymentRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -306,7 +315,10 @@ func resourceKubernetesDeploymentRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceKubernetesDeploymentDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -327,7 +339,10 @@ func resourceKubernetesDeploymentDelete(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesDeploymentExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -195,7 +195,7 @@ func resourceKubernetesDeployment() *schema.Resource {
 }
 
 func resourceKubernetesDeploymentCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandDeploymentSpec(d.Get("spec").([]interface{}))
@@ -231,7 +231,7 @@ func resourceKubernetesDeploymentCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesDeploymentUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -272,7 +272,7 @@ func resourceKubernetesDeploymentUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesDeploymentRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -306,7 +306,7 @@ func resourceKubernetesDeploymentRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceKubernetesDeploymentDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -327,7 +327,7 @@ func resourceKubernetesDeploymentDelete(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesDeploymentExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -849,7 +849,7 @@ func TestAccKubernetesDeployment_config_with_automount_service_account_token(t *
 }
 
 func testAccCheckKubernetesDeploymentDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_deployment" {
@@ -879,7 +879,7 @@ func testAccCheckKubernetesDeploymentExists(n string, obj *api.Deployment) resou
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -849,7 +849,10 @@ func TestAccKubernetesDeployment_config_with_automount_service_account_token(t *
 }
 
 func testAccCheckKubernetesDeploymentDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_deployment" {
@@ -879,7 +882,10 @@ func testAccCheckKubernetesDeploymentExists(n string, obj *api.Deployment) resou
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_endpoints.go
+++ b/kubernetes/resource_kubernetes_endpoints.go
@@ -36,7 +36,7 @@ func resourceKubernetesEndpoints() *schema.Resource {
 }
 
 func resourceKubernetesEndpointsCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	ep := api.Endpoints{
@@ -55,7 +55,7 @@ func resourceKubernetesEndpointsCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesEndpointsRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -85,7 +85,7 @@ func resourceKubernetesEndpointsRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesEndpointsUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -116,7 +116,7 @@ func resourceKubernetesEndpointsUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesEndpointsDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -134,7 +134,7 @@ func resourceKubernetesEndpointsDelete(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesEndpointsExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_endpoints.go
+++ b/kubernetes/resource_kubernetes_endpoints.go
@@ -36,7 +36,10 @@ func resourceKubernetesEndpoints() *schema.Resource {
 }
 
 func resourceKubernetesEndpointsCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	ep := api.Endpoints{
@@ -55,7 +58,10 @@ func resourceKubernetesEndpointsCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesEndpointsRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -85,7 +91,10 @@ func resourceKubernetesEndpointsRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesEndpointsUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -116,7 +125,10 @@ func resourceKubernetesEndpointsUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesEndpointsDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -134,7 +146,10 @@ func resourceKubernetesEndpointsDelete(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesEndpointsExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_endpoints_test.go
+++ b/kubernetes/resource_kubernetes_endpoints_test.go
@@ -275,7 +275,7 @@ func testAccCheckEndpointSubsets(svc *api.Endpoints, expected []api.EndpointSubs
 }
 
 func testAccCheckKubernetesEndpointDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_endpoints" {
@@ -305,7 +305,7 @@ func testAccCheckKubernetesEndpointExists(n string, obj *api.Endpoints) resource
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_endpoints_test.go
+++ b/kubernetes/resource_kubernetes_endpoints_test.go
@@ -275,7 +275,10 @@ func testAccCheckEndpointSubsets(svc *api.Endpoints, expected []api.EndpointSubs
 }
 
 func testAccCheckKubernetesEndpointDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_endpoints" {
@@ -305,7 +308,10 @@ func testAccCheckKubernetesEndpointExists(n string, obj *api.Endpoints) resource
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
@@ -81,7 +81,7 @@ func resourceKubernetesHorizontalPodAutoscaler() *schema.Resource {
 }
 
 func resourceKubernetesHorizontalPodAutoscalerCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandHorizontalPodAutoscalerSpec(d.Get("spec").([]interface{}))
@@ -106,7 +106,7 @@ func resourceKubernetesHorizontalPodAutoscalerCreate(d *schema.ResourceData, met
 }
 
 func resourceKubernetesHorizontalPodAutoscalerRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -135,7 +135,7 @@ func resourceKubernetesHorizontalPodAutoscalerRead(d *schema.ResourceData, meta 
 }
 
 func resourceKubernetesHorizontalPodAutoscalerUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -163,7 +163,7 @@ func resourceKubernetesHorizontalPodAutoscalerUpdate(d *schema.ResourceData, met
 }
 
 func resourceKubernetesHorizontalPodAutoscalerDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -182,7 +182,7 @@ func resourceKubernetesHorizontalPodAutoscalerDelete(d *schema.ResourceData, met
 }
 
 func resourceKubernetesHorizontalPodAutoscalerExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler.go
@@ -81,7 +81,10 @@ func resourceKubernetesHorizontalPodAutoscaler() *schema.Resource {
 }
 
 func resourceKubernetesHorizontalPodAutoscalerCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandHorizontalPodAutoscalerSpec(d.Get("spec").([]interface{}))
@@ -106,7 +109,10 @@ func resourceKubernetesHorizontalPodAutoscalerCreate(d *schema.ResourceData, met
 }
 
 func resourceKubernetesHorizontalPodAutoscalerRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -135,7 +141,10 @@ func resourceKubernetesHorizontalPodAutoscalerRead(d *schema.ResourceData, meta 
 }
 
 func resourceKubernetesHorizontalPodAutoscalerUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -163,7 +172,10 @@ func resourceKubernetesHorizontalPodAutoscalerUpdate(d *schema.ResourceData, met
 }
 
 func resourceKubernetesHorizontalPodAutoscalerDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -182,7 +194,10 @@ func resourceKubernetesHorizontalPodAutoscalerDelete(d *schema.ResourceData, met
 }
 
 func resourceKubernetesHorizontalPodAutoscalerExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_test.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_test.go
@@ -154,7 +154,10 @@ func TestAccKubernetesHorizontalPodAutoscaler_importBasic(t *testing.T) {
 }
 
 func testAccCheckKubernetesHorizontalPodAutoscalerDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_horizontal_pod_autoscaler" {
@@ -184,7 +187,10 @@ func testAccCheckKubernetesHorizontalPodAutoscalerExists(n string, obj *api.Hori
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_test.go
+++ b/kubernetes/resource_kubernetes_horizontal_pod_autoscaler_test.go
@@ -154,7 +154,7 @@ func TestAccKubernetesHorizontalPodAutoscaler_importBasic(t *testing.T) {
 }
 
 func testAccCheckKubernetesHorizontalPodAutoscalerDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_horizontal_pod_autoscaler" {
@@ -184,7 +184,7 @@ func testAccCheckKubernetesHorizontalPodAutoscalerExists(n string, obj *api.Hori
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_ingress.go
+++ b/kubernetes/resource_kubernetes_ingress.go
@@ -114,7 +114,10 @@ func resourceKubernetesIngress() *schema.Resource {
 }
 
 func resourceKubernetesIngressCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	ing := &v1beta1.Ingress{
@@ -133,7 +136,10 @@ func resourceKubernetesIngressCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesIngressRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -168,7 +174,10 @@ func resourceKubernetesIngressRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceKubernetesIngressUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, _, err := idParts(d.Id())
 	if err != nil {
@@ -197,7 +206,10 @@ func resourceKubernetesIngressUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesIngressDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -217,7 +229,10 @@ func resourceKubernetesIngressDelete(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesIngressExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_ingress.go
+++ b/kubernetes/resource_kubernetes_ingress.go
@@ -114,7 +114,7 @@ func resourceKubernetesIngress() *schema.Resource {
 }
 
 func resourceKubernetesIngressCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	ing := &v1beta1.Ingress{
@@ -133,7 +133,7 @@ func resourceKubernetesIngressCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesIngressRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -168,7 +168,7 @@ func resourceKubernetesIngressRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceKubernetesIngressUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, _, err := idParts(d.Id())
 	if err != nil {
@@ -197,7 +197,7 @@ func resourceKubernetesIngressUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesIngressDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -217,7 +217,7 @@ func resourceKubernetesIngressDelete(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesIngressExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_ingress_test.go
+++ b/kubernetes/resource_kubernetes_ingress_test.go
@@ -148,7 +148,10 @@ func TestAccKubernetesIngress_InternalKey(t *testing.T) {
 }
 
 func testAccCheckKubernetesIngressDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_ingress" {
@@ -178,7 +181,10 @@ func testAccCheckKubernetesIngressExists(n string, obj *api.Ingress) resource.Te
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_ingress_test.go
+++ b/kubernetes/resource_kubernetes_ingress_test.go
@@ -148,7 +148,7 @@ func TestAccKubernetesIngress_InternalKey(t *testing.T) {
 }
 
 func testAccCheckKubernetesIngressDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_ingress" {
@@ -178,7 +178,7 @@ func testAccCheckKubernetesIngressExists(n string, obj *api.Ingress) resource.Te
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -47,7 +47,7 @@ func resourceKubernetesJob() *schema.Resource {
 }
 
 func resourceKubernetesJobCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandJobSpec(d.Get("spec").([]interface{}))
@@ -74,7 +74,7 @@ func resourceKubernetesJobCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceKubernetesJobUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -101,7 +101,7 @@ func resourceKubernetesJobUpdate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceKubernetesJobRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -154,7 +154,7 @@ func resourceKubernetesJobRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceKubernetesJobDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -190,7 +190,7 @@ func resourceKubernetesJobDelete(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceKubernetesJobExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_job.go
+++ b/kubernetes/resource_kubernetes_job.go
@@ -47,7 +47,10 @@ func resourceKubernetesJob() *schema.Resource {
 }
 
 func resourceKubernetesJobCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandJobSpec(d.Get("spec").([]interface{}))
@@ -74,7 +77,10 @@ func resourceKubernetesJobCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceKubernetesJobUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -101,7 +107,10 @@ func resourceKubernetesJobUpdate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceKubernetesJobRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -154,7 +163,10 @@ func resourceKubernetesJobRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceKubernetesJobDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -190,7 +202,10 @@ func resourceKubernetesJobDelete(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceKubernetesJobExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_job_test.go
+++ b/kubernetes/resource_kubernetes_job_test.go
@@ -65,7 +65,7 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 }
 
 func testAccCheckKubernetesJobDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_job" {
@@ -95,7 +95,7 @@ func testAccCheckKubernetesJobExists(n string, obj *api.Job) resource.TestCheckF
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_job_test.go
+++ b/kubernetes/resource_kubernetes_job_test.go
@@ -65,7 +65,10 @@ func TestAccKubernetesJob_basic(t *testing.T) {
 }
 
 func testAccCheckKubernetesJobDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_job" {
@@ -95,7 +98,10 @@ func testAccCheckKubernetesJobExists(n string, obj *api.Job) resource.TestCheckF
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_limit_range.go
+++ b/kubernetes/resource_kubernetes_limit_range.go
@@ -79,7 +79,10 @@ func resourceKubernetesLimitRange() *schema.Resource {
 }
 
 func resourceKubernetesLimitRangeCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandLimitRangeSpec(d.Get("spec").([]interface{}), d.IsNewResource())
@@ -102,7 +105,10 @@ func resourceKubernetesLimitRangeCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesLimitRangeRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -129,7 +135,10 @@ func resourceKubernetesLimitRangeRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceKubernetesLimitRangeUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -163,7 +172,10 @@ func resourceKubernetesLimitRangeUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesLimitRangeDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -183,7 +195,10 @@ func resourceKubernetesLimitRangeDelete(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesLimitRangeExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_limit_range.go
+++ b/kubernetes/resource_kubernetes_limit_range.go
@@ -79,7 +79,7 @@ func resourceKubernetesLimitRange() *schema.Resource {
 }
 
 func resourceKubernetesLimitRangeCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandLimitRangeSpec(d.Get("spec").([]interface{}), d.IsNewResource())
@@ -102,7 +102,7 @@ func resourceKubernetesLimitRangeCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesLimitRangeRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -129,7 +129,7 @@ func resourceKubernetesLimitRangeRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceKubernetesLimitRangeUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -163,7 +163,7 @@ func resourceKubernetesLimitRangeUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesLimitRangeDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -183,7 +183,7 @@ func resourceKubernetesLimitRangeDelete(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesLimitRangeExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_limit_range_test.go
+++ b/kubernetes/resource_kubernetes_limit_range_test.go
@@ -287,7 +287,7 @@ func TestAccKubernetesLimitRange_importBasic(t *testing.T) {
 }
 
 func testAccCheckKubernetesLimitRangeDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_limit_range" {
@@ -317,7 +317,7 @@ func testAccCheckKubernetesLimitRangeExists(n string, obj *api.LimitRange) resou
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_limit_range_test.go
+++ b/kubernetes/resource_kubernetes_limit_range_test.go
@@ -287,7 +287,10 @@ func TestAccKubernetesLimitRange_importBasic(t *testing.T) {
 }
 
 func testAccCheckKubernetesLimitRangeDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_limit_range" {
@@ -317,7 +320,10 @@ func testAccCheckKubernetesLimitRangeExists(n string, obj *api.LimitRange) resou
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_namespace.go
+++ b/kubernetes/resource_kubernetes_namespace.go
@@ -34,7 +34,10 @@ func resourceKubernetesNamespace() *schema.Resource {
 }
 
 func resourceKubernetesNamespaceCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	namespace := api.Namespace{
@@ -52,7 +55,10 @@ func resourceKubernetesNamespaceCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesNamespaceRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 	log.Printf("[INFO] Reading namespace %s", name)
@@ -71,7 +77,10 @@ func resourceKubernetesNamespaceRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesNamespaceUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 	data, err := ops.MarshalJSON()
@@ -91,11 +100,14 @@ func resourceKubernetesNamespaceUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 	log.Printf("[INFO] Deleting namespace: %#v", name)
-	err := conn.CoreV1().Namespaces().Delete(name, &meta_v1.DeleteOptions{})
+	err = conn.CoreV1().Namespaces().Delete(name, &meta_v1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -130,11 +142,14 @@ func resourceKubernetesNamespaceDelete(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesNamespaceExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	name := d.Id()
 	log.Printf("[INFO] Checking namespace %s", name)
-	_, err := conn.CoreV1().Namespaces().Get(name, meta_v1.GetOptions{})
+	_, err = conn.CoreV1().Namespaces().Get(name, meta_v1.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return false, nil

--- a/kubernetes/resource_kubernetes_namespace.go
+++ b/kubernetes/resource_kubernetes_namespace.go
@@ -34,7 +34,7 @@ func resourceKubernetesNamespace() *schema.Resource {
 }
 
 func resourceKubernetesNamespaceCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	namespace := api.Namespace{
@@ -52,7 +52,7 @@ func resourceKubernetesNamespaceCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesNamespaceRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 	log.Printf("[INFO] Reading namespace %s", name)
@@ -71,7 +71,7 @@ func resourceKubernetesNamespaceRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesNamespaceUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 	data, err := ops.MarshalJSON()
@@ -91,7 +91,7 @@ func resourceKubernetesNamespaceUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 	log.Printf("[INFO] Deleting namespace: %#v", name)
@@ -130,7 +130,7 @@ func resourceKubernetesNamespaceDelete(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesNamespaceExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 	log.Printf("[INFO] Checking namespace %s", name)

--- a/kubernetes/resource_kubernetes_namespace_test.go
+++ b/kubernetes/resource_kubernetes_namespace_test.go
@@ -299,7 +299,7 @@ func testAccCheckMetaLabels(om *meta_v1.ObjectMeta, expected map[string]string) 
 }
 
 func testAccCheckKubernetesNamespaceDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_namespace" {
@@ -324,7 +324,7 @@ func testAccCheckKubernetesNamespaceExists(n string, obj *api.Namespace) resourc
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 		out, err := conn.CoreV1().Namespaces().Get(rs.Primary.ID, meta_v1.GetOptions{})
 		if err != nil {
 			return err

--- a/kubernetes/resource_kubernetes_namespace_test.go
+++ b/kubernetes/resource_kubernetes_namespace_test.go
@@ -299,7 +299,10 @@ func testAccCheckMetaLabels(om *meta_v1.ObjectMeta, expected map[string]string) 
 }
 
 func testAccCheckKubernetesNamespaceDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_namespace" {
@@ -324,7 +327,11 @@ func testAccCheckKubernetesNamespaceExists(n string, obj *api.Namespace) resourc
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
+
 		out, err := conn.CoreV1().Namespaces().Get(rs.Primary.ID, meta_v1.GetOptions{})
 		if err != nil {
 			return err

--- a/kubernetes/resource_kubernetes_network_policy.go
+++ b/kubernetes/resource_kubernetes_network_policy.go
@@ -235,7 +235,7 @@ func resourceKubernetesNetworkPolicy() *schema.Resource {
 }
 
 func resourceKubernetesNetworkPolicyCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandNetworkPolicySpec(d.Get("spec").([]interface{}))
@@ -260,7 +260,7 @@ func resourceKubernetesNetworkPolicyCreate(d *schema.ResourceData, meta interfac
 }
 
 func resourceKubernetesNetworkPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -289,7 +289,7 @@ func resourceKubernetesNetworkPolicyRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesNetworkPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -320,7 +320,7 @@ func resourceKubernetesNetworkPolicyUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceKubernetesNetworkPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -338,7 +338,7 @@ func resourceKubernetesNetworkPolicyDelete(d *schema.ResourceData, meta interfac
 }
 
 func resourceKubernetesNetworkPolicyExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_network_policy.go
+++ b/kubernetes/resource_kubernetes_network_policy.go
@@ -235,7 +235,10 @@ func resourceKubernetesNetworkPolicy() *schema.Resource {
 }
 
 func resourceKubernetesNetworkPolicyCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandNetworkPolicySpec(d.Get("spec").([]interface{}))
@@ -260,7 +263,10 @@ func resourceKubernetesNetworkPolicyCreate(d *schema.ResourceData, meta interfac
 }
 
 func resourceKubernetesNetworkPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -289,7 +295,10 @@ func resourceKubernetesNetworkPolicyRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesNetworkPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -320,7 +329,10 @@ func resourceKubernetesNetworkPolicyUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceKubernetesNetworkPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -338,7 +350,10 @@ func resourceKubernetesNetworkPolicyDelete(d *schema.ResourceData, meta interfac
 }
 
 func resourceKubernetesNetworkPolicyExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_network_policy_test.go
+++ b/kubernetes/resource_kubernetes_network_policy_test.go
@@ -364,7 +364,10 @@ func TestAccKubernetesNetworkPolicy_importBasic(t *testing.T) {
 }
 
 func testAccCheckKubernetesNetworkPolicyDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_network_policy" {
@@ -394,7 +397,10 @@ func testAccCheckKubernetesNetworkPolicyExists(n string, obj *api.NetworkPolicy)
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_network_policy_test.go
+++ b/kubernetes/resource_kubernetes_network_policy_test.go
@@ -364,7 +364,7 @@ func TestAccKubernetesNetworkPolicy_importBasic(t *testing.T) {
 }
 
 func testAccCheckKubernetesNetworkPolicyDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_network_policy" {
@@ -394,7 +394,7 @@ func testAccCheckKubernetesNetworkPolicyExists(n string, obj *api.NetworkPolicy)
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -37,7 +37,7 @@ func resourceKubernetesPersistentVolume() *schema.Resource {
 
 			// Mutation of PersistentVolumeSource after creation is no longer allowed in 1.9+
 			// See https://github.com/kubernetes/kubernetes/blob/v1.9.3/CHANGELOG-1.9.md#storage-3
-			conn := meta.(*KubeClientsets).MainClientset
+			conn := meta.(KubeClientsets).MainClientset()
 			serverVersion, err := conn.ServerVersion()
 			if err != nil {
 				return err
@@ -149,7 +149,7 @@ func resourceKubernetesPersistentVolume() *schema.Resource {
 }
 
 func resourceKubernetesPersistentVolumeCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandPersistentVolumeSpec(d.Get("spec").([]interface{}))
@@ -196,7 +196,7 @@ func resourceKubernetesPersistentVolumeCreate(d *schema.ResourceData, meta inter
 }
 
 func resourceKubernetesPersistentVolumeRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 	log.Printf("[INFO] Reading persistent volume %s", name)
@@ -219,7 +219,7 @@ func resourceKubernetesPersistentVolumeRead(d *schema.ResourceData, meta interfa
 }
 
 func resourceKubernetesPersistentVolumeUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 	if d.HasChange("spec") {
@@ -246,7 +246,7 @@ func resourceKubernetesPersistentVolumeUpdate(d *schema.ResourceData, meta inter
 }
 
 func resourceKubernetesPersistentVolumeDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 	log.Printf("[INFO] Deleting persistent volume: %#v", name)
@@ -279,7 +279,7 @@ func resourceKubernetesPersistentVolumeDelete(d *schema.ResourceData, meta inter
 }
 
 func resourceKubernetesPersistentVolumeExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 	log.Printf("[INFO] Checking persistent volume %s", name)

--- a/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/kubernetes/resource_kubernetes_persistent_volume.go
@@ -37,7 +37,10 @@ func resourceKubernetesPersistentVolume() *schema.Resource {
 
 			// Mutation of PersistentVolumeSource after creation is no longer allowed in 1.9+
 			// See https://github.com/kubernetes/kubernetes/blob/v1.9.3/CHANGELOG-1.9.md#storage-3
-			conn := meta.(KubeClientsets).MainClientset()
+			conn, err := meta.(KubeClientsets).MainClientset()
+			if err != nil {
+				return err
+			}
 			serverVersion, err := conn.ServerVersion()
 			if err != nil {
 				return err
@@ -149,7 +152,10 @@ func resourceKubernetesPersistentVolume() *schema.Resource {
 }
 
 func resourceKubernetesPersistentVolumeCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandPersistentVolumeSpec(d.Get("spec").([]interface{}))
@@ -196,7 +202,10 @@ func resourceKubernetesPersistentVolumeCreate(d *schema.ResourceData, meta inter
 }
 
 func resourceKubernetesPersistentVolumeRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 	log.Printf("[INFO] Reading persistent volume %s", name)
@@ -219,7 +228,10 @@ func resourceKubernetesPersistentVolumeRead(d *schema.ResourceData, meta interfa
 }
 
 func resourceKubernetesPersistentVolumeUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
 	if d.HasChange("spec") {
@@ -246,11 +258,14 @@ func resourceKubernetesPersistentVolumeUpdate(d *schema.ResourceData, meta inter
 }
 
 func resourceKubernetesPersistentVolumeDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 	log.Printf("[INFO] Deleting persistent volume: %#v", name)
-	err := conn.CoreV1().PersistentVolumes().Delete(name, &meta_v1.DeleteOptions{})
+	err = conn.CoreV1().PersistentVolumes().Delete(name, &meta_v1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -279,11 +294,14 @@ func resourceKubernetesPersistentVolumeDelete(d *schema.ResourceData, meta inter
 }
 
 func resourceKubernetesPersistentVolumeExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	name := d.Id()
 	log.Printf("[INFO] Checking persistent volume %s", name)
-	_, err := conn.CoreV1().PersistentVolumes().Get(name, meta_v1.GetOptions{})
+	_, err = conn.CoreV1().PersistentVolumes().Get(name, meta_v1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return false, nil

--- a/kubernetes/resource_kubernetes_persistent_volume_claim.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim.go
@@ -45,7 +45,10 @@ func resourceKubernetesPersistentVolumeClaim() *schema.Resource {
 }
 
 func resourceKubernetesPersistentVolumeClaimCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	claim, err := expandPersistenVolumeClaim(map[string]interface{}{
 		"metadata": d.Get("metadata"),
@@ -109,7 +112,10 @@ func resourceKubernetesPersistentVolumeClaimCreate(d *schema.ResourceData, meta 
 }
 
 func resourceKubernetesPersistentVolumeClaimRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -136,7 +142,10 @@ func resourceKubernetesPersistentVolumeClaimRead(d *schema.ResourceData, meta in
 }
 
 func resourceKubernetesPersistentVolumeClaimUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -161,7 +170,10 @@ func resourceKubernetesPersistentVolumeClaimUpdate(d *schema.ResourceData, meta 
 }
 
 func resourceKubernetesPersistentVolumeClaimDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -181,7 +193,10 @@ func resourceKubernetesPersistentVolumeClaimDelete(d *schema.ResourceData, meta 
 }
 
 func resourceKubernetesPersistentVolumeClaimExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_persistent_volume_claim.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim.go
@@ -45,7 +45,7 @@ func resourceKubernetesPersistentVolumeClaim() *schema.Resource {
 }
 
 func resourceKubernetesPersistentVolumeClaimCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	claim, err := expandPersistenVolumeClaim(map[string]interface{}{
 		"metadata": d.Get("metadata"),
@@ -109,7 +109,7 @@ func resourceKubernetesPersistentVolumeClaimCreate(d *schema.ResourceData, meta 
 }
 
 func resourceKubernetesPersistentVolumeClaimRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -136,7 +136,7 @@ func resourceKubernetesPersistentVolumeClaimRead(d *schema.ResourceData, meta in
 }
 
 func resourceKubernetesPersistentVolumeClaimUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -161,7 +161,7 @@ func resourceKubernetesPersistentVolumeClaimUpdate(d *schema.ResourceData, meta 
 }
 
 func resourceKubernetesPersistentVolumeClaimDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -181,7 +181,7 @@ func resourceKubernetesPersistentVolumeClaimDelete(d *schema.ResourceData, meta 
 }
 
 func resourceKubernetesPersistentVolumeClaimExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
@@ -447,7 +447,7 @@ func TestAccKubernetesPersistentVolumeClaim_googleCloud_storageClass(t *testing.
 }
 
 func testAccCheckKubernetesPersistentVolumeClaimDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_persistent_volume_claim" {
@@ -488,7 +488,7 @@ func testAccCheckKubernetesPersistentVolumeClaimExists(n string, obj *api.Persis
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim_test.go
@@ -447,7 +447,10 @@ func TestAccKubernetesPersistentVolumeClaim_googleCloud_storageClass(t *testing.
 }
 
 func testAccCheckKubernetesPersistentVolumeClaimDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_persistent_volume_claim" {
@@ -488,7 +491,10 @@ func testAccCheckKubernetesPersistentVolumeClaimExists(n string, obj *api.Persis
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -586,7 +586,7 @@ func TestAccKubernetesPersistentVolume_hostPath_mountOptions(t *testing.T) {
 }
 
 func waitForPersistenceVolumeDeleted(pvName string, poll, timeout time.Duration) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
 		_, err := conn.CoreV1().PersistentVolumes().Get(pvName, meta_v1.GetOptions{})
 		if err != nil && apierrs.IsNotFound(err) {
@@ -597,7 +597,7 @@ func waitForPersistenceVolumeDeleted(pvName string, poll, timeout time.Duration)
 }
 
 func testAccCheckKubernetesPersistentVolumeDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 	timeout := 5 * time.Second
 	poll := 1 * time.Second
 
@@ -624,7 +624,7 @@ func testAccCheckKubernetesPersistentVolumeExists(n string, obj *api.PersistentV
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 		name := rs.Primary.ID
 		out, err := conn.CoreV1().PersistentVolumes().Get(name, meta_v1.GetOptions{})
 		if err != nil {

--- a/kubernetes/resource_kubernetes_persistent_volume_test.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_test.go
@@ -586,7 +586,11 @@ func TestAccKubernetesPersistentVolume_hostPath_mountOptions(t *testing.T) {
 }
 
 func waitForPersistenceVolumeDeleted(pvName string, poll, timeout time.Duration) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
+
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
 		_, err := conn.CoreV1().PersistentVolumes().Get(pvName, meta_v1.GetOptions{})
 		if err != nil && apierrs.IsNotFound(err) {
@@ -597,7 +601,11 @@ func waitForPersistenceVolumeDeleted(pvName string, poll, timeout time.Duration)
 }
 
 func testAccCheckKubernetesPersistentVolumeDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
+
 	timeout := 5 * time.Second
 	poll := 1 * time.Second
 
@@ -624,7 +632,11 @@ func testAccCheckKubernetesPersistentVolumeExists(n string, obj *api.PersistentV
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
+
 		name := rs.Primary.ID
 		out, err := conn.CoreV1().PersistentVolumes().Get(name, meta_v1.GetOptions{})
 		if err != nil {

--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -49,7 +49,7 @@ func resourceKubernetesPod() *schema.Resource {
 	}
 }
 func resourceKubernetesPodCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandPodSpec(d.Get("spec").([]interface{}))
@@ -102,7 +102,7 @@ func resourceKubernetesPodCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceKubernetesPodUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -135,7 +135,7 @@ func resourceKubernetesPodUpdate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceKubernetesPodRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -169,7 +169,7 @@ func resourceKubernetesPodRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceKubernetesPodDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -206,7 +206,7 @@ func resourceKubernetesPodDelete(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceKubernetesPodExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_pod.go
+++ b/kubernetes/resource_kubernetes_pod.go
@@ -49,7 +49,10 @@ func resourceKubernetesPod() *schema.Resource {
 	}
 }
 func resourceKubernetesPodCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandPodSpec(d.Get("spec").([]interface{}))
@@ -102,7 +105,10 @@ func resourceKubernetesPodCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceKubernetesPodUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -135,7 +141,10 @@ func resourceKubernetesPodUpdate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceKubernetesPodRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -169,7 +178,10 @@ func resourceKubernetesPodRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceKubernetesPodDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -206,7 +218,10 @@ func resourceKubernetesPodDelete(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceKubernetesPodExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_pod_disruption_budget.go
+++ b/kubernetes/resource_kubernetes_pod_disruption_budget.go
@@ -75,7 +75,10 @@ func resourceKubernetesPodDisruptionBudget() *schema.Resource {
 }
 
 func resourceKubernetesPodDisruptionBudgetUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -101,7 +104,10 @@ func resourceKubernetesPodDisruptionBudgetUpdate(d *schema.ResourceData, meta in
 }
 
 func resourceKubernetesPodDisruptionBudgetCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandPodDisruptionBudgetSpec(d.Get("spec").([]interface{}))
@@ -126,7 +132,10 @@ func resourceKubernetesPodDisruptionBudgetCreate(d *schema.ResourceData, meta in
 }
 
 func resourceKubernetesPodDisruptionBudgetRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -155,7 +164,10 @@ func resourceKubernetesPodDisruptionBudgetRead(d *schema.ResourceData, meta inte
 }
 
 func resourceKubernetesPodDisruptionBudgetDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -176,7 +188,10 @@ func resourceKubernetesPodDisruptionBudgetDelete(d *schema.ResourceData, meta in
 }
 
 func resourceKubernetesPodDisruptionBudgetExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_pod_disruption_budget.go
+++ b/kubernetes/resource_kubernetes_pod_disruption_budget.go
@@ -75,7 +75,7 @@ func resourceKubernetesPodDisruptionBudget() *schema.Resource {
 }
 
 func resourceKubernetesPodDisruptionBudgetUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -101,7 +101,7 @@ func resourceKubernetesPodDisruptionBudgetUpdate(d *schema.ResourceData, meta in
 }
 
 func resourceKubernetesPodDisruptionBudgetCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandPodDisruptionBudgetSpec(d.Get("spec").([]interface{}))
@@ -126,7 +126,7 @@ func resourceKubernetesPodDisruptionBudgetCreate(d *schema.ResourceData, meta in
 }
 
 func resourceKubernetesPodDisruptionBudgetRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -155,7 +155,7 @@ func resourceKubernetesPodDisruptionBudgetRead(d *schema.ResourceData, meta inte
 }
 
 func resourceKubernetesPodDisruptionBudgetDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -176,7 +176,7 @@ func resourceKubernetesPodDisruptionBudgetDelete(d *schema.ResourceData, meta in
 }
 
 func resourceKubernetesPodDisruptionBudgetExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_pod_disruption_budget_test.go
+++ b/kubernetes/resource_kubernetes_pod_disruption_budget_test.go
@@ -103,7 +103,7 @@ func TestAccKubernetesPodDisruptionBudget_importBasic(t *testing.T) {
 }
 
 func testAccCheckKubernetesPodDisruptionBudgetDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_pod_disruption_budget" {
@@ -133,7 +133,7 @@ func testAccCheckKubernetesPodDisruptionBudgetExists(n string, obj *api.PodDisru
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_pod_disruption_budget_test.go
+++ b/kubernetes/resource_kubernetes_pod_disruption_budget_test.go
@@ -103,7 +103,10 @@ func TestAccKubernetesPodDisruptionBudget_importBasic(t *testing.T) {
 }
 
 func testAccCheckKubernetesPodDisruptionBudgetDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_pod_disruption_budget" {
@@ -133,7 +136,10 @@ func testAccCheckKubernetesPodDisruptionBudgetExists(n string, obj *api.PodDisru
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -723,7 +723,7 @@ func TestAccKubernetesPod_config_container_startup_probe(t *testing.T) {
 }
 
 func testAccCheckKubernetesPodDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_pod" {
@@ -753,7 +753,7 @@ func testAccCheckKubernetesPodExists(n string, obj *api.Pod) resource.TestCheckF
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -723,7 +723,10 @@ func TestAccKubernetesPod_config_container_startup_probe(t *testing.T) {
 }
 
 func testAccCheckKubernetesPodDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_pod" {
@@ -753,7 +756,10 @@ func testAccCheckKubernetesPodExists(n string, obj *api.Pod) resource.TestCheckF
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_priority_class.go
+++ b/kubernetes/resource_kubernetes_priority_class.go
@@ -47,7 +47,10 @@ func resourceKubernetesPriorityClass() *schema.Resource {
 }
 
 func resourceKubernetesPriorityClassCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	value := d.Get("value").(int)
@@ -73,7 +76,10 @@ func resourceKubernetesPriorityClassCreate(d *schema.ResourceData, meta interfac
 }
 
 func resourceKubernetesPriorityClassRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 
@@ -109,7 +115,10 @@ func resourceKubernetesPriorityClassRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesPriorityClassUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 
@@ -147,12 +156,15 @@ func resourceKubernetesPriorityClassUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceKubernetesPriorityClassDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 
 	log.Printf("[INFO] Deleting priority class: %#v", name)
-	err := conn.SchedulingV1().PriorityClasses().Delete(name, &meta_v1.DeleteOptions{})
+	err = conn.SchedulingV1().PriorityClasses().Delete(name, &meta_v1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -164,12 +176,15 @@ func resourceKubernetesPriorityClassDelete(d *schema.ResourceData, meta interfac
 }
 
 func resourceKubernetesPriorityClassExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	name := d.Id()
 
 	log.Printf("[INFO] Checking priority class %s", name)
-	_, err := conn.SchedulingV1().PriorityClasses().Get(name, meta_v1.GetOptions{})
+	_, err = conn.SchedulingV1().PriorityClasses().Get(name, meta_v1.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return false, nil

--- a/kubernetes/resource_kubernetes_priority_class.go
+++ b/kubernetes/resource_kubernetes_priority_class.go
@@ -47,7 +47,7 @@ func resourceKubernetesPriorityClass() *schema.Resource {
 }
 
 func resourceKubernetesPriorityClassCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	value := d.Get("value").(int)
@@ -73,7 +73,7 @@ func resourceKubernetesPriorityClassCreate(d *schema.ResourceData, meta interfac
 }
 
 func resourceKubernetesPriorityClassRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 
@@ -109,7 +109,7 @@ func resourceKubernetesPriorityClassRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesPriorityClassUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 
@@ -147,7 +147,7 @@ func resourceKubernetesPriorityClassUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceKubernetesPriorityClassDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 
@@ -164,7 +164,7 @@ func resourceKubernetesPriorityClassDelete(d *schema.ResourceData, meta interfac
 }
 
 func resourceKubernetesPriorityClassExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 

--- a/kubernetes/resource_kubernetes_priority_class_test.go
+++ b/kubernetes/resource_kubernetes_priority_class_test.go
@@ -137,7 +137,10 @@ func TestAccKubernetesPriorityClass_importBasic(t *testing.T) {
 }
 
 func testAccCheckKubernetesPriorityClassDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_priority_class" {
@@ -164,7 +167,10 @@ func testAccCheckKubernetesPriorityClassExists(n string, obj *api.PriorityClass)
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		name := rs.Primary.ID
 

--- a/kubernetes/resource_kubernetes_priority_class_test.go
+++ b/kubernetes/resource_kubernetes_priority_class_test.go
@@ -137,7 +137,7 @@ func TestAccKubernetesPriorityClass_importBasic(t *testing.T) {
 }
 
 func testAccCheckKubernetesPriorityClassDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_priority_class" {
@@ -164,7 +164,7 @@ func testAccCheckKubernetesPriorityClassExists(n string, obj *api.PriorityClass)
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		name := rs.Primary.ID
 

--- a/kubernetes/resource_kubernetes_replication_controller.go
+++ b/kubernetes/resource_kubernetes_replication_controller.go
@@ -110,7 +110,10 @@ func useDeprecatedSpecFields(d *schema.ResourceData) (deprecatedSpecFieldsExist 
 }
 
 func resourceKubernetesReplicationControllerCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 
@@ -150,7 +153,10 @@ func resourceKubernetesReplicationControllerCreate(d *schema.ResourceData, meta 
 }
 
 func resourceKubernetesReplicationControllerRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -184,7 +190,10 @@ func resourceKubernetesReplicationControllerRead(d *schema.ResourceData, meta in
 }
 
 func resourceKubernetesReplicationControllerUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -225,7 +234,10 @@ func resourceKubernetesReplicationControllerUpdate(d *schema.ResourceData, meta 
 }
 
 func resourceKubernetesReplicationControllerDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -268,7 +280,10 @@ func resourceKubernetesReplicationControllerDelete(d *schema.ResourceData, meta 
 }
 
 func resourceKubernetesReplicationControllerExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_replication_controller.go
+++ b/kubernetes/resource_kubernetes_replication_controller.go
@@ -110,7 +110,7 @@ func useDeprecatedSpecFields(d *schema.ResourceData) (deprecatedSpecFieldsExist 
 }
 
 func resourceKubernetesReplicationControllerCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 
@@ -150,7 +150,7 @@ func resourceKubernetesReplicationControllerCreate(d *schema.ResourceData, meta 
 }
 
 func resourceKubernetesReplicationControllerRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -184,7 +184,7 @@ func resourceKubernetesReplicationControllerRead(d *schema.ResourceData, meta in
 }
 
 func resourceKubernetesReplicationControllerUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -225,7 +225,7 @@ func resourceKubernetesReplicationControllerUpdate(d *schema.ResourceData, meta 
 }
 
 func resourceKubernetesReplicationControllerDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -268,7 +268,7 @@ func resourceKubernetesReplicationControllerDelete(d *schema.ResourceData, meta 
 }
 
 func resourceKubernetesReplicationControllerExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_replication_controller_test.go
+++ b/kubernetes/resource_kubernetes_replication_controller_test.go
@@ -461,7 +461,10 @@ func TestAccKubernetesReplicationController_with_empty_dir_volume(t *testing.T) 
 }
 
 func testAccCheckKubernetesReplicationControllerDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_replication_controller" {
@@ -491,7 +494,10 @@ func testAccCheckKubernetesReplicationControllerExists(n string, obj *api.Replic
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_replication_controller_test.go
+++ b/kubernetes/resource_kubernetes_replication_controller_test.go
@@ -461,7 +461,7 @@ func TestAccKubernetesReplicationController_with_empty_dir_volume(t *testing.T) 
 }
 
 func testAccCheckKubernetesReplicationControllerDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_replication_controller" {
@@ -491,7 +491,7 @@ func testAccCheckKubernetesReplicationControllerExists(n string, obj *api.Replic
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_resource_quota.go
+++ b/kubernetes/resource_kubernetes_resource_quota.go
@@ -61,7 +61,7 @@ func resourceKubernetesResourceQuota() *schema.Resource {
 }
 
 func resourceKubernetesResourceQuotaCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandResourceQuotaSpec(d.Get("spec").([]interface{}))
@@ -100,7 +100,7 @@ func resourceKubernetesResourceQuotaCreate(d *schema.ResourceData, meta interfac
 }
 
 func resourceKubernetesResourceQuotaRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -136,7 +136,7 @@ func resourceKubernetesResourceQuotaRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesResourceQuotaUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -191,7 +191,7 @@ func resourceKubernetesResourceQuotaUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceKubernetesResourceQuotaDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -211,7 +211,7 @@ func resourceKubernetesResourceQuotaDelete(d *schema.ResourceData, meta interfac
 }
 
 func resourceKubernetesResourceQuotaExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_resource_quota.go
+++ b/kubernetes/resource_kubernetes_resource_quota.go
@@ -61,7 +61,10 @@ func resourceKubernetesResourceQuota() *schema.Resource {
 }
 
 func resourceKubernetesResourceQuotaCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandResourceQuotaSpec(d.Get("spec").([]interface{}))
@@ -100,7 +103,10 @@ func resourceKubernetesResourceQuotaCreate(d *schema.ResourceData, meta interfac
 }
 
 func resourceKubernetesResourceQuotaRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -136,7 +142,10 @@ func resourceKubernetesResourceQuotaRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesResourceQuotaUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -191,7 +200,10 @@ func resourceKubernetesResourceQuotaUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceKubernetesResourceQuotaDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -211,7 +223,10 @@ func resourceKubernetesResourceQuotaDelete(d *schema.ResourceData, meta interfac
 }
 
 func resourceKubernetesResourceQuotaExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_resource_quota_test.go
+++ b/kubernetes/resource_kubernetes_resource_quota_test.go
@@ -199,7 +199,7 @@ func TestAccKubernetesResourceQuota_importBasic(t *testing.T) {
 }
 
 func testAccCheckKubernetesResourceQuotaDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_resource_quota" {
@@ -229,7 +229,7 @@ func testAccCheckKubernetesResourceQuotaExists(n string, obj *api.ResourceQuota)
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_resource_quota_test.go
+++ b/kubernetes/resource_kubernetes_resource_quota_test.go
@@ -199,7 +199,10 @@ func TestAccKubernetesResourceQuota_importBasic(t *testing.T) {
 }
 
 func testAccCheckKubernetesResourceQuotaDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_resource_quota" {
@@ -229,7 +232,10 @@ func testAccCheckKubernetesResourceQuotaExists(n string, obj *api.ResourceQuota)
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_role.go
+++ b/kubernetes/resource_kubernetes_role.go
@@ -66,7 +66,7 @@ func resourceKubernetesRole() *schema.Resource {
 }
 
 func resourceKubernetesRoleCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	rules := expandRules(d.Get("rule").([]interface{}))
@@ -88,7 +88,7 @@ func resourceKubernetesRoleCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceKubernetesRoleRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -117,7 +117,7 @@ func resourceKubernetesRoleRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceKubernetesRoleUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -150,7 +150,7 @@ func resourceKubernetesRoleUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceKubernetesRoleDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -169,7 +169,7 @@ func resourceKubernetesRoleDelete(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceKubernetesRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_role.go
+++ b/kubernetes/resource_kubernetes_role.go
@@ -66,7 +66,10 @@ func resourceKubernetesRole() *schema.Resource {
 }
 
 func resourceKubernetesRoleCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	rules := expandRules(d.Get("rule").([]interface{}))
@@ -88,7 +91,10 @@ func resourceKubernetesRoleCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceKubernetesRoleRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -117,7 +123,10 @@ func resourceKubernetesRoleRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceKubernetesRoleUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -150,7 +159,10 @@ func resourceKubernetesRoleUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceKubernetesRoleDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -169,7 +181,10 @@ func resourceKubernetesRoleDelete(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceKubernetesRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_role_binding.go
+++ b/kubernetes/resource_kubernetes_role_binding.go
@@ -48,7 +48,7 @@ func resourceKubernetesRoleBinding() *schema.Resource {
 }
 
 func resourceKubernetesRoleBindingCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	binding := &api.RoleBinding{
@@ -69,7 +69,7 @@ func resourceKubernetesRoleBindingCreate(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesRoleBindingRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -107,7 +107,7 @@ func resourceKubernetesRoleBindingRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesRoleBindingUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -135,7 +135,7 @@ func resourceKubernetesRoleBindingUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesRoleBindingDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -153,7 +153,7 @@ func resourceKubernetesRoleBindingDelete(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesRoleBindingExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_role_binding.go
+++ b/kubernetes/resource_kubernetes_role_binding.go
@@ -48,7 +48,10 @@ func resourceKubernetesRoleBinding() *schema.Resource {
 }
 
 func resourceKubernetesRoleBindingCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	binding := &api.RoleBinding{
@@ -69,7 +72,10 @@ func resourceKubernetesRoleBindingCreate(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesRoleBindingRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -107,7 +113,10 @@ func resourceKubernetesRoleBindingRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesRoleBindingUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -135,7 +144,10 @@ func resourceKubernetesRoleBindingUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesRoleBindingDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -153,7 +165,10 @@ func resourceKubernetesRoleBindingDelete(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesRoleBindingExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_role_binding_test.go
+++ b/kubernetes/resource_kubernetes_role_binding_test.go
@@ -300,7 +300,10 @@ func TestAccKubernetesRoleBindingBug(t *testing.T) {
 }
 
 func testAccCheckKubernetesRoleBindingDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_role_binding" {
@@ -330,7 +333,10 @@ func testAccCheckKubernetesRoleBindingExists(n string, obj *api.RoleBinding) res
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_role_binding_test.go
+++ b/kubernetes/resource_kubernetes_role_binding_test.go
@@ -300,7 +300,7 @@ func TestAccKubernetesRoleBindingBug(t *testing.T) {
 }
 
 func testAccCheckKubernetesRoleBindingDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_role_binding" {
@@ -330,7 +330,7 @@ func testAccCheckKubernetesRoleBindingExists(n string, obj *api.RoleBinding) res
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_role_test.go
+++ b/kubernetes/resource_kubernetes_role_test.go
@@ -283,7 +283,10 @@ func testAccCheckKubernetesRoleExists(n string, obj *api.Role) resource.TestChec
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {
@@ -301,7 +304,10 @@ func testAccCheckKubernetesRoleExists(n string, obj *api.Role) resource.TestChec
 }
 
 func testAccCheckKubernetesRoleDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_role" {

--- a/kubernetes/resource_kubernetes_role_test.go
+++ b/kubernetes/resource_kubernetes_role_test.go
@@ -283,7 +283,7 @@ func testAccCheckKubernetesRoleExists(n string, obj *api.Role) resource.TestChec
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {
@@ -301,7 +301,7 @@ func testAccCheckKubernetesRoleExists(n string, obj *api.Role) resource.TestChec
 }
 
 func testAccCheckKubernetesRoleDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_role" {

--- a/kubernetes/resource_kubernetes_secret.go
+++ b/kubernetes/resource_kubernetes_secret.go
@@ -42,7 +42,7 @@ func resourceKubernetesSecret() *schema.Resource {
 }
 
 func resourceKubernetesSecretCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	secret := api.Secret{
@@ -67,7 +67,7 @@ func resourceKubernetesSecretCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceKubernetesSecretRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -93,7 +93,7 @@ func resourceKubernetesSecretRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceKubernetesSecretUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -130,7 +130,7 @@ func resourceKubernetesSecretUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceKubernetesSecretDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -151,7 +151,7 @@ func resourceKubernetesSecretDelete(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceKubernetesSecretExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_secret.go
+++ b/kubernetes/resource_kubernetes_secret.go
@@ -42,7 +42,10 @@ func resourceKubernetesSecret() *schema.Resource {
 }
 
 func resourceKubernetesSecretCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	secret := api.Secret{
@@ -67,7 +70,10 @@ func resourceKubernetesSecretCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceKubernetesSecretRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -93,7 +99,10 @@ func resourceKubernetesSecretRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceKubernetesSecretUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -130,7 +139,10 @@ func resourceKubernetesSecretUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceKubernetesSecretDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -151,7 +163,10 @@ func resourceKubernetesSecretDelete(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceKubernetesSecretExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_secret_test.go
+++ b/kubernetes/resource_kubernetes_secret_test.go
@@ -278,7 +278,7 @@ func testAccCheckSecretData(m *api.Secret, expected map[string]string) resource.
 }
 
 func testAccCheckKubernetesSecretDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_secret" {
@@ -308,7 +308,7 @@ func testAccCheckKubernetesSecretExists(n string, obj *api.Secret) resource.Test
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_secret_test.go
+++ b/kubernetes/resource_kubernetes_secret_test.go
@@ -278,7 +278,10 @@ func testAccCheckSecretData(m *api.Secret, expected map[string]string) resource.
 }
 
 func testAccCheckKubernetesSecretDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_secret" {
@@ -308,7 +311,10 @@ func testAccCheckKubernetesSecretExists(n string, obj *api.Secret) resource.Test
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_service.go
+++ b/kubernetes/resource_kubernetes_service.go
@@ -161,7 +161,7 @@ func resourceKubernetesService() *schema.Resource {
 }
 
 func resourceKubernetesServiceCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	svc := api.Service{
@@ -209,7 +209,7 @@ func resourceKubernetesServiceCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesServiceRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -244,7 +244,7 @@ func resourceKubernetesServiceRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceKubernetesServiceUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -279,7 +279,7 @@ func resourceKubernetesServiceUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -299,7 +299,7 @@ func resourceKubernetesServiceDelete(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesServiceExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_service.go
+++ b/kubernetes/resource_kubernetes_service.go
@@ -161,7 +161,10 @@ func resourceKubernetesService() *schema.Resource {
 }
 
 func resourceKubernetesServiceCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	svc := api.Service{
@@ -209,7 +212,10 @@ func resourceKubernetesServiceCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesServiceRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -244,7 +250,10 @@ func resourceKubernetesServiceRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceKubernetesServiceUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -279,7 +288,10 @@ func resourceKubernetesServiceUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -299,7 +311,10 @@ func resourceKubernetesServiceDelete(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceKubernetesServiceExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -74,7 +74,7 @@ func resourceKubernetesServiceAccount() *schema.Resource {
 }
 
 func resourceKubernetesServiceAccountCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	svcAcc := api.ServiceAccount{
@@ -154,7 +154,7 @@ func diffObjectReferences(origOrs []api.ObjectReference, ors []api.ObjectReferen
 }
 
 func resourceKubernetesServiceAccountRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -196,7 +196,7 @@ func resourceKubernetesServiceAccountRead(d *schema.ResourceData, meta interface
 }
 
 func resourceKubernetesServiceAccountUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -243,7 +243,7 @@ func resourceKubernetesServiceAccountUpdate(d *schema.ResourceData, meta interfa
 }
 
 func resourceKubernetesServiceAccountDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -263,7 +263,7 @@ func resourceKubernetesServiceAccountDelete(d *schema.ResourceData, meta interfa
 }
 
 func resourceKubernetesServiceAccountExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -282,7 +282,7 @@ func resourceKubernetesServiceAccountExists(d *schema.ResourceData, meta interfa
 }
 
 func resourceKubernetesServiceAccountImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -74,7 +74,10 @@ func resourceKubernetesServiceAccount() *schema.Resource {
 }
 
 func resourceKubernetesServiceAccountCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	svcAcc := api.ServiceAccount{
@@ -154,7 +157,10 @@ func diffObjectReferences(origOrs []api.ObjectReference, ors []api.ObjectReferen
 }
 
 func resourceKubernetesServiceAccountRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -196,7 +202,10 @@ func resourceKubernetesServiceAccountRead(d *schema.ResourceData, meta interface
 }
 
 func resourceKubernetesServiceAccountUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -243,7 +252,10 @@ func resourceKubernetesServiceAccountUpdate(d *schema.ResourceData, meta interfa
 }
 
 func resourceKubernetesServiceAccountDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -263,7 +275,10 @@ func resourceKubernetesServiceAccountDelete(d *schema.ResourceData, meta interfa
 }
 
 func resourceKubernetesServiceAccountExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -282,7 +297,10 @@ func resourceKubernetesServiceAccountExists(d *schema.ResourceData, meta interfa
 }
 
 func resourceKubernetesServiceAccountImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return nil, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_service_account_test.go
+++ b/kubernetes/resource_kubernetes_service_account_test.go
@@ -312,7 +312,10 @@ func matchObjectReferenceName(lor []api.ObjectReference, expected []*regexp.Rege
 }
 
 func testAccCheckKubernetesServiceAccountDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_service_account" {
@@ -342,7 +345,10 @@ func testAccCheckKubernetesServiceAccountExists(n string, obj *api.ServiceAccoun
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_service_account_test.go
+++ b/kubernetes/resource_kubernetes_service_account_test.go
@@ -312,7 +312,7 @@ func matchObjectReferenceName(lor []api.ObjectReference, expected []*regexp.Rege
 }
 
 func testAccCheckKubernetesServiceAccountDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_service_account" {
@@ -342,7 +342,7 @@ func testAccCheckKubernetesServiceAccountExists(n string, obj *api.ServiceAccoun
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_service_test.go
+++ b/kubernetes/resource_kubernetes_service_test.go
@@ -546,7 +546,7 @@ func testAccCheckServicePorts(svc *api.Service, expected []api.ServicePort) reso
 }
 
 func testAccCheckKubernetesServiceDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_service" {
@@ -576,7 +576,7 @@ func testAccCheckKubernetesServiceExists(n string, obj *api.Service) resource.Te
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_service_test.go
+++ b/kubernetes/resource_kubernetes_service_test.go
@@ -546,7 +546,10 @@ func testAccCheckServicePorts(svc *api.Service, expected []api.ServicePort) reso
 }
 
 func testAccCheckKubernetesServiceDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_service" {
@@ -576,7 +579,10 @@ func testAccCheckKubernetesServiceExists(n string, obj *api.Service) resource.Te
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_stateful_set.go
+++ b/kubernetes/resource_kubernetes_stateful_set.go
@@ -40,7 +40,10 @@ func resourceKubernetesStatefulSet() *schema.Resource {
 }
 
 func resourceKubernetesStatefulSetCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandStatefulSetSpec(d.Get("spec").([]interface{}))
 	if err != nil {
@@ -68,7 +71,10 @@ func resourceKubernetesStatefulSetCreate(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesStatefulSetExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -87,7 +93,10 @@ func resourceKubernetesStatefulSetExists(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesStatefulSetRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	id := d.Id()
 	namespace, name, err := idParts(id)
@@ -123,7 +132,10 @@ func resourceKubernetesStatefulSetRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesStatefulSetUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
 		return fmt.Errorf("Error parsing resource ID: %#v", err)
@@ -154,7 +166,10 @@ func resourceKubernetesStatefulSetUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesStatefulSetDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_stateful_set.go
+++ b/kubernetes/resource_kubernetes_stateful_set.go
@@ -40,7 +40,7 @@ func resourceKubernetesStatefulSet() *schema.Resource {
 }
 
 func resourceKubernetesStatefulSetCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	spec, err := expandStatefulSetSpec(d.Get("spec").([]interface{}))
 	if err != nil {
@@ -68,7 +68,7 @@ func resourceKubernetesStatefulSetCreate(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesStatefulSetExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
@@ -87,7 +87,7 @@ func resourceKubernetesStatefulSetExists(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesStatefulSetRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	id := d.Id()
 	namespace, name, err := idParts(id)
@@ -123,7 +123,7 @@ func resourceKubernetesStatefulSetRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceKubernetesStatefulSetUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 	namespace, name, err := idParts(d.Id())
 	if err != nil {
 		return fmt.Errorf("Error parsing resource ID: %#v", err)
@@ -154,7 +154,7 @@ func resourceKubernetesStatefulSetUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceKubernetesStatefulSetDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	namespace, name, err := idParts(d.Id())
 	if err != nil {

--- a/kubernetes/resource_kubernetes_stateful_set_test.go
+++ b/kubernetes/resource_kubernetes_stateful_set_test.go
@@ -311,7 +311,7 @@ func TestAccKubernetesStatefulSet_update_pod_template(t *testing.T) {
 }
 
 func testAccCheckKubernetesStatefulSetDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_stateful_set" {
@@ -341,7 +341,7 @@ func testAccCheckKubernetesStatefulSetExists(n string, obj *api.StatefulSet) res
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_stateful_set_test.go
+++ b/kubernetes/resource_kubernetes_stateful_set_test.go
@@ -311,7 +311,10 @@ func TestAccKubernetesStatefulSet_update_pod_template(t *testing.T) {
 }
 
 func testAccCheckKubernetesStatefulSetDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_stateful_set" {
@@ -341,7 +344,10 @@ func testAccCheckKubernetesStatefulSetExists(n string, obj *api.StatefulSet) res
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
 
 		namespace, name, err := idParts(rs.Primary.ID)
 		if err != nil {

--- a/kubernetes/resource_kubernetes_storage_class.go
+++ b/kubernetes/resource_kubernetes_storage_class.go
@@ -68,7 +68,10 @@ func resourceKubernetesStorageClass() *schema.Resource {
 }
 
 func resourceKubernetesStorageClassCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	reclaimPolicy := v1.PersistentVolumeReclaimPolicy(d.Get("reclaim_policy").(string))
@@ -102,7 +105,10 @@ func resourceKubernetesStorageClassCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceKubernetesStorageClassRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 	log.Printf("[INFO] Reading storage class %s", name)
@@ -129,7 +135,10 @@ func resourceKubernetesStorageClassRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesStorageClassUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
@@ -149,11 +158,14 @@ func resourceKubernetesStorageClassUpdate(d *schema.ResourceData, meta interface
 }
 
 func resourceKubernetesStorageClassDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 	log.Printf("[INFO] Deleting storage class: %#v", name)
-	err := conn.StorageV1().StorageClasses().Delete(name, &deleteOptions)
+	err = conn.StorageV1().StorageClasses().Delete(name, &deleteOptions)
 	if err != nil {
 		return err
 	}
@@ -165,11 +177,14 @@ func resourceKubernetesStorageClassDelete(d *schema.ResourceData, meta interface
 }
 
 func resourceKubernetesStorageClassExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(KubeClientsets).MainClientset()
+	conn, err := meta.(KubeClientsets).MainClientset()
+	if err != nil {
+		return false, err
+	}
 
 	name := d.Id()
 	log.Printf("[INFO] Checking storage class %s", name)
-	_, err := conn.StorageV1().StorageClasses().Get(name, metav1.GetOptions{})
+	_, err = conn.StorageV1().StorageClasses().Get(name, metav1.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return false, nil

--- a/kubernetes/resource_kubernetes_storage_class.go
+++ b/kubernetes/resource_kubernetes_storage_class.go
@@ -68,7 +68,7 @@ func resourceKubernetesStorageClass() *schema.Resource {
 }
 
 func resourceKubernetesStorageClassCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	reclaimPolicy := v1.PersistentVolumeReclaimPolicy(d.Get("reclaim_policy").(string))
@@ -102,7 +102,7 @@ func resourceKubernetesStorageClassCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceKubernetesStorageClassRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 	log.Printf("[INFO] Reading storage class %s", name)
@@ -129,7 +129,7 @@ func resourceKubernetesStorageClassRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceKubernetesStorageClassUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
@@ -149,7 +149,7 @@ func resourceKubernetesStorageClassUpdate(d *schema.ResourceData, meta interface
 }
 
 func resourceKubernetesStorageClassDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 	log.Printf("[INFO] Deleting storage class: %#v", name)
@@ -165,7 +165,7 @@ func resourceKubernetesStorageClassDelete(d *schema.ResourceData, meta interface
 }
 
 func resourceKubernetesStorageClassExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*KubeClientsets).MainClientset
+	conn := meta.(KubeClientsets).MainClientset()
 
 	name := d.Id()
 	log.Printf("[INFO] Checking storage class %s", name)

--- a/kubernetes/resource_kubernetes_storage_class_test.go
+++ b/kubernetes/resource_kubernetes_storage_class_test.go
@@ -198,7 +198,7 @@ func testAccCheckStorageClassParameters(m *api.StorageClass, expected map[string
 }
 
 func testAccCheckKubernetesStorageClassDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_storage_class" {
@@ -223,7 +223,7 @@ func testAccCheckKubernetesStorageClassExists(n string, obj *api.StorageClass) r
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(*KubeClientsets).MainClientset
+		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
 		name := rs.Primary.ID
 		out, err := conn.StorageV1().StorageClasses().Get(name, meta_v1.GetOptions{})
 		if err != nil {

--- a/kubernetes/resource_kubernetes_storage_class_test.go
+++ b/kubernetes/resource_kubernetes_storage_class_test.go
@@ -198,7 +198,10 @@ func testAccCheckStorageClassParameters(m *api.StorageClass, expected map[string
 }
 
 func testAccCheckKubernetesStorageClassDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "kubernetes_storage_class" {
@@ -223,7 +226,11 @@ func testAccCheckKubernetesStorageClassExists(n string, obj *api.StorageClass) r
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		conn, err := testAccProvider.Meta().(KubeClientsets).MainClientset()
+		if err != nil {
+			return err
+		}
+
 		name := rs.Primary.ID
 		out, err := conn.StorageV1().StorageClasses().Get(name, meta_v1.GetOptions{})
 		if err != nil {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -38,6 +38,17 @@ Below are versions of the library bundled with given versions of Terraform.
 * Terraform `0.9.7` (prior to provider split) `< 1.1` (provider version) - Kubernetes `1.6.1`
 * `1.1+` - Kubernetes `1.7`
 
+## Stacking with managed Kubernetes cluster resources
+
+Terraform providers for various cloud providers feature resources to spin up managed Kubernetes clusters on services such as EKS, AKS and GKE. Such resources (or data-sources) will have attributes that expose the credentials needed for the Kubernetes provider to connect to these clusters.
+
+To use these credentials with the Kubernetes provider, they can be interpolated into the respective attributes of the Kubernetes provider configuration block.
+
+**IMPORTANT WARNING**
+*When using interpolation to pass credentials to the Kubernetes provider from other resources, these resources SHOULD NOT be created in the same `apply` operation where Kubernetes provider resources are also used. This will lead to intermittent and unpredictable errors which are hard to debug and diagnose. The root issue lies with the order in which Terraform itself evaluates the provider blocks vs. actual resources. Please refer to [this section of Terraform docs](https://www.terraform.io/docs/configuration/providers.html#provider-configuration) for further explanation.*
+
+The best-practice in this case is to ensure that the cluster itself and the Kubernetes provider resources are managed with separate `apply` operations. Data-sources can be used to convey values between the two stages as needed.
+
 ## Authentication
 
 There are generally two ways to configure the Kubernetes provider.


### PR DESCRIPTION
This PR attempts to reduce the disruption caused by the strict configuration sanitizing introduced in release 1.11 and described in https://github.com/terraform-providers/terraform-provider-kubernetes/issues/759.

**THIS IS NOT A FIX!** 
This change is only intended alleviate symptoms and does not address the root cause of issues described in https://github.com/terraform-providers/terraform-provider-kubernetes/issues/759
For addressing the cause, changes are required in Terraform itself and the discussion towards a solution is tracked under: https://github.com/hashicorp/terraform/issues/4149

The recommendation to not use the provider in the same `apply` action that also creates the cluster remains valid. It is the safest way to avoid running into the pitfalls described by https://github.com/terraform-providers/terraform-provider-kubernetes/issues/759.

TODO:
- [x] refactor to defer client initialization
- [x] document recommended usage pattern
- [x] test extensively

CC: @pdecat 