### PR TITLE
Add wait_for_load_balancer field to kubernetes_ingress

### DIFF
--- a/kubernetes/resource_kubernetes_ingress.go
+++ b/kubernetes/resource_kubernetes_ingress.go
@@ -8,8 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func resourceKubernetesIngress() *schema.Resource {
@@ -146,7 +145,7 @@ func resourceKubernetesIngressCreate(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[INFO] Waiting for load balancer to become ready: %#v", out)
 	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		res, err := conn.ExtensionsV1beta1().Ingresses(metadata.Namespace).Get(metadata.Name, v1.GetOptions{})
+		res, err := conn.ExtensionsV1beta1().Ingresses(metadata.Namespace).Get(metadata.Name, metav1.GetOptions{})
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
@@ -172,7 +171,7 @@ func resourceKubernetesIngressRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	log.Printf("[INFO] Reading ingress %s", name)
-	ing, err := conn.ExtensionsV1beta1().Ingresses(namespace).Get(name, meta_v1.GetOptions{})
+	ing, err := conn.ExtensionsV1beta1().Ingresses(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		log.Printf("[DEBUG] Received error: %#v", err)
 		return fmt.Errorf("Failed to read Ingress '%s' because: %s", buildId(ing.ObjectMeta), err)
@@ -242,7 +241,7 @@ func resourceKubernetesIngressDelete(d *schema.ResourceData, meta interface{}) e
 	}
 
 	log.Printf("[INFO] Deleting ingress: %#v", name)
-	err = conn.ExtensionsV1beta1().Ingresses(namespace).Delete(name, &meta_v1.DeleteOptions{})
+	err = conn.ExtensionsV1beta1().Ingresses(namespace).Delete(name, &metav1.DeleteOptions{})
 	if err != nil {
 		return fmt.Errorf("Failed to delete Ingress %s because: %s", d.Id(), err)
 	}
@@ -265,7 +264,7 @@ func resourceKubernetesIngressExists(d *schema.ResourceData, meta interface{}) (
 	}
 
 	log.Printf("[INFO] Checking ingress %s", name)
-	_, err = conn.ExtensionsV1beta1().Ingresses(namespace).Get(name, meta_v1.GetOptions{})
+	_, err = conn.ExtensionsV1beta1().Ingresses(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
 			return false, nil

--- a/kubernetes/resource_kubernetes_ingress.go
+++ b/kubernetes/resource_kubernetes_ingress.go
@@ -147,6 +147,11 @@ func resourceKubernetesIngressCreate(d *schema.ResourceData, meta interface{}) e
 	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		res, err := conn.ExtensionsV1beta1().Ingresses(metadata.Namespace).Get(metadata.Name, metav1.GetOptions{})
 		if err != nil {
+			// NOTE it possible in some HA apiserver setups that are eventually consistent
+			// that we could get a 404 when doing a Get immediately after a Create
+			if errors.IsNotFound(err) {
+				return resource.RetryableError(err)
+			}
 			return resource.NonRetryableError(err)
 		}
 

--- a/kubernetes/resource_kubernetes_ingress.go
+++ b/kubernetes/resource_kubernetes_ingress.go
@@ -147,7 +147,7 @@ func resourceKubernetesIngressCreate(d *schema.ResourceData, meta interface{}) e
 	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		res, err := conn.ExtensionsV1beta1().Ingresses(metadata.Namespace).Get(metadata.Name, metav1.GetOptions{})
 		if err != nil {
-			// NOTE it possible in some HA apiserver setups that are eventually consistent
+			// NOTE it is possible in some HA apiserver setups that are eventually consistent
 			// that we could get a 404 when doing a Get immediately after a Create
 			if errors.IsNotFound(err) {
 				return resource.RetryableError(err)

--- a/kubernetes/resource_kubernetes_ingress.go
+++ b/kubernetes/resource_kubernetes_ingress.go
@@ -155,6 +155,7 @@ func resourceKubernetesIngressCreate(d *schema.ResourceData, meta interface{}) e
 			return resource.NonRetryableError(resourceKubernetesIngressRead(d, meta))
 		}
 
+		log.Printf("[INFO] Load Balancer not ready yet...")
 		return resource.RetryableError(fmt.Errorf("Load Balancer is not ready yet"))
 	})
 }

--- a/kubernetes/resource_kubernetes_ingress_test.go
+++ b/kubernetes/resource_kubernetes_ingress_test.go
@@ -153,7 +153,7 @@ func TestAccKubernetesIngress_WaitForLoadBalancerGoogleCloud(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) skipIfNoGoogleCloudSettingsFound(t) },
+		PreCheck:      func() { testAccPreCheck(t); skipIfNoGoogleCloudSettingsFound(t) },
 		IDRefreshName: "kubernetes_ingress.test",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckKubernetesIngressDestroy,

--- a/kubernetes/resource_kubernetes_ingress_test.go
+++ b/kubernetes/resource_kubernetes_ingress_test.go
@@ -153,7 +153,7 @@ func TestAccKubernetesIngress_WaitForLoadBalancerGoogleCloud(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); skipIfNoGoogleCloudSettingsFound(t) },
+		PreCheck:      func() { testAccPreCheck(t) /*skipIfNoGoogleCloudSettingsFound(t)*/ },
 		IDRefreshName: "kubernetes_ingress.test",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckKubernetesIngressDestroy,

--- a/website/docs/r/ingress.html.markdown
+++ b/website/docs/r/ingress.html.markdown
@@ -100,6 +100,7 @@ The following arguments are supported:
 
 * `metadata` - (Required) Standard ingress's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
 * `spec` - (Required) Spec defines the behavior of a ingress. https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+* `wait_for_load_balancer` - (Optional) Terraform will wait for the load balancer to have at least 1 endpoint before considering the resource created.
 
 ## Nested Blocks
 


### PR DESCRIPTION
### Description

Adds a `wait_for_load_balancer` field that will wait until the load balancer status is not empty for the ingress.

Resolves #631 

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)
