### PR TITLE
Add an example for GKE + NFS + PVC

### DIFF
--- a/_examples/google-gke-cluster/README.md
+++ b/_examples/google-gke-cluster/README.md
@@ -1,4 +1,4 @@
-# Google GKE (Google Container Enginer) cluster
+# Google GKE (Google Container Engine) cluster
 
 In case you don't have a K8S cluster yet the easiest way
 to create one from scratch is to use GKE (Google Container Service).

--- a/_examples/google-gke-nfs-filestore/README.md
+++ b/_examples/google-gke-nfs-filestore/README.md
@@ -1,0 +1,48 @@
+# GKE (Google Container Engine) and Google Filestore (NFS)
+
+This example demonstrates building a Google GKE cluster and Google Filestore (NFS) to create persistent volumes for use in applications in Kubernetes. There is an example application Deployment included to demonstrate mounting the NFS volume using a Persistent Volume Claim.
+
+You will need the following environment variables to be set:
+
+ - `GOOGLE_CREDENTIALS`
+ - `GOOGLE_PROJECT`
+ - `GOOGLE_REGION`
+
+For example:
+```
+[myuser@linux ~]$ env |grep GOOGLE
+GOOGLE_REGION=us-west1
+GOOGLE_CREDENTIALS=/home/myuser/.config/gcloud/legacy_credentials/mygoogleuser/adc.json
+GOOGLE_PROJECT=my-gcp-project
+```
+
+See [Google Cloud Provider docs](https://www.terraform.io/docs/providers/google/index.html#configuration-reference) for more details about these variables.
+
+Install the example using the GKE default version of Kubernetes:
+```
+terraform init
+terraform apply
+```
+
+Or optionally specify a version to use:
+```
+terraform apply -var=kubernetes_version=1.15
+```
+
+## Versions
+
+Other available versions of Kubernetes can be found by running the [gcloud](https://cloud.google.com/sdk/docs#install_the_latest_cloud_tools_version_cloudsdk_current_version) tool. However, be aware that your chosen version must be present in the `validMasterVersions`, or else the GKE `defaultClusterVersion` will be used.
+
+```
+gcloud container get-server-config --region $GOOGLE_REGION
+```
+
+## Exporting K8S variables
+To access the cluster you need to export the `KUBECONFIG` variable pointing to the `kubeconfig` file for the current cluster.
+```
+export KUBECONFIG="$(terraform output kubeconfig_path)"
+export GOOGLE_ZONE=$(terraform output google_zone)
+```
+
+Now you can access the cluster via `kubectl`.
+

--- a/_examples/google-gke-nfs-filestore/README.md
+++ b/_examples/google-gke-nfs-filestore/README.md
@@ -10,7 +10,7 @@ You will need the following environment variables to be set:
 
 For example:
 ```
-[myuser@linux ~]$ env |grep GOOGLE
+[myuser@linux ~]$ env | grep GOOGLE
 GOOGLE_REGION=us-west1
 GOOGLE_CREDENTIALS=/home/myuser/.config/gcloud/legacy_credentials/mygoogleuser/adc.json
 GOOGLE_PROJECT=my-gcp-project
@@ -45,4 +45,3 @@ export GOOGLE_ZONE=$(terraform output google_zone)
 ```
 
 Now you can access the cluster via `kubectl`.
-

--- a/_examples/google-gke-nfs-filestore/kubeconfig-template.yaml
+++ b/_examples/google-gke-nfs-filestore/kubeconfig-template.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Config
+preferences:
+  colors: true
+current-context: tf-k8s-gcp-test
+contexts:
+- context:
+    cluster: ${cluster_name}
+    namespace: default
+    user: ${user_name}
+  name: tf-k8s-gcp-test
+clusters:
+- cluster:
+    server: https://${endpoint}
+    certificate-authority-data: ${cluster_ca}
+  name: ${cluster_name}
+users:
+- name: ${user_name}
+  user:
+    password: ${user_password}
+    username: ${user_name}
+    client-certificate-data: ${client_cert}
+    client-key-data: ${client_cert_key}

--- a/_examples/google-gke-nfs-filestore/main.tf
+++ b/_examples/google-gke-nfs-filestore/main.tf
@@ -1,0 +1,242 @@
+provider "google" {
+  // Provider settings to be provided via ENV variables
+}
+
+data "google_compute_zones" "available" {
+}
+
+resource "random_id" "cluster_name" {
+  byte_length = 10
+}
+
+resource "random_id" "username" {
+  byte_length = 14
+}
+
+resource "random_id" "password" {
+  byte_length = 16
+}
+
+variable "kubernetes_version" {
+  default = ""
+}
+
+variable "workers_count" {
+  default = "3"
+}
+
+data "google_container_engine_versions" "supported" {
+  location           = data.google_compute_zones.available.names[0]
+  version_prefix     = var.kubernetes_version
+}
+
+# If the result is empty '[]', the GKE default_cluster_version will be used.
+output "available_master_versions_matching_user_input" {
+  value = data.google_container_engine_versions.supported.valid_master_versions
+}
+
+# Shared network for GKE cluster and Filestore to use.
+resource "google_compute_network" "vpc" {
+  name = "shared"
+  auto_create_subnetworks = true
+}
+
+resource "google_container_cluster" "primary" {
+  name               = "tf-acc-test-${random_id.cluster_name.hex}"
+  location           = data.google_compute_zones.available.names[0]
+  network            = google_compute_network.vpc.name
+  initial_node_count = var.workers_count
+  min_master_version = data.google_container_engine_versions.supported.latest_master_version
+  # node version must match master version
+  # https://www.terraform.io/docs/providers/google/r/container_cluster.html#node_version
+  node_version       = data.google_container_engine_versions.supported.latest_master_version
+
+  node_locations = [
+    data.google_compute_zones.available.names[1],
+  ]
+
+  master_auth {
+    username = random_id.username.hex
+    password = random_id.password.hex
+  }
+
+  node_config {
+    machine_type = "n1-standard-4"
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+}
+
+
+resource "google_filestore_instance" "test" {
+  name = "test-nfs-server"
+  tier = "STANDARD"
+  zone = "us-west1-a"
+
+  file_shares {
+    capacity_gb = 1024
+    name        = "vol1"
+  }
+
+  networks {
+    network = google_compute_network.vpc.name
+    modes   = ["MODE_IPV4"]
+  }
+}
+
+data "template_file" "kubeconfig" {
+  template = file("${path.module}/kubeconfig-template.yaml")
+
+  vars = {
+    cluster_name    = google_container_cluster.primary.name
+    user_name       = google_container_cluster.primary.master_auth[0].username
+    user_password   = google_container_cluster.primary.master_auth[0].password
+    endpoint        = google_container_cluster.primary.endpoint
+    cluster_ca      = google_container_cluster.primary.master_auth[0].cluster_ca_certificate
+    client_cert     = google_container_cluster.primary.master_auth[0].client_certificate
+    client_cert_key = google_container_cluster.primary.master_auth[0].client_key
+  }
+}
+
+resource "local_file" "kubeconfig" {
+  content  = data.template_file.kubeconfig.rendered
+  filename = "${path.module}/kubeconfig"
+}
+
+provider "kubernetes" {
+  version = "1.11.2"
+  load_config_file = "false"
+
+  host = google_container_cluster.primary.endpoint
+
+  username               = google_container_cluster.primary.master_auth[0].username
+  password               = google_container_cluster.primary.master_auth[0].password
+  client_certificate     = base64decode(google_container_cluster.primary.master_auth[0].client_certificate)
+  client_key             = base64decode(google_container_cluster.primary.master_auth[0].client_key)
+  cluster_ca_certificate = base64decode(google_container_cluster.primary.master_auth[0].cluster_ca_certificate)
+}
+
+resource "kubernetes_namespace" "example" {
+  metadata {
+    name = "test"
+  }
+}
+
+resource "kubernetes_storage_class" "nfs" {
+  metadata {
+    name = "filestore"
+  }
+  reclaim_policy  = "Retain"
+  storage_provisioner = "nfs"
+}
+
+resource "kubernetes_persistent_volume" "example" {
+  metadata {
+    name = "nfs-volume"
+  }
+  spec {
+    capacity = {
+      storage = "1T"
+    }
+    storage_class_name = kubernetes_storage_class.nfs.metadata[0].name
+    access_modes = ["ReadWriteMany"]
+    persistent_volume_source {
+      nfs {
+        server = google_filestore_instance.test.networks[0].ip_addresses[0]
+        path = "/${google_filestore_instance.test.file_shares[0].name}"
+      }
+    }
+  }
+}
+
+resource "kubernetes_persistent_volume_claim" "example" {
+  metadata {
+    name = "mariadb-data"
+    namespace = "test"
+  }
+  spec {
+    access_modes = ["ReadWriteMany"]
+    storage_class_name = kubernetes_storage_class.nfs.metadata[0].name
+    volume_name = kubernetes_persistent_volume.example.metadata[0].name
+    resources {
+      requests = {
+        storage = "1T"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment" "mariadb" {
+  metadata {
+    name = "mariadb-example"
+    namespace = "test"
+    labels = {
+      mylabel = "MyExampleApp"
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        mylabel = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          mylabel = "MyExampleApp"
+        }
+      }
+
+      spec {
+        container {
+          image = "mariadb:10.5.2"
+          name  = "example"
+
+          env {
+            name = "MYSQL_RANDOM_ROOT_PASSWORD"
+            value = true
+          }
+
+          resources {
+            limits {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          volume_mount {
+            mount_path = "/var/lib/mysql"
+            name       = "mariadb-data"
+          }
+        }
+        volume {
+          name = "mariadb-data"
+          persistent_volume_claim {
+            claim_name = "mariadb-data"
+          }
+        }
+      }
+    }
+  }
+}
+
+output "node_version" {
+  value = google_container_cluster.primary.node_version
+}
+
+output "kubeconfig_path" {
+  value = local_file.kubeconfig.filename
+}


### PR DESCRIPTION
# Description

This example shows how to create a GKE cluster and use Google Filestore (NFS) to create Persistent Volumes in Kubernetes. It also mounts the volume to an example Deployment (mariadb) using a Persistent Volume Claim.

### References

There is a limitation in the current version of the terraform-plugin-sdk, [which makes it difficult to differentiate between `null` and `""` values for attributes](https://discuss.hashicorp.com/t/differentiate-between-null-and-empty-value/8134). For example, the `storage_class_name` attribute of the `kubernetes_persistent_volume_claim` resource cannot accept a value of `""` using the current SDK. It will interpret the value as if the attribute had been omitted entirely, which generally will cause Kubernetes to use the default storage class.

This example demonstrates a workaround, which is to create a storageclass instead of attempting to use the blank value.

There are related issues that may be mitigated by this workaround.

* https://github.com/terraform-providers/terraform-provider-kubernetes/issues/567
* https://github.com/terraform-providers/terraform-provider-kubernetes/issues/102
* https://github.com/terraform-providers/terraform-provider-kubernetes/issues/339