### PR TITLE
Fix AKS test stage

### DIFF
--- a/kubernetes/test-infra/aks/main.tf
+++ b/kubernetes/test-infra/aks/main.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 provider "azurerm" {
-  version = ">= 1.28.0"
+  version = ">= 1.28.0, <2.0.0"
 }
 
 data "azurerm_kubernetes_service_versions" "current" {


### PR DESCRIPTION
Pin AzureRM provider to pre-2.0.0 versions.

Recently version 2.0.0 of the AzureRM provider was released which requires template configurations to be adapted.
Until we get to refactor them, this unblocks testing on AKS. 