### PR TITLE
Add data source for reading config maps

### DIFF
--- a/kubernetes/data_source_kubernetes_config_map.go
+++ b/kubernetes/data_source_kubernetes_config_map.go
@@ -1,0 +1,36 @@
+package kubernetes
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func dataSourceKubernetesConfigMap() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceKubernetesConfigMapRead,
+
+		Schema: map[string]*schema.Schema{
+			"metadata": namespacedMetadataSchema("config_map", false),
+			"data": {
+				Type:        schema.TypeMap,
+				Description: "A map of the config map data.",
+				Computed:    true,
+			},
+			"binary_data": {
+				Type:        schema.TypeMap,
+				Description: "A map of the config map binary data.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceKubernetesConfigMapRead(d *schema.ResourceData, meta interface{}) error {
+	om := meta_v1.ObjectMeta{
+		Namespace: d.Get("metadata.0.namespace").(string),
+		Name:      d.Get("metadata.0.name").(string),
+	}
+	d.SetId(buildId(om))
+
+	return resourceKubernetesConfigMapRead(d, meta)
+}

--- a/kubernetes/data_source_kubernetes_config_map_test.go
+++ b/kubernetes/data_source_kubernetes_config_map_test.go
@@ -1,0 +1,49 @@
+package kubernetes
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccKubernetesDataSourceConfigMap_basic(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesDataSourceConfigMapConfig_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.kubernetes_config_map.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("data.kubernetes_config_map.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_config_map.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_config_map.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("data.kubernetes_config_map.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("data.kubernetes_config_map.test", "metadata.0.annotations.%", "2"),
+					resource.TestCheckResourceAttr("data.kubernetes_config_map.test", "metadata.0.annotations.TestAnnotationOne", "one"),
+					resource.TestCheckResourceAttr("data.kubernetes_config_map.test", "metadata.0.annotations.TestAnnotationTwo", "two"),
+					resource.TestCheckResourceAttr("data.kubernetes_config_map.test", "metadata.0.labels.TestLabelOne", "one"),
+					resource.TestCheckResourceAttr("data.kubernetes_config_map.test", "metadata.0.labels.TestLabelTwo", "two"),
+					resource.TestCheckResourceAttr("data.kubernetes_config_map.test", "metadata.0.labels.TestLabelThree", "three"),
+					resource.TestCheckResourceAttr("data.kubernetes_config_map.test", "data.%", "2"),
+					resource.TestCheckResourceAttr("data.kubernetes_config_map.test", "data.one", "first"),
+					resource.TestCheckResourceAttr("data.kubernetes_config_map.test", "data.two", "second"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKubernetesDataSourceConfigMapConfig_basic(name string) string {
+	return testAccKubernetesConfigMapConfig_basic(name) + `
+data "kubernetes_config_map" "test" {
+	metadata {
+		name = "${kubernetes_config_map.test.metadata.0.name}"
+	}
+}
+`
+}

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -137,6 +137,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"kubernetes_config_map":    dataSourceKubernetesConfigMap(),
 			"kubernetes_secret":        dataSourceKubernetesSecret(),
 			"kubernetes_service":       dataSourceKubernetesService(),
 			"kubernetes_storage_class": dataSourceKubernetesStorageClass(),

--- a/website/docs/d/config_map.html.markdown
+++ b/website/docs/d/config_map.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "kubernetes"
+page_title: "Kubernetes: kubernetes_config map"
+sidebar_current: "docs-kubernetes-resource-config map"
+description: |-
+  This data source reads configuration data from a config map.
+---
+
+# kubernetes_config map
+
+Config Maps are key-value pairs containing configuration data. The Config Map data source provides a mechanism for extracting these key-value pairs.
+
+~> **Note:** All arguments including the config map data will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
+
+## Example Usage
+
+```hcl
+data "kubernetes_config map" "example" {
+  metadata {
+    name = "my-config"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `metadata` - (Required) Standard config map's metadata. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
+
+## Nested Blocks
+
+### `metadata`
+
+#### Arguments
+
+* `name` - (Required) Name of the config map, must be unique. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+* `namespace` - (Optional) Namespace defines the space within which name of the config map must be unique.
+
+#### Attributes
+
+* `generation` - A sequence number representing a specific generation of the desired state.
+* `resource_version` - An opaque value that represents the internal version of this config map that can be used by clients to determine when config map has changed. For more info see [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency)
+* `self_link` - A URL representing this config map.
+* `uid` - The unique in time and space value for this config map. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#uids)
+
+## Attribute Reference
+
+* `data` - A map of the config map data.
+* `binary_data` - A map of preserved non-UTF8 data. For more info see [Kubernetes API reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#configmap-v1-core).

--- a/website/kubernetes.erb
+++ b/website/kubernetes.erb
@@ -18,6 +18,9 @@
         <li<%= sidebar_current("docs-kubernetes-data-source") %>>
           <a href="#">Data Sources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-kubernetes-data-source-config-map") %>>
+￼             <a href="/docs/providers/kubernetes/d/config_map.html">kubernetes_config_map</a>
+￼           </li>
             <li<%= sidebar_current("docs-kubernetes-data-source-secret") %>>
               <a href="/docs/providers/kubernetes/d/secret.html">kubernetes_secret</a>
             </li>


### PR DESCRIPTION
Add data source for reading config maps.
Based on PR https://github.com/terraform-providers/terraform-provider-kubernetes/pull/90.
Solves https://github.com/terraform-providers/terraform-provider-kubernetes/issues/76.