### PR TITLE
Add configuration for Typhoon based acceptance test environment

### DIFF
--- a/kubernetes/test-infra/typhoon-aws/README.md
+++ b/kubernetes/test-infra/typhoon-aws/README.md
@@ -1,0 +1,65 @@
+# Typhoon Kubernetes clusters on AWS
+
+This environment deploys a Kubernetes cluster using the Typhoon distribution. See here for details: https://github.com/poseidon/typhoon
+
+You will need the standard AWS environment variables to be set, e.g.
+
+  - `AWS_ACCESS_KEY_ID`
+  - `AWS_SECRET_ACCESS_KEY`
+
+See [AWS Provider docs](https://www.terraform.io/docs/providers/aws/index.html#configuration-reference) for more details about these variables
+and alternatives, like `AWS_PROFILE`.
+
+Additionally, a publicly accesible DNS domain registered as a Route53 managed zone is required.
+The name of the domain should be passed to terraform via the `base_domain` input variable.
+
+Example:
+
+```export TF_VAR_base_domain=k8s.myself.com```
+## Versions
+
+You can set the desired version of Kubernetes by editing the `main.tf` configuration file and replacing the version in the source URL of the `typhoon-acc` module.
+
+Example:
+```
+
+module "typhoon-acc" {
+  source = "git::https://github.com/poseidon/typhoon//aws/fedora-coreos/kubernetes?ref=v1.18.0" # set the desired Kubernetes version here
+...
+```
+## Worker node count and instance type
+
+You can control the amount of worker nodes in the cluster as well as their machine type, using the following variables:
+
+ - `TF_VAR_controller_count`
+ - `TF_VAR_controller_type`
+ - `TF_VAR_workers_count`
+ - `TF_VAR_workers_type`
+
+Export values for them or pass them to the apply command line.
+
+## Build the cluster
+
+```
+terraform init
+terraform apply -var=cluster_name=typhoon
+```
+
+## Exporting K8S variables
+To access the cluster you need to export the `KUBECONFIG` variable pointing to the `kubeconfig` file for the current cluster.
+```
+export KUBECONFIG="$(terraform output kubeconfig_path)"
+```
+
+Now you can access the cluster via `kubectl` and you can run acceptance tests against it.
+
+To run acceptance tests, your the following command in the root of the repository.
+```
+TESTARGS="-run '^TestAcc'" make testacc
+```
+
+To run only a specific set of tests, you can replace `^TestAcc` with any regular expression to filter tests by name.
+For example, to run tests for Pod resources, you can do:
+```
+TESTARGS="-run '^TestAccKubernetesPod_'" make testacc
+```

--- a/kubernetes/test-infra/typhoon-aws/main.tf
+++ b/kubernetes/test-infra/typhoon-aws/main.tf
@@ -1,0 +1,53 @@
+resource "tls_private_key" "typhoon-acc" {
+  algorithm = "RSA"
+}
+
+resource "local_file" "public_key_openssh" {
+  content    = tls_private_key.typhoon-acc.public_key_openssh
+  filename   = "${path.cwd}/${var.cluster_name}.pub"
+}
+
+resource "local_file" "private_key_pem" {
+  content    = tls_private_key.typhoon-acc.private_key_pem
+  filename   = "${path.cwd}/${var.cluster_name}"
+}
+
+resource "null_resource" "ssh-key" {
+  provisioner "local-exec" {
+    command = format("chmod 600 %v", local_file.private_key_pem.filename)
+    working_dir = path.cwd
+  }
+  provisioner "local-exec" {
+    command = format("ssh-add %v", local_file.private_key_pem.filename)
+    working_dir = path.cwd
+  }
+}
+
+data "aws_route53_zone" "typhoon-acc" {
+  name = var.base_domain
+}
+
+module "typhoon-acc" {
+  source = "git::https://github.com/poseidon/typhoon//aws/fedora-coreos/kubernetes?ref=v1.18.0" # set the desired Kubernetes version here
+
+  cluster_name = var.cluster_name
+  dns_zone     = var.base_domain
+  dns_zone_id  = data.aws_route53_zone.typhoon-acc.zone_id
+
+  # node configuration
+  ssh_authorized_key = tls_private_key.typhoon-acc.public_key_openssh
+
+  worker_count = var.worker_count
+  controller_count = var.controller_count
+  worker_type  = var.controller_type
+  controller_type = var.worker_type
+}
+
+resource "local_file" "typhoon-acc" {
+  content  = module.typhoon-acc.kubeconfig-admin
+  filename = "kubeconfig"
+}
+
+output "kubeconfig_path" {
+  value = "${path.cwd}/${local_file.typhoon-acc.filename}"
+}

--- a/kubernetes/test-infra/typhoon-aws/variables.tf
+++ b/kubernetes/test-infra/typhoon-aws/variables.tf
@@ -1,0 +1,23 @@
+variable "base_domain" {
+  type = string
+}
+
+variable "cluster_name" {
+  type = string
+}
+
+variable "controller_count" {
+  default = 1
+}
+
+variable "worker_count" {
+  default = 4
+}
+
+variable "controller_type" {
+  default = "m5a.xlarge"
+}
+
+variable "worker_type" {
+  default = "m5a.large"
+}


### PR DESCRIPTION
This change introduces a new test environment configuration based on the Typhoon distribution of Kubernetes.

Typhoon is known for consistently offering support for the very latest version of Kubernetes. This will allow us to test newer resource implementations which may not yet be supported by cloud provider hosted Kubernetes services.

https://github.com/poseidon/typhoon