### PR TITLE
Update getting-started.html.markdown

### DIFF
--- a/website/docs/guides/getting-started.html.markdown
+++ b/website/docs/guides/getting-started.html.markdown
@@ -73,8 +73,6 @@ If you wish to configure the provider statically you can do so by providing TLS 
 
 ```hcl
 provider "kubernetes" {
-  load_config_file = "false"
-
   host = "https://104.196.242.174"
 
   client_certificate     = file("~/.kube/client-cert.pem")
@@ -89,8 +87,6 @@ or by providing username and password (HTTP Basic Authorization):
 
 ```hcl
 provider "kubernetes" {
-  load_config_file = "false"
-
   host = "https://104.196.242.174"
 
   username = "ClusterMaster"


### PR DESCRIPTION
Remove duplicated `load_config_file` lines in Kubernetes provider section

### Description

I'm not sure, but for me it seems like `load_config_file` instructions are just duplicated in docs. If I'm wrong, could you please explain to me why it needs to be like this?
