### PR TITLE
Configure travis for repo migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ services:
   - docker
 language: go
 go:
-  - 1.13.x
+  - 1.14.x
+
+env:
+  - GO111MODULE=on
 
 install:
   # This script is used by the Travis build to install a cookie for


### PR DESCRIPTION
As part of the migration to the hashicorp github org,
travis needs to be configured to use vendoring (default in Go 1.14+ when
the vendor dir is present) and Go modules.

This also configures travis to use the same version of Go as our docs recommend.