### PR TITLE
Fix static provider config code block

### DIFF
--- a/website/docs/guides/getting-started.html.markdown
+++ b/website/docs/guides/getting-started.html.markdown
@@ -70,6 +70,7 @@ provider "kubernetes" {
 ```
 
 If you wish to configure the provider statically you can do so by providing TLS certificates:
+
 ```hcl
 provider "kubernetes" {
   load_config_file = "false"


### PR DESCRIPTION
This fixes a code block that is not rendered correctly on the Kubernetes provider getting started page.