### PR TITLE
Update metadata name attribute to required for kubernetes_service data source

### DIFF
--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 #### Arguments
 
-* `name` - (Optional) Name of the service, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
+* `name` - Name of the service, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)
 * `namespace` - (Optional) Namespace defines the space within which name of the service must be unique.
 
 #### Attributes


### PR DESCRIPTION
### Description

Removed `(Optional)` label from kubernetes_service data source, since it's required.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

Fixes #854
