### PR TITLE
Update cron_job.html.markdown

### DIFF
--- a/website/docs/r/cron_job.html.markdown
+++ b/website/docs/r/cron_job.html.markdown
@@ -29,11 +29,11 @@ resource "kubernetes_cron_job" "demo" {
     starting_deadline_seconds     = 10
     successful_jobs_history_limit = 10
     suspend                       = true
-    ttl_seconds_after_finished    = 10
     job_template {
       metadata {}
       spec {
         backoff_limit = 2
+        ttl_seconds_after_finished    = 10
         template {
           metadata {}
           spec {


### PR DESCRIPTION
The ttl_seconds_after_finished field in the example was placed into the wrong spec object! This resulted in the example not working for users blindly copying over the resource declaration.

### Description

Simple fix for the kubernetes_cron_job resource example.

### Acceptance tests
- [] Have you added an acceptance test for the functionality being added?
- [] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
