### PR TITLE
Handle empty PersistentVolumeClaimSpec storage_class_name

### DIFF
--- a/kubernetes/structure_persistent_volume_claim.go
+++ b/kubernetes/structure_persistent_volume_claim.go
@@ -79,7 +79,7 @@ func expandPersistentVolumeClaimSpec(l []interface{}) (*v1.PersistentVolumeClaim
 	if v, ok := in["volume_name"].(string); ok {
 		obj.VolumeName = v
 	}
-	if v, ok := in["storage_class_name"].(string); ok && v != "" {
+	if v, ok := in["storage_class_name"].(string); ok {
 		obj.StorageClassName = ptrToString(v)
 	}
 	return obj, nil

--- a/kubernetes/structure_persistent_volume_claim_test.go
+++ b/kubernetes/structure_persistent_volume_claim_test.go
@@ -1,0 +1,64 @@
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestExpandPersistentVolumeClaimSpec(t *testing.T) {
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput *corev1.PersistentVolumeClaimSpec
+	}{
+		{
+			[]interface{}{
+				map[string]interface{}{
+					"resources":          []interface{}{},
+					"access_modes":       &schema.Set{},
+					"storage_class_name": "",
+				},
+			},
+			&corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{},
+				Selector:         nil,
+				Resources:        corev1.ResourceRequirements{},
+				VolumeName:       "",
+				StorageClassName: ptrToString(""),
+				VolumeMode:       nil,
+				DataSource:       nil,
+			},
+		},
+		{
+			[]interface{}{
+				map[string]interface{}{
+					"resources":          []interface{}{},
+					"access_modes":       &schema.Set{},
+					"storage_class_name": nil,
+				},
+			},
+			&corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{},
+				Selector:         nil,
+				Resources:        corev1.ResourceRequirements{},
+				VolumeName:       "",
+				StorageClassName: nil,
+				VolumeMode:       nil,
+				DataSource:       nil,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		output, err := expandPersistentVolumeClaimSpec(tc.Input)
+		if err != nil {
+			t.Fatalf("Unexpected failure in expander.\nInput: %#v, error: %#v", tc.Input, err)
+		}
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}


### PR DESCRIPTION
### Description

Pass empty string to `PersistentVolumeClaimSpec.StorageClassName ` instead of leaving attribute untouched (`nil`).

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)
https://gist.github.com/ragelo/b988b0d4cbb8b22bf53d3ab8b6fdc76f
### References
#864
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
