### PR TITLE
Remove namespace from metadata attributes

### DIFF
--- a/website/docs/r/mutating_webhook_configuration.html.markdown
+++ b/website/docs/r/mutating_webhook_configuration.html.markdown
@@ -70,7 +70,6 @@ For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/an
 **By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
 For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the Mutating Webhook Configuration, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
-* `namespace` - (Optional) Namespace defines the space within which name of the Mutating Webhook Configuration must be unique.
 
 #### Attributes
 

--- a/website/docs/r/validating_webhook_configuration.html.markdown
+++ b/website/docs/r/validating_webhook_configuration.html.markdown
@@ -69,7 +69,6 @@ For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/an
 **By default, the provider ignores any labels whose key names end with *kubernetes.io*. This is necessary because such labels can be mutated by server-side components and consequently cause a perpetual diff in the Terraform plan output. If you explicitly specify any such labels in the configuration template then Terraform will consider these as normal resource attributes and manage them as expected (while still avoiding the perpetual diff problem).**
 For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/labels)
 * `name` - (Optional) Name of the Validating Webhook Configuration, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
-* `namespace` - (Optional) Namespace defines the space within which name of the Validating Webhook Configuration must be unique.
 
 #### Attributes
 


### PR DESCRIPTION
### Description

Removes namespace from metadata attributes in documentation for validating_webhook_configuration and mutating_webhook_configuration

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

Fixes #846
